### PR TITLE
Added a property for yarn install arguments

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,7 @@
     <frontend-maven-plugin-version>1.6</frontend-maven-plugin-version>
     <node.version>v8.9.1</node.version>
     <yarn.version>v1.2.1</yarn.version>
+    <yarn.install.args>--no-progress</yarn.install.args>
     <image.ui>hawtio-online</image.ui>
   </properties>
 
@@ -67,7 +68,7 @@
               <goal>yarn</goal>
             </goals>
             <configuration>
-              <arguments>install --no-progress</arguments>
+              <arguments>install ${yarn.install.args}</arguments>
             </configuration>
           </execution>
           <execution>


### PR DESCRIPTION
This is to allow them to be overridden from the command line in case the production and community builds differ.