### PR TITLE
Add licenses to docker image.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,6 +22,14 @@ RUN curl -sO http://nginx.org/keys/nginx_signing.key && \
     rm -f ./nginx_signing.key && \
     yum clean all
 
+# Copy licenses
+RUN mkdir -p /opt/fuse/licenses
+COPY licenses/licenses.css /opt/fuse/licenses
+COPY licenses/licenses.xml /opt/fuse/licenses
+COPY licenses/licenses.html /opt/fuse/licenses
+COPY licenses/mit.txt /opt/fuse/licenses
+COPY licenses/nginx.txt /opt/fuse/licenses
+
 # forward request and error logs to docker log collector
 # - Change pid file location & remove nginx user & change port to 8080
 # - modify perms for non-root runtime

--- a/docker/licenses/licenses.css
+++ b/docker/licenses/licenses.css
@@ -1,0 +1,21 @@
+table {
+    border-collapse: collapse;
+}
+
+table, th, td {
+    border: 1px solid navy;
+}
+
+th {
+    background-color: #BCC6CC;
+    text-align: left;
+}
+
+th, td {
+    padding: 2px;
+    text-align: left;
+}
+
+tr:nth-child(even) {
+    background-color: #f2f2f2;
+}

--- a/docker/licenses/licenses.html
+++ b/docker/licenses/licenses.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html><html>
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+      <link rel="stylesheet" type="text/css" href="licenses.css">
+      <title>JBoss Fuse </title>
+   </head>
+   <body>
+      <h2>Hawtio Online</h2>
+      <p>The following material has been provided for informational purposes only, and should
+         not be relied upon or construed as a legal opinion or legal advice.
+      </p>
+      <table>
+         <tr>
+            <th>Package Group</th>
+            <th>Package Artifact</th>
+            <th>Package Version</th>
+            <th>Remote Licenses</th>
+            <th>Local Licenses</th>
+         </tr>
+         <tr>
+            <td>nginx</td>
+            <td>nginx</td>
+            <td>1.13.4-1.el7</td>
+            <td><a href="http://nginx.org/LICENSE">nginx 2 Clause BSD-like license</a><br></td>
+            <td><a href="nginx.txt">nginx.txt</a><br></td>
+         </tr>
+         <tr>
+            <td>angular</td>
+            <td>angular</td>
+            <td>1.6.0</td>
+            <td><a href="https://github.com/angular/angular/blob/master/LICENSE">MIT License</a><br></td>
+            <td><a href="mit.txt">mit.txt</a><br></td>
+         </tr>
+         <tr>
+            <td>jquery</td>
+            <td>jquery</td>
+            <td>2.2.4</td>
+            <td><a href="http://repository.jboss.org/licenses/apache-2.0.txt">MIT License</a><br></td>
+            <td><a href="mit.txt">mit.txt</a><br></td>
+         </tr>
+      </table>
+   </body>
+</html>

--- a/docker/licenses/licenses.xml
+++ b/docker/licenses/licenses.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<licenseSummary>
+  <dependencies>
+    <dependency>
+      <groupId>nginx</groupId>
+      <artifactId>nginx</artifactId>
+      <version>1.13.4-1.el7</version>
+      <licenses>
+        <license>
+          <name>nginx 2 Clause BSD-like license</name>
+          <url>http://nginx.org/LICENSE</url>
+          <distribution>repo</distribution>
+        </license>
+      </licenses>
+    </dependency>
+    <dependency>
+      <groupId>angular</groupId>
+      <artifactId>angular</artifactId>
+      <version>1.6.0</version>
+      <licenses>
+        <license>
+          <name>MIT License</name>
+          <url>https://github.com/angular/angular/blob/master/LICENSE</url>
+          <distribution>repo</distribution>
+        </license>
+      </licenses>
+    </dependency>
+    <dependency>
+      <groupId>jquery</groupId>
+      <artifactId>jquery</artifactId>
+      <version>2.2.4</version>
+      <licenses>
+        <license>
+          <name>MIT License</name>
+          <url>https://github.com/jquery/jquery/blob/master/LICENSE.txt</url>
+          <distribution>repo</distribution>
+        </license>
+      </licenses>
+    </dependency>
+  </dependencies>
+</licenseSummary>

--- a/docker/licenses/mit.txt
+++ b/docker/licenses/mit.txt
@@ -1,0 +1,973 @@
+<!DOCTYPE html>
+<html class="client-nojs" lang="en" dir="ltr">
+<head>
+<meta charset="UTF-8"/>
+<title>Licensing:MIT - Fedora Project Wiki</title>
+<script>document.documentElement.className = document.documentElement.className.replace( /(^|\s)client-nojs(\s|$)/, "$1client-js$2" );</script>
+<script>(window.RLQ=window.RLQ||[]).push(function(){mw.config.set({"wgCanonicalNamespace":"Licensing","wgCanonicalSpecialPageName":false,"wgNamespaceNumber":108,"wgPageName":"Licensing:MIT","wgTitle":"MIT","wgCurRevisionId":407754,"wgRevisionId":407754,"wgArticleId":3246,"wgIsArticle":true,"wgIsRedirect":false,"wgAction":"view","wgUserName":null,"wgUserGroups":["*"],"wgCategories":[],"wgBreakFrames":false,"wgPageContentLanguage":"en","wgPageContentModel":"wikitext","wgSeparatorTransformTable":["",""],"wgDigitTransformTable":["",""],"wgDefaultDateFormat":"dmy","wgMonthNames":["","January","February","March","April","May","June","July","August","September","October","November","December"],"wgMonthNamesShort":["","Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"],"wgRelevantPageName":"Licensing:MIT","wgRelevantArticleId":3246,"wgRequestId":"Wr3jst1j01bon@eJP-gSFwAAARI","wgIsProbablyEditable":false,"wgRestrictionEdit":[],"wgRestrictionMove":[],"wgWikiEditorEnabledModules":{"toolbar":true,"dialogs":true,"preview":true,"publish":true}});mw.loader.state({"site.styles":"ready","noscript":"ready","user.styles":"ready","user":"ready","user.options":"loading","user.tokens":"loading","mediawiki.skinning.interface":"ready","mediawiki.skinning.content.externallinks":"ready","skins.fedora":"ready","mediawiki.legacy.shared":"ready","mediawiki.legacy.commonPrint":"ready","mediawiki.sectionAnchor":"ready"});mw.loader.implement("user.options@0j3lz3q",function($,jQuery,require,module){mw.user.options.set({"variant":"en"});});mw.loader.implement("user.tokens@1vf83y7",function ( $, jQuery, require, module ) {
+mw.user.tokens.set({"editToken":"+\\","patrolToken":"+\\","watchToken":"+\\","csrfToken":"+\\"});/*@nomin*/;
+
+});mw.loader.load(["mediawiki.toc","mediawiki.action.view.postEdit","site","mediawiki.page.startup","mediawiki.user","mediawiki.hidpi","mediawiki.page.ready","mediawiki.searchSuggest","skins.fedora.js"]);});</script>
+<link rel="stylesheet" href="/w/load.php?debug=false&amp;lang=en&amp;modules=mediawiki.legacy.commonPrint%2Cshared%7Cmediawiki.sectionAnchor%7Cmediawiki.skinning.content.externallinks%7Cmediawiki.skinning.interface%7Cskins.fedora&amp;only=styles&amp;skin=fedora"/>
+<script async="" src="/w/load.php?debug=false&amp;lang=en&amp;modules=startup&amp;only=scripts&amp;skin=fedora"></script>
+<link rel="stylesheet" href="https://apps.fedoraproject.org/global/fedora-bootstrap-1.0.1/fedora-bootstrap.css"/><link rel="stylesheet" href="https://apps.fedoraproject.org/global/fedora-bootstrap-fonts/open-sans.css"/><link rel="stylesheet" href="https://apps.fedoraproject.org/global/fedora-bootstrap-fonts/font-awesome.css"/><link rel="stylesheet" href="https://apps.fedoraproject.org/global/fedora-bootstrap-fonts/hack.css"/>
+<meta name="ResourceLoaderDynamicStyles" content=""/>
+<link rel="stylesheet" href="/w/load.php?debug=false&amp;lang=en&amp;modules=site.styles&amp;only=styles&amp;skin=fedora"/>
+<meta name="generator" content="MediaWiki 1.29.2"/>
+<meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+<link rel="shortcut icon" href="/favicon.ico"/>
+<link rel="search" type="application/opensearchdescription+xml" href="/w/opensearch_desc.php" title="Fedora Project Wiki (en)"/>
+<link rel="EditURI" type="application/rsd+xml" href="https://fedoraproject.org/w/api.php?action=rsd"/>
+<link rel="copyright" href="/wiki/Legal:Main"/>
+<link rel="alternate" type="application/atom+xml" title="Fedora Project Wiki Atom feed" href="/w/index.php?title=Special:RecentChanges&amp;feed=atom"/>
+</head>
+<body class="mediawiki ltr sitedir-ltr mw-hide-empty-elt ns-108 ns-subject page-Licensing_MIT rootpage-Licensing_MIT skin-fedora action-view">		<div class="navbar navbar-full navbar-light masthead"><div class="container"><div class="row"><div class="col-md-4"><a href="/wiki/Fedora_Project_Wiki"><img src="/w/skins/Fedora/resources/images/fedorawiki_logo.png" alt="Fedora Project Wiki" height="40px"/></a></div><div class="col-md-4"><form action="/w/index.php" role="search" class="mw-portlet" id="p-search"><input type="hidden" value="Special:Search" name="title"/><h3><label for="searchInput">Search</label></h3><div class="input-group"><input type="search" name="search" placeholder="Search Fedora Project Wiki" title="Search Fedora Project Wiki [f]" accesskey="f" id="searchInput" class="form-control"/><span class="input-group-btn"><button id="searchGoButton" class="btn btn-secondary" type="submit"><i class="fa fa-search"></i></button></span></div></form></div><div class="col-md-4"><ul class="nav navbar-nav pull-xs-right"><li class="nav-item dropdown"><a class="nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">wiki</a><ul class="dropdown-menu dropdown-menu-right"><li id="n-mainpage"><a href="/wiki/Fedora_Project_Wiki" title="Visit the main page [z]" accesskey="z" class="dropdown-item">Fedora Project Wiki</a></li><li id="n-News"><a href="/wiki/FWN" class="dropdown-item">News</a></li><li id="n-Events"><a href="/wiki/FedoraEvents" class="dropdown-item">Events</a></li><li id="n-Features"><a href="/wiki/Features" class="dropdown-item">Features</a></li><li id="n-recentchanges"><a href="/wiki/Special:RecentChanges" title="A list of recent changes in the wiki [r]" accesskey="r" class="dropdown-item">Recent changes</a></li><li id="n-randompage"><a href="/wiki/Special:Random" title="Load a random page [x]" accesskey="x" class="dropdown-item">Random page</a></li><li id="n-Help"><a href="/wiki/Help" title="The place to find out" class="dropdown-item">Help</a></li></ul></li><li class="nav-item dropdown"><a class="nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">Navigation</a><ul class="dropdown-menu dropdown-menu-right"><li id="n-Home"><a href="http://fedoraproject.org/" class="dropdown-item">Home</a></li><li id="n-Get-Fedora"><a href="http://get.fedoraproject.org/" class="dropdown-item">Get Fedora</a></li><li id="n-Join-Fedora"><a href="http://join.fedoraproject.org/" class="dropdown-item">Join Fedora</a></li></ul></li><li class="nav-item dropdown"><a class="nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button">sub-projects</a><ul class="dropdown-menu dropdown-menu-right"><li id="n-Ambassadors"><a href="/wiki/Ambassadors" class="dropdown-item">Ambassadors</a></li><li id="n-Community-Operations"><a href="/wiki/CommOps" class="dropdown-item">Community Operations</a></li><li id="n-Design"><a href="/wiki/Design" class="dropdown-item">Design</a></li><li id="n-Documentation"><a href="/wiki/DocsProject" class="dropdown-item">Documentation</a></li><li id="n-EPEL"><a href="/wiki/EPEL" class="dropdown-item">EPEL</a></li><li id="n-Infrastructure"><a href="/wiki/Infrastructure" class="dropdown-item">Infrastructure</a></li><li id="n-Internationalization"><a href="/wiki/I18N" class="dropdown-item">Internationalization</a></li><li id="n-Localization"><a href="/wiki/L10N" class="dropdown-item">Localization</a></li><li id="n-Marketing"><a href="/wiki/Marketing" class="dropdown-item">Marketing</a></li><li id="n-Magazine"><a href="/wiki/FWN" class="dropdown-item">Magazine</a></li><li id="n-Package-Maintainers"><a href="/wiki/PackageMaintainers" class="dropdown-item">Package Maintainers</a></li><li id="n-Quality-Assurance"><a href="/wiki/QA" class="dropdown-item">Quality Assurance</a></li><li id="n-Websites"><a href="/wiki/Websites" class="dropdown-item">Websites</a></li><li id="n-All-projects"><a href="/wiki/Projects" class="dropdown-item">All projects</a></li></ul></li><a href="/w/index.php?title=Special:UserLogin&amp;returnto=Licensing%3AMIT&amp;returntoquery=rd%3DLicensing%252FMIT" class="btn btn-primary m-l-2">Log In</a></ul></div></div></div></div>
+
+		<div class="bodycontent">
+			<div class="sub-header p-t-1">
+				<div class="container">
+					<div class="row">
+						<div class="col-sm-6">
+						<h1>Licensing:MIT</h1>					</div>
+					<div class="col-sm-6">
+						<div class="btn-group pull-xs-right">
+						<div class="mw-indicators mw-body-content">
+</div>
+					 </div>
+				</div>
+			</div>
+
+				<ul class="nav nav-tabs nav-small m-l-0">
+				<li class="nav-item" id="ca-nstab-licensing" class="selected"><a href="/wiki/Licensing:MIT" class="nav-link active">Licensing</a></li class="nav-item"><li class="nav-item" id="ca-talk"><a href="/wiki/Licensing_talk:MIT" rel="discussion" title="Discussion about the content page [t]" accesskey="t" class="nav-link">Discussion</a></li class="nav-item"><li class="nav-item pull-xs-right" id="ca-view" class="selected"><a href="/wiki/Licensing:MIT" redundant="1" class="nav-link active">View</a></li class="nav-item pull-xs-right"><li class="nav-item pull-xs-right" id="ca-viewsource"><a href="/w/index.php?title=Licensing:MIT&amp;action=edit" title="This page is protected.&#10;You can view its source [e]" accesskey="e" class="nav-link">View source</a></li class="nav-item pull-xs-right"><li class="nav-item pull-xs-right" id="ca-history"><a href="/w/index.php?title=Licensing:MIT&amp;action=history" title="Past revisions of this page [h]" accesskey="h" class="nav-link">History</a></li class="nav-item pull-xs-right">
+			</ul>
+				</div>
+			</div>
+
+			<div class="mw-body container" role="main">
+				<div id="siteNotice"><div id="localNotice" lang="en" dir="ltr"></div></div><div id="siteSub">From Fedora Project Wiki</div>
+				<div class="mw-body-content">
+					<div id="contentSub"><p></p></div><div id="mw-content-text" lang="en" dir="ltr" class="mw-content-ltr"><p>There are many MIT variants, all of which are functionally identical.
+</p>
+<div id="toc" class="toc"><div id="toctitle" class="toctitle"><h2>Contents</h2></div>
+<ul>
+<li class="toclevel-1 tocsection-1"><a href="#Old_Style"><span class="tocnumber">1</span> <span class="toctext">Old Style</span></a></li>
+<li class="toclevel-1 tocsection-2"><a href="#Old_Style_.28no_advertising_without_permission.29"><span class="tocnumber">2</span> <span class="toctext">Old Style (no advertising without permission)</span></a></li>
+<li class="toclevel-1 tocsection-3"><a href="#Old_Style_with_legal_disclaimer"><span class="tocnumber">3</span> <span class="toctext">Old Style with legal disclaimer</span></a></li>
+<li class="toclevel-1 tocsection-4"><a href="#Old_Style_with_legal_disclaimer_2"><span class="tocnumber">4</span> <span class="toctext">Old Style with legal disclaimer 2</span></a></li>
+<li class="toclevel-1 tocsection-5"><a href="#Old_Style_with_legal_disclaimer_3"><span class="tocnumber">5</span> <span class="toctext">Old Style with legal disclaimer 3</span></a></li>
+<li class="toclevel-1 tocsection-6"><a href="#Old_Style_.28Bellcore_variant.29"><span class="tocnumber">6</span> <span class="toctext">Old Style (Bellcore variant)</span></a></li>
+<li class="toclevel-1 tocsection-7"><a href="#PostgreSQL_License_.28MIT_Variant.29"><span class="tocnumber">7</span> <span class="toctext">PostgreSQL License (MIT Variant)</span></a>
+<ul>
+<li class="toclevel-2 tocsection-8"><a href="#License_Notes"><span class="tocnumber">7.1</span> <span class="toctext">License Notes</span></a></li>
+</ul>
+</li>
+<li class="toclevel-1 tocsection-9"><a href="#CMU_Style"><span class="tocnumber">8</span> <span class="toctext">CMU Style</span></a></li>
+<li class="toclevel-1 tocsection-10"><a href="#MLton_variant"><span class="tocnumber">9</span> <span class="toctext">MLton variant</span></a></li>
+<li class="toclevel-1 tocsection-11"><a href="#Standard_ML_of_New_Jersey_Variant"><span class="tocnumber">10</span> <span class="toctext">Standard ML of New Jersey Variant</span></a></li>
+<li class="toclevel-1 tocsection-12"><a href="#WordNet_Variant"><span class="tocnumber">11</span> <span class="toctext">WordNet Variant</span></a></li>
+<li class="toclevel-1 tocsection-13"><a href="#Modern_Style_with_sublicense"><span class="tocnumber">12</span> <span class="toctext">Modern Style with sublicense</span></a></li>
+<li class="toclevel-1 tocsection-14"><a href="#Modern_Style_without_sublicense_.28Unicode.29"><span class="tocnumber">13</span> <span class="toctext">Modern Style without sublicense (Unicode)</span></a>
+<ul>
+<li class="toclevel-2 tocsection-15"><a href="#Modern_Variants"><span class="tocnumber">13.1</span> <span class="toctext">Modern Variants</span></a></li>
+<li class="toclevel-2 tocsection-16"><a href="#Modern_style_.28ICU_Variant.29"><span class="tocnumber">13.2</span> <span class="toctext">Modern style (ICU Variant)</span></a></li>
+<li class="toclevel-2 tocsection-17"><a href="#feh_variant"><span class="tocnumber">13.3</span> <span class="toctext">feh variant</span></a></li>
+<li class="toclevel-2 tocsection-18"><a href="#enna_variant"><span class="tocnumber">13.4</span> <span class="toctext">enna variant</span></a></li>
+<li class="toclevel-2 tocsection-19"><a href="#Thrift_variant"><span class="tocnumber">13.5</span> <span class="toctext">Thrift variant</span></a></li>
+<li class="toclevel-2 tocsection-20"><a href="#mpich2_variant"><span class="tocnumber">13.6</span> <span class="toctext">mpich2 variant</span></a></li>
+<li class="toclevel-2 tocsection-21"><a href="#Festival_variant"><span class="tocnumber">13.7</span> <span class="toctext">Festival variant</span></a></li>
+<li class="toclevel-2 tocsection-22"><a href="#Minimal_variant_.28found_in_io_lib.29"><span class="tocnumber">13.8</span> <span class="toctext">Minimal variant (found in io_lib)</span></a></li>
+<li class="toclevel-2 tocsection-23"><a href="#Another_Minimal_variant_.28found_in_libatomic_ops.29"><span class="tocnumber">13.9</span> <span class="toctext">Another Minimal variant (found in libatomic_ops)</span></a></li>
+<li class="toclevel-2 tocsection-24"><a href="#Adobe_Glyph_List_Variant"><span class="tocnumber">13.10</span> <span class="toctext">Adobe Glyph List Variant</span></a></li>
+<li class="toclevel-2 tocsection-25"><a href="#Xfig_Variant"><span class="tocnumber">13.11</span> <span class="toctext">Xfig Variant</span></a></li>
+<li class="toclevel-2 tocsection-26"><a href="#Hylafax_Variant"><span class="tocnumber">13.12</span> <span class="toctext">Hylafax Variant</span></a></li>
+</ul>
+</li>
+<li class="toclevel-1 tocsection-27"><a href="#DANSE_Variant"><span class="tocnumber">14</span> <span class="toctext">DANSE Variant</span></a></li>
+<li class="toclevel-1 tocsection-28"><a href="#Nuclear_Variant"><span class="tocnumber">15</span> <span class="toctext">Nuclear Variant</span></a></li>
+<li class="toclevel-1 tocsection-29"><a href="#Epinions_Variant"><span class="tocnumber">16</span> <span class="toctext">Epinions Variant</span></a></li>
+<li class="toclevel-1 tocsection-30"><a href="#OpenVision_Variant"><span class="tocnumber">17</span> <span class="toctext">OpenVision Variant</span></a>
+<ul>
+<li class="toclevel-2 tocsection-31"><a href="#Notes"><span class="tocnumber">17.1</span> <span class="toctext">Notes</span></a></li>
+<li class="toclevel-2 tocsection-32"><a href="#License_Text"><span class="tocnumber">17.2</span> <span class="toctext">License Text</span></a></li>
+</ul>
+</li>
+<li class="toclevel-1 tocsection-33"><a href="#PetSC_Variant"><span class="tocnumber">18</span> <span class="toctext">PetSC Variant</span></a></li>
+<li class="toclevel-1 tocsection-34"><a href="#Whatever_Variant"><span class="tocnumber">19</span> <span class="toctext">Whatever Variant</span></a></li>
+<li class="toclevel-1 tocsection-35"><a href="#UnixCrypt_Variant"><span class="tocnumber">20</span> <span class="toctext">UnixCrypt Variant</span></a>
+<ul>
+<li class="toclevel-2 tocsection-36"><a href="#Notes_2"><span class="tocnumber">20.1</span> <span class="toctext">Notes</span></a></li>
+<li class="toclevel-2 tocsection-37"><a href="#Text"><span class="tocnumber">20.2</span> <span class="toctext">Text</span></a></li>
+<li class="toclevel-2 tocsection-38"><a href="#Variant_Text"><span class="tocnumber">20.3</span> <span class="toctext">Variant Text</span></a></li>
+</ul>
+</li>
+<li class="toclevel-1 tocsection-39"><a href="#HP_Variant"><span class="tocnumber">21</span> <span class="toctext">HP Variant</span></a></li>
+<li class="toclevel-1 tocsection-40"><a href="#Cheusov_variant"><span class="tocnumber">22</span> <span class="toctext">Cheusov variant</span></a>
+<ul>
+<li class="toclevel-2 tocsection-41"><a href="#Notes_3"><span class="tocnumber">22.1</span> <span class="toctext">Notes</span></a></li>
+<li class="toclevel-2 tocsection-42"><a href="#Text_2"><span class="tocnumber">22.2</span> <span class="toctext">Text</span></a></li>
+</ul>
+</li>
+</ul>
+</div>
+
+<h2><span class="mw-headline" id="Old_Style">Old Style</span></h2>
+<pre>
+Permission to use, copy, modify, distribute, and sell this software and its
+documentation for any purpose is hereby granted without fee, provided that
+the above copyright notice appear in all copies and that both that
+copyright notice and this permission notice appear in supporting
+documentation.  No representations are made about the suitability of this
+software for any purpose.  It is provided "as is" without express or
+implied warranty.
+</pre>
+<p><br />
+</p>
+<h2><span class="mw-headline" id="Old_Style_.28no_advertising_without_permission.29">Old Style (no advertising without permission)</span></h2>
+<pre>
+Copyright 1989 Massachusetts Institute of Technology
+
+Permission to use, copy, modify, and distribute this software and its
+documentation for any purpose and without fee is hereby granted, provided
+that the above copyright notice appear in all copies and that both that
+copyright notice and this permission notice appear in supporting
+documentation, and that the name of M.I.T. not be used in advertising
+or publicity pertaining to distribution of the software without specific,
+written prior permission.  M.I.T. makes no representations about the
+suitability of this software for any purpose.  It is provided "as is"
+without express or implied warranty.
+</pre>
+<p><br />
+</p>
+<h2><span class="mw-headline" id="Old_Style_with_legal_disclaimer">Old Style with legal disclaimer</span></h2>
+<pre>
+Permission to use, copy, modify, and distribute this software and its
+documentation for any purpose and without fee is hereby granted, provided
+that the above copyright notice appear in all copies and that both that
+copyright notice and this permission notice appear in supporting
+documentation, and that the name of M.I.T. not be used in advertising
+or publicity pertaining to distribution of the software without specific,
+written prior permission.  M.I.T. makes no representations about the
+suitability of this software for any purpose.  It is provided "as is"
+without express or implied warranty.
+
+M.I.T. DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE, INCLUDING ALL
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS, IN NO EVENT SHALL M.I.T.
+BE LIABLE FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION
+OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+</pre>
+<h2><span class="mw-headline" id="Old_Style_with_legal_disclaimer_2">Old Style with legal disclaimer 2</span></h2>
+<pre>
+Permission to use, copy, modify, and distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+The software is provided "as is" and the author disclaims all warranties
+with regard to this software including all implied warranties of
+merchantability and fitness. In no event shall the author be liable for
+any special, direct, indirect, or consequential damages or any damages
+whatsoever resulting from loss of use, data or profits, whether in an
+action of contract, negligence or other tortious action, arising out of
+or in connection with the use or performance of this software.
+</pre>
+<h2><span class="mw-headline" id="Old_Style_with_legal_disclaimer_3">Old Style with legal disclaimer 3</span></h2>
+<pre>
+Permission to use, copy, modify, and distribute this software and its
+documentation for any purpose and without fee is hereby granted,
+provided that the above copyright notice appear in all copies and that
+both that copyright notice and this permission notice appear in
+supporting documentation.
+
+THE AUTHOR PROVIDES THIS SOFTWARE ''AS IS'' AND ANY EXPRESSED OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+</pre>
+<h2><span class="mw-headline" id="Old_Style_.28Bellcore_variant.29">Old Style (Bellcore variant)</span></h2>
+<pre>
+Permission to use, copy, modify, and distribute this material
+for any purpose and without fee is hereby granted, provided
+that the above copyright notice and this permission notice
+appear in all copies, and that the name of Bellcore not be
+used in advertising or publicity pertaining to this
+material without the specific, prior written permission
+of an authorized representative of Bellcore.  BELLCORE
+MAKES NO REPRESENTATIONS ABOUT THE ACCURACY OR SUITABILITY
+OF THIS MATERIAL FOR ANY PURPOSE.  IT IS PROVIDED "AS IS",
+WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES.
+</pre>
+<h2><span class="mw-headline" id="PostgreSQL_License_.28MIT_Variant.29">PostgreSQL License (MIT Variant)</span></h2>
+<h3><span class="mw-headline" id="License_Notes">License Notes</span></h3>
+<p>This MIT variant is unique in that it has a unique license short name: PostgreSQL.
+Please see <a class="external free" href="https://fedoraproject.org/wiki/Licensing/PostgreSQL_License">https://fedoraproject.org/wiki/Licensing/PostgreSQL_License</a> for more information.
+</p>
+<pre>
+Copyright (c) &lt;YEAR&gt;, &lt;ORGANISATION&gt;
+
+Permission to use, copy, modify, and distribute this software and its
+documentation for any purpose, without fee, and without a written
+agreement is hereby granted, provided that the above copyright notice
+and this paragraph and the following two paragraphs appear in all
+copies.
+
+IN NO EVENT SHALL &lt;ORGANISATION&gt; BE LIABLE TO ANY PARTY FOR DIRECT,
+INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS
+DOCUMENTATION, EVEN IF &lt;ORGANISATION&gt; HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+&lt;ORGANISATION&gt; SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT
+NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON AN "AS
+IS" BASIS, AND &lt;ORGANISATION&gt; HAS NO OBLIGATIONS TO PROVIDE
+MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+</pre>
+<h2><span class="mw-headline" id="CMU_Style">CMU Style</span></h2>
+<pre>
+Copyright 1989, 1991, 1992 by Carnegie Mellon University
+
+Derivative Work - 1996, 1998-2000
+Copyright 1996, 1998-2000 The Regents of the University of California
+
+All Rights Reserved
+
+Permission to use, copy, modify and distribute this software and its
+documentation for any purpose and without fee is hereby granted,
+provided that the above copyright notice appears in all copies and
+that both that copyright notice and this permission notice appear in
+supporting documentation, and that the name of CMU and The Regents of
+the University of California not be used in advertising or publicity
+pertaining to distribution of the software without specific written
+permission.
+
+CMU AND THE REGENTS OF THE UNIVERSITY OF CALIFORNIA DISCLAIM ALL
+WARRANTIES WITH REGARD TO THIS SOFTWARE, INCLUDING ALL IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS.  IN NO EVENT SHALL CMU OR
+THE REGENTS OF THE UNIVERSITY OF CALIFORNIA BE LIABLE FOR ANY SPECIAL,
+INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING
+FROM THE LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF
+CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+</pre>
+<h2><span class="mw-headline" id="MLton_variant">MLton variant</span></h2>
+<pre>
+This is the license for MLton, a whole-program optimizing compiler for
+the Standard ML programming language.  Send comments and questions to
+MLton@mlton.org.
+
+MLton COPYRIGHT NOTICE, LICENSE AND DISCLAIMER.
+
+Copyright (C) 1999-2006 Henry Cejtin, Matthew Fluet, Suresh
+Jagannathan, and Stephen Weeks.
+Copyright (C) 1997-2000 by the NEC Research Institute
+
+Permission to use, copy, modify, and distribute this software and its
+documentation for any purpose and without fee is hereby granted,
+provided that the above copyright notice appear in all copies and that
+both the copyright notice and this permission notice and warranty
+disclaimer appear in supporting documentation, and that the name of
+the above copyright holders, or their entities, not be used in
+advertising or publicity pertaining to distribution of the software
+without specific, written prior permission.
+
+The above copyright holders disclaim all warranties with regard to
+this software, including all implied warranties of merchantability and
+fitness. In no event shall the above copyright holders be liable for
+any special, indirect or consequential damages or any damages
+whatsoever resulting from loss of use, data or profits, whether in an
+action of contract, negligence or other tortious action, arising out
+of or in connection with the use or performance of this software.
+</pre>
+<h2><span class="mw-headline" id="Standard_ML_of_New_Jersey_Variant">Standard ML of New Jersey Variant</span></h2>
+<pre>
+STANDARD ML OF NEW JERSEY COPYRIGHT NOTICE, LICENSE AND DISCLAIMER.
+
+Copyright (c) 1989-1998 by Lucent Technologies
+
+Permission to use, copy, modify, and distribute this software and
+its documentation for any purpose and without fee is hereby granted,
+provided that the above copyright notice appear in all copies and
+that both the copyright notice and this permission notice and
+warranty disclaimer appear in supporting documentation, and that
+the name of Lucent Technologies, Bell Labs or any Lucent entity not
+be used in advertising or publicity pertaining to distribution of
+the software without specific, written prior permission.
+
+Lucent disclaims all warranties with regard to this software,
+including all implied warranties of merchantability and fitness. In
+no event shall Lucent be liable for any special, indirect or
+consequential damages or any damages whatsoever resulting from loss
+of use, data or profits, whether in an action of contract,
+negligence or other tortious action, arising out of or in
+connection with the use or performance of this software.
+</pre>
+<h2><span class="mw-headline" id="WordNet_Variant">WordNet Variant</span></h2>
+<pre>
+Permission to use, copy, modify and distribute this software and  
+database and its documentation for any purpose and without fee or  
+royalty is hereby granted, provided that you agree to comply with  
+the following copyright notice and statements, including the disclaimer,  
+and that the same appear on ALL copies of the software, database and  
+documentation, including modifications that you make for internal  
+use or for distribution.  
+  
+WordNet 3.0 Copyright 2006 by Princeton University.  All rights reserved.  
+  
+THIS SOFTWARE AND DATABASE IS PROVIDED "AS IS" AND PRINCETON  
+UNIVERSITY MAKES NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR  
+IMPLIED.  BY WAY OF EXAMPLE, BUT NOT LIMITATION, PRINCETON  
+UNIVERSITY MAKES NO REPRESENTATIONS OR WARRANTIES OF MERCHANT-  
+ABILITY OR FITNESS FOR ANY PARTICULAR PURPOSE OR THAT THE USE  
+OF THE LICENSED SOFTWARE, DATABASE OR DOCUMENTATION WILL NOT  
+INFRINGE ANY THIRD PARTY PATENTS, COPYRIGHTS, TRADEMARKS OR  
+OTHER RIGHTS.  
+  
+The name of Princeton University or Princeton may not be used in  
+advertising or publicity pertaining to distribution of the software  
+and/or database.  Title to copyright in this software, database and  
+any associated documentation shall at all times remain with  
+Princeton University and LICENSEE agrees to preserve same.
+</pre>
+<h2><span class="mw-headline" id="Modern_Style_with_sublicense">Modern Style with sublicense</span></h2>
+<pre>
+Copyright (c) 1998, 1999, 2000 Thai Open Source Software Center Ltd
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+</pre>
+<h2><span class="mw-headline" id="Modern_Style_without_sublicense_.28Unicode.29">Modern Style without sublicense (Unicode)</span></h2>
+<pre>
+Copyright © 1991-2005 Unicode, Inc. All rights reserved. Distributed under the
+Terms of Use in http://www.unicode.org/copyright.html.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of the Unicode data files and any associated documentation (the "Data Files")
+or Unicode software and any associated documentation (the "Software") to deal
+in the Data Files or Software without restriction, including without
+limitation the rights to use, copy, modify, merge, publish, distribute, and/or
+sell copies of the Data Files or Software, and to permit persons to whom the
+Data Files or Software are furnished to do so, provided that (a) the above
+copyright notice(s) and this permission notice appear with all copies of the
+Data Files or Software, (b) both the above copyright notice(s) and this
+permission notice appear in associated documentation, and (c) there is clear
+notice in each modified Data File or in the Software as well as in the
+documentation associated with the Data File(s) or Software that the data or
+software has been modified.
+
+THE DATA FILES AND SOFTWARE ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF THIRD
+PARTY RIGHTS. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS INCLUDED IN
+THIS NOTICE BE LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT OR CONSEQUENTIAL
+DAMAGES, OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR
+PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS
+ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THE
+DATA FILES OR SOFTWARE.
+
+Except as contained in this notice, the name of a copyright holder shall not
+be used in advertising or otherwise to promote the sale, use or other dealings
+in these Data Files or Software without prior written authorization of the
+copyright holder.
+</pre>
+<h3><span class="mw-headline" id="Modern_Variants">Modern Variants</span></h3>
+<pre>
+Permission is hereby granted, without written agreement and without
+license or royalty fees, to use, copy, modify, and distribute this
+software and its documentation for any purpose, provided that the
+above copyright notice and the following two paragraphs appear in
+all copies of this software.
+
+IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE TO ANY PARTY FOR
+DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN
+IF THE COPYRIGHT HOLDER HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
+
+THE COPYRIGHT HOLDER SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING,
+BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS FOR A PARTICULAR PURPOSE.  THE SOFTWARE PROVIDED HEREUNDER IS
+ON AN "AS IS" BASIS, AND THE COPYRIGHT HOLDER HAS NO OBLIGATION TO
+PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+</pre>
+<h3><span class="mw-headline" id="Modern_style_.28ICU_Variant.29">Modern style (ICU Variant)</span></h3>
+<pre>
+Copyright (c) 1995-2006 International Business Machines Corporation and others
+
+All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, and/or sell copies of the
+Software, and to permit persons to whom the Software is furnished to do so,
+provided that the above copyright notice(s) and this permission notice
+appear in all copies of the Software and that both the above copyright
+notice(s) and this permission notice appear in supporting documentation.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF THIRD PARTY RIGHTS.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS INCLUDED IN THIS NOTICE BE
+LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT OR CONSEQUENTIAL DAMAGES, OR
+ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER
+IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT
+OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+Except as contained in this notice, the name of a copyright holder shall not
+be used in advertising or otherwise to promote the sale, use or other
+dealings in this Software without prior written authorization of the
+copyright holder.
+</pre>
+<p><span id="feh"></span>
+</p>
+<h3><span class="mw-headline" id="feh_variant">feh variant</span></h3>
+<pre>
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies of the Software and its documentation and acknowledgment
+shall be given in the documentation and software packages that this
+Software was used.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+</pre>
+<p><span id="enna"></span>
+</p>
+<h3><span class="mw-headline" id="enna_variant">enna variant</span></h3>
+<pre>
+Copyright (C) 2000 Carsten Haitzler and various contributors (see AUTHORS)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to
+deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+sell copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies of the Software and its Copyright notices. In addition publicly
+documented acknowledgment must be given that this software has been used if no
+source code of this software is made available publicly. This includes
+acknowledgments in either Copyright notices, Manuals, Publicity and Marketing
+documents or any documentation provided with any product containing this
+software. This License does not apply to any software that links to the
+libraries provided by this software (statically or dynamically), but only to
+the software provided.
+
+Please see the COPYING.PLAIN for a plain-english explanation of this notice
+and it's intent.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+</pre>
+<p><span id="Thrift"></span>
+</p>
+<h3><span class="mw-headline" id="Thrift_variant">Thrift variant</span></h3>
+<pre>
+Permission is hereby granted, free of charge, to any person or organization
+obtaining a copy of the software and accompanying documentation covered by
+this license (the "Software") to use, reproduce, display, distribute,
+execute, and transmit the Software, and to prepare derivative works of the
+Software, and to permit third-parties to whom the Software is furnished to
+do so, all subject to the following:
+
+The copyright notices in the Software and this entire statement, including
+the above license grant, this restriction and the following disclaimer,
+must be included in all copies of the Software, in whole or in part, and
+all derivative works of the Software, unless such copies or derivative
+works are solely in the form of machine-executable object code generated by
+a source language processor.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT
+SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE
+FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+</pre>
+<p><span id="mpich2"></span>
+</p>
+<h3><span class="mw-headline" id="mpich2_variant">mpich2 variant</span></h3>
+<p>This is missing the "anti-publicity-use clause", and doesn't mention sublicensing,
+but otherwise, it is functionally identical to MIT.
+</p>
+<pre>
+COPYRIGHT
+
+The following is a notice of limited availability of the code, and
+disclaimer which must be included in the prologue of the code and in all source
+listings of the code.
+
+Copyright Notice
++ 2002 University of Chicago
+
+Permission is hereby granted to use, reproduce, prepare derivative
+works, and to redistribute to others.  This software was authored by:
+
+Argonne National Laboratory Group
+W. Gropp: (630) 252-4318; FAX: (630) 252-5986; e-mail: gropp@mcs.anl.gov
+E. Lusk:  (630) 252-7852; FAX: (630) 252-5986; e-mail: lusk@mcs.anl.gov
+Mathematics and Computer Science Division
+Argonne National Laboratory, Argonne IL 60439
+
+
+GOVERNMENT LICENSE
+
+Portions of this material resulted from work developed under a U.S.
+Government Contract and are subject to the following license: the
+Government is granted for itself and others acting on its behalf a paid-up,
+nonexclusive, irrevocable worldwide license in this computer software to reproduce,
+prepare derivative works, and perform publicly and display publicly.
+
+DISCLAIMER
+
+This computer code material was prepared, in part, as an account of work
+sponsored by an agency of the United States Government.  Neither the
+United States, nor the University of Chicago, nor any of their employees, makes
+any warranty express or implied, or assumes any legal liability or
+responsibility for the accuracy, completeness, or usefulness of any information,
+apparatus, product, or process disclosed, or represents that its use would not
+infringe privately owned rights.
+</pre>
+<p><span id="Festival"></span>
+</p>
+<h3><span class="mw-headline" id="Festival_variant">Festival variant</span></h3>
+<pre>
+  Permission is hereby granted, free of charge, to use and distribute
+  this software and its documentation without restriction, including
+  without limitation the rights to use, copy, modify, merge, publish,
+  distribute, sublicense, and/or sell copies of this work, and to
+  permit persons to whom this work is furnished to do so, subject to
+  the following conditions:
+   1. The code must retain the above copyright notice, this list of
+      conditions and the following disclaimer.
+   2. Any modifications must be clearly marked as such.
+   3. Original authors' names are not deleted.
+   4. The authors' names are not used to endorse or promote products
+      derived from this software without specific prior written
+      permission.
+
+  THE UNIVERSITY OF EDINBURGH AND THE CONTRIBUTORS TO THIS WORK
+  DISCLAIM ALL WARRANTIES WITH REGARD TO THIS SOFTWARE, INCLUDING
+  ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS, IN NO EVENT
+  SHALL THE UNIVERSITY OF EDINBURGH NOR THE CONTRIBUTORS BE LIABLE
+  FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN
+  AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
+  ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
+  THIS SOFTWARE.
+</pre>
+<p><span id="minimal"></span>
+</p>
+<h3><span class="mw-headline" id="Minimal_variant_.28found_in_io_lib.29">Minimal variant (found in io_lib)</span></h3>
+<pre>
+Copyright (c) Medical Research Council 1994. All rights reserved.
+
+Permission to use, copy, modify and distribute this software and its
+documentation for any purpose is hereby granted without fee, provided that
+this copyright and notice appears in all copies.
+
+This file was written by James Bonfield, Simon Dear, Rodger Staden,
+as part of the Staden Package at the MRC Laboratory of Molecular
+Biology, Hills Road, Cambridge, CB2 2QH, United Kingdom.
+
+MRC disclaims all warranties with regard to this software.
+</pre>
+<p><span id="AnotherMinimalVariant"></span>
+</p>
+<h3><span class="mw-headline" id="Another_Minimal_variant_.28found_in_libatomic_ops.29">Another Minimal variant (found in libatomic_ops)</span></h3>
+<pre>
+Copyright (c) ...
+
+THIS MATERIAL IS PROVIDED AS IS, WITH ABSOLUTELY NO WARRANTY EXPRESSED
+OR IMPLIED.  ANY USE IS AT YOUR OWN RISK.
+
+Permission is hereby granted to use or copy this program
+for any purpose,  provided the above notices are retained on all copies.
+Permission to modify the code and to distribute modified code is granted,
+provided the above notices are retained, and a notice that the code was
+modified is included with the above copyright notice.
+</pre>
+<p><span id="AdobeGlyph"></span>
+</p>
+<h3><span class="mw-headline" id="Adobe_Glyph_List_Variant">Adobe Glyph List Variant</span></h3>
+<pre>
+# ###################################################################################
+# Copyright (c) 1997,1998,2002,2007 Adobe Systems Incorporated
+# 
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this documentation file to use, copy, publish, distribute,
+# sublicense, and/or sell copies of the documentation, and to permit
+# others to do the same, provided that:
+# - No modification, editing or other alteration of this document is
+# allowed; and
+# - The above copyright notice and this permission notice shall be
+# included in all copies of the documentation.
+# 
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this documentation file, to create their own derivative works
+# from the content of this document to use, copy, publish, distribute,
+# sublicense, and/or sell the derivative works, and to permit others to do
+# the same, provided that the derived work is not represented as being a
+# copy or version of this document.
+# 
+# Adobe shall not be liable to any party for any loss of revenue or profit
+# or for indirect, incidental, special, consequential, or other similar
+# damages, whether based on tort (including without limitation negligence
+# or strict liability), contract or other legal or equitable grounds even
+# if Adobe has been advised or had reason to know of the possibility of
+# such damages.Ê The Adobe materials are provided on an "AS IS" basis.Ê
+# Adobe specifically disclaims all express, statutory, or implied
+# warranties relating to the Adobe materials, including but not limited to
+# those concerning merchantability or fitness for a particular purpose or
+# non-infringement of any third party rights regarding the Adobe
+# materials.
+# ###################################################################################
+</pre>
+<p><span id="Xfig"></span>
+</p>
+<h3><span class="mw-headline" id="Xfig_Variant">Xfig Variant</span></h3>
+<pre>
+ * Any party obtaining a copy of these files is granted, free of charge, a
+ * full and unrestricted irrevocable, world-wide, paid up, royalty-free,
+ * nonexclusive right and license to deal in this software and
+ * documentation files (the "Software"), including without limitation the
+ * rights to use, copy, modify, merge, publish and/or distribute copies of
+ * the Software, and to permit persons who receive copies from any such
+ * party to do so, with the only requirement being that this copyright
+ * notice remain intact.
+</pre>
+<p><span id="Hylafax"></span>
+</p>
+<h3><span class="mw-headline" id="Hylafax_Variant">Hylafax Variant</span></h3>
+<pre>
+Copyright (c) 1990-1996 Sam Leffler Copyright (c) 1991-1996 Silicon Graphics, 
+Inc. HylaFAX is a trademark of Silicon Graphics, Inc.
+
+Permission to use, copy, modify, distribute, and sell this software and its 
+documentation for any purpose is hereby granted without fee, provided that 
+(i) the above copyright notices and this permission notice appear in all 
+copies of the software and related documentation, and (ii) the names of Sam 
+Leffler and Silicon Graphics may not be used in any advertising or publicity 
+relating to the software without the specific, prior written permission of 
+Sam Leffler and Silicon Graphics.
+
+THE SOFTWARE IS PROVIDED "AS-IS" AND WITHOUT WARRANTY OF ANY KIND, EXPRESS, 
+IMPLIED OR OTHERWISE, INCLUDING WITHOUT LIMITATION, ANY WARRANTY OF 
+MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+IN NO EVENT SHALL SAM LEFFLER OR SILICON GRAPHICS BE LIABLE FOR ANY SPECIAL, 
+INCIDENTAL, INDIRECT OR CONSEQUENTIAL DAMAGES OF ANY KIND, OR ANY DAMAGES 
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER OR NOT 
+ADVISED OF THE POSSIBILITY OF DAMAGE, AND ON ANY THEORY OF LIABILITY, 
+ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE. 
+</pre>
+<h2><span class="mw-headline" id="DANSE_Variant">DANSE Variant</span></h2>
+<pre>
+DANSE Software 1.0 
+
+COPYRIGHT AND PERMISSION NOTICE:
+Copyright (c) 2009 California Institute of Technology. All rights reserved. 
+Permission is hereby granted, free of charge, to any person obtaining a copy 
+of this software and associated documentation files (the “Software”), to deal in 
+the Software without restriction, including without limitation the rights to use, 
+copy, modify, merge, publish, distribute, and/or sell copies of the Software, and to 
+permit persons to whom the Software is furnished to do so, provided that the above 
+copyright notice(s) and this permission notice appear in all copies of the Software 
+and that both the above copyright notice(s) and this permission notice appear in 
+supporting documentation. 
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY 
+KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE 
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PUR- 
+POSE AND NONINFRINGEMENT OF THIRD PARTY RIGHTS. IN NO EVENT 
+SHALL THE COPYRIGHT HOLDER OR HOLDERS INCLUDED IN THIS NO- 
+TICE BE LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT OR CON- 
+SEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER RESULTING 
+FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF 
+CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT 
+OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS 
+SOFTWARE. 
+
+Except as contained in this notice, the name of a copyright holder shall not be 
+used in advertising or otherwise to promote the sale, use or other dealings in this 
+Software without prior written authorization of the copyright holder. 
+All source code included in this distribution is covered by this notice, unless 
+specifically stated otherwise within each file. See each file within each release for 
+specific copyright holders. 
+
+DANSE is the name of a software system under construction with U.S. National 
+Science Foundation funding.  All work derived from DANSE software should
+acknowledge DANSE with the following statement:
+
+  "This work benefitted from DANSE software developed
+   under NSF award DMR-0520547."
+</pre>
+<h2><span class="mw-headline" id="Nuclear_Variant">Nuclear Variant</span></h2>
+<pre>
+    Copyright (c) 1996 Widget Workshop, Inc. All Rights Reserved.
+
+    Permission to use, copy, modify, and distribute this software and its
+    documentation for NON-COMMERCIAL or COMMERCIAL purposes and without fee
+    is hereby granted, provided that this copyright notice is kept intact.
+
+    WIDGET WORKSHOP MAKES NO REPRESENTATIONS OR WARRANTIES ABOUT THE
+    SUITABILITY OF THE SOFTWARE, EITHER EXPRESS OR IMPLIED, INCLUDING BUT
+    NOT LIMITED TO THE IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+    PARTICULAR PURPOSE, OR NON-INFRINGEMENT. WIDGET WORKSHOP SHALL NOT BE
+    LIABLE FOR ANY DAMAGES SUFFERED BY LICENSEE AS A RESULT OF USING,
+    MODIFYING OR DISTRIBUTING THIS SOFTWARE OR ITS DERIVATIVES.
+
+    THIS SOFTWARE IS NOT DESIGNED OR INTENDED FOR USE OR RESALE AS ON-LINE
+    CONTROL EQUIPMENT IN HAZARDOUS ENVIRONMENTS REQUIRING FAIL-SAFE
+    PERFORMANCE, SUCH AS IN THE OPERATION OF NUCLEAR FACILITIES, AIRCRAFT
+    NAVIGATION OR COMMUNICATION SYSTEMS, AIR TRAFFIC CONTROL, DIRECT LIFE
+    SUPPORT MACHINES, OR WEAPONS SYSTEMS, IN WHICH THE FAILURE OF THE
+    SOFTWARE COULD LEAD DIRECTLY TO DEATH, PERSONAL INJURY, OR SEVERE
+    PHYSICAL OR ENVIRONMENTAL DAMAGE ("HIGH RISK ACTIVITIES").  WIDGET
+    WORKSHOP SPECIFICALLY DISCLAIMS ANY EXPRESS OR IMPLIED WARRANTY OF
+    FITNESS FOR HIGH RISK ACTIVITIES.
+</pre>
+<h2><span class="mw-headline" id="Epinions_Variant">Epinions Variant</span></h2>
+<pre>
+Copyright 2000 Epinions, Inc.
+
+Subject to the following 3 conditions, Epinions, Inc. permits you, free of 
+charge, to (a) use, copy, distribute, modify, perform and display this 
+software and associated documentation files (the "Software"), and (b) 
+permit others to whom the Software is furnished to do so as well.
+
+1) The above copyright notice and this permission notice shall be included 
+without modification in all copies or substantial portions of the Software.
+
+2) THE SOFTWARE IS PROVIDED "AS IS", WITHOUT ANY WARRANTY OR CONDITION OF 
+ANY KIND, EXPRESS, IMPLIED OR STATUTORY, INCLUDING WITHOUT LIMITATION ANY 
+IMPLIED WARRANTIES OF ACCURACY, MERCHANTABILITY, FITNESS FOR A PARTICULAR 
+PURPOSE OR NONINFRINGEMENT.
+
+3) IN NO EVENT SHALL EPINIONS, INC. BE LIABLE FOR ANY DIRECT, INDIRECT, 
+SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES OR LOST PROFITS ARISING OUT OF 
+OR IN CONNECTION WITH THE SOFTWARE (HOWEVER ARISING, INCLUDING NEGLIGENCE), 
+EVEN IF EPINIONS, INC. IS AWARE OF THE POSSIBILITY OF SUCH DAMAGES. 
+</pre>
+<h2><span class="mw-headline" id="OpenVision_Variant">OpenVision Variant</span></h2>
+<h3><span class="mw-headline" id="Notes">Notes</span></h3>
+<p>This license contains a title preservation clause, which can literally be read as a purported requirement to assign copyright in derivative works upstream to OpenVision. However, the use of the word "retained" suggests instead that it should be read as a mere assertion of persistence of copyright in derivative works.
+</p><p>Since this would automatically occur, as long as code persists from the original OpenVision copyrighted code base, under this interpretation, this becomes functionally equivalent to MIT.
+</p>
+<h3><span class="mw-headline" id="License_Text">License Text</span></h3>
+<pre>
+Copyright, OpenVision Technologies, Inc., 1996, All Rights Reserved
+
+WARNING: Retrieving the OpenVision Kerberos Administration system
+source code, as described below, indicates your acceptance of the
+following terms.  If you do not agree to the following terms, do not
+retrieve the OpenVision Kerberos administration system.
+
+You may freely use and distribute the Source Code and Object Code
+compiled from it, with or without modification, but this Source Code
+is provided to you "AS IS" EXCLUSIVE OF ANY WARRANTY, INCLUDING,
+WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A
+PARTICULAR PURPOSE, OR ANY OTHER WARRANTY, WHETHER EXPRESS OR IMPLIED.
+IN NO EVENT WILL OPENVISION HAVE ANY LIABILITY FOR ANY LOST PROFITS,
+LOSS OF DATA OR COSTS OF PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES,
+OR FOR ANY SPECIAL, INDIRECT, OR CONSEQUENTIAL DAMAGES ARISING OUT OF
+THIS AGREEMENT, INCLUDING, WITHOUT LIMITATION, THOSE RESULTING FROM
+THE USE OF THE SOURCE CODE, OR THE FAILURE OF THE SOURCE CODE TO
+PERFORM, OR FOR ANY OTHER REASON.
+
+OpenVision retains all copyrights in the donated Source
+Code. OpenVision also retains copyright to derivative works of the
+Source Code, whether created by OpenVision or by a third party. The
+OpenVision copyright notice must be preserved if derivative works are
+made based on the donated Source Code.
+
+OpenVision Technologies, Inc. has donated this Kerberos Administration
+system to MIT for inclusion in the standard Kerberos 5 distribution.
+This donation underscores our commitment to continuing Kerberos
+technology development and our gratitude for the valuable work which
+has been performed by MIT and the Kerberos community.
+</pre>
+<h2><span class="mw-headline" id="PetSC_Variant">PetSC Variant</span></h2>
+<pre>
+(C) COPYRIGHT 1995-2010 UNIVERSITY OF CHICAGO
+
+This program discloses material protectable under copyright laws of the United States. Permission to copy and 
+modify this software and its documentation is hereby granted, provided that this notice is retained thereon 
+and on all copies or modifications. The University of Chicago makes no representations as to the suitability 
+and operability of this software for any purpose. It is provided "as is" without express or implied warranty. 
+Permission is hereby granted to use, reproduce, prepare derivative works, and to redistribute to others, so 
+long as this original copyright notice is retained.
+
+Software authors
+
+    * Mathematics and Computer Science Division
+    * Argonne National Laboratory,
+    * Argonne IL 60439 FAX: (630) 252-5986
+    * Any questions or comments on the software may be directed to petsc-maint@mcs.anl.gov.
+
+Argonne National Laboratory with facilities in the state of Illinois, is owned by The United States Government, 
+and operated by the University of Chicago under provision of a contract with the Department of Energy.
+
+DISCLAIMER
+
+THIS PROGRAM WAS PREPARED AS AN ACCOUNT OF WORK SPONSORED BY AN AGENCY OF THE UNITED STATES GOVERNMENT. 
+NEITHER THE UNITED STATES GOVERNMENT NOR ANY AGENCY THEREOF, NOR THE UNIVERSITY OF CHICAGO, NOR ANY OF 
+THEIR EMPLOYEES OR OFFICERS, MAKES ANY WARRANTY, EXPRESS OR IMPLIED, OR ASSUMES ANY LEGAL LIABILITY OR 
+RESPONSIBILITY FOR THE ACCURACY, COMPLETENESS, OR USEFULNESS OF ANY INFORMATION, APPARATUS, PRODUCT, OR 
+PROCESS DISCLOSED, OR REPRESENTS THAT ITS USE WOULD NOT INFRINGE PRIVATELY OWNED RIGHTS. REFERENCE HEREIN 
+TO ANY SPECIFIC COMMERCIAL PRODUCT, PROCESS, OR SERVICE BY TRADE NAME, TRADEMARK, MANUFACTURER, OR OTHERWISE, 
+DOES NOT NECESSARILY CONSTITUTE OR IMPLY ITS ENDORSEMENT, RECOMMENDATION, OR FAVORING BY THE UNITED STATES 
+GOVERNMENT OR ANY AGENCY THEREOF. THE VIEW AND OPINIONS OF AUTHORS EXPRESSED HEREIN DO NOT NECESSARILY STATE 
+OR REFLECT THOSE OF THE UNITED STATES GOVERNMENT OR ANY AGENCY THEREOF.
+</pre>
+<h2><span class="mw-headline" id="Whatever_Variant">Whatever Variant</span></h2>
+<pre>
+THIS SOFTWARE IS PROVIDED 'AS-IS', WITHOUT ANY EXPRESS OR IMPLIED
+WARRANTY.  IN NO EVENT WILL THE AUTHORS BE HELD LIABLE FOR ANY DAMAGES
+ARISING FROM THE USE OF THIS SOFTWARE.
+
+Everyone is permitted to copy and distribute verbatim or modified
+copies of this license document.
+
+Permission is granted to anyone to use this software for any purpose,
+including commercial applications, and to alter it and redistribute it
+freely.
+</pre>
+<h2><span class="mw-headline" id="UnixCrypt_Variant">UnixCrypt Variant</span></h2>
+<h3><span class="mw-headline" id="Notes_2">Notes</span></h3>
+<p>This MIT variant is worded in a slightly confusing manner and does not include a warranty disclaimer.
+While this is technically free (and GPL-compatible), we do not recommend its use.
+</p>
+<h3><span class="mw-headline" id="Text">Text</span></h3>
+<pre>
+ Permission to use, copy, modify and distribute this software
+ for non-commercial or commercial purposes and without fee is
+ hereby granted provided that this copyright notice appears in
+ all copies.
+</pre>
+<h3><span class="mw-headline" id="Variant_Text">Variant Text</span></h3>
+<p>Yes, there is a variant of this variant, replacing the "non-commercial or commercial purposes and without fee" wording that is confusing with "any purpose with or without fee". It is still free (and GPL-compatible), but because of the absence of any warranty disclaimer, we do not recommend its use.
+</p>
+<pre>
+ Permission to use, copy, modify, and distribute this software 
+ for any purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies. 
+</pre>
+<h2><span class="mw-headline" id="HP_Variant">HP Variant</span></h2>
+<pre>
+/*
+ * (c) Copyright 1995 HEWLETT-PACKARD COMPANY
+ *
+ * To anyone who acknowledges that this file is provided
+ * "AS IS" without any express or implied warranty:
+ * permission to use, copy, modify, and distribute this
+ * file for any purpose is hereby granted without fee,
+ * provided that the above copyright notice and this
+ * notice appears in all copies, and that the name of
+ * Hewlett-Packard Company not be used in advertising or
+ * publicity pertaining to distribution of the software
+ * without specific, written prior permission.  Hewlett-
+ * Packard Company makes no representations about the
+ * suitability of this software for any purpose.
+ *
+ */
+</pre>
+<h2><span class="mw-headline" id="Cheusov_variant">Cheusov variant</span></h2>
+<h3><span class="mw-headline" id="Notes_3">Notes</span></h3>
+<p>This variant does not give explicit permission to redistribute unmodified copies, however, since it does give permission to "copy" unmodifed copies, we are interpreting it that way. Also, since it does grant explicit permission to redistribute modified code, we feel the intent was to grant permission to redistribute unmodified copies as well. That said, this license is poorly worded, and we do not recommend its use.
+</p>
+<h3><span class="mw-headline" id="Text_2">Text</span></h3>
+<pre>
+/*
+ * Copyright (C) 2006 Aleksey Cheusov
+ *
+ * This material is provided "as is", with absolutely no warranty expressed
+ * or implied. Any use is at your own risk.
+ *
+ * Permission to use or copy this software for any purpose is hereby granted
+ * without fee. Permission to modify the code and to distribute modified
+ * code is also granted without any restrictions.
+ */
+</pre>
+
+<!-- 
+NewPP limit report
+Cached time: 20180329104802
+Cache expiry: 86400
+Dynamic content: false
+CPU time usage: 0.113 seconds
+Real time usage: 0.131 seconds
+Preprocessor visited node count: 556/1000000
+Preprocessor generated node count: 1091/1000000
+Post‐expand include size: 342/2097152 bytes
+Template argument size: 76/2097152 bytes
+Highest expansion depth: 3/40
+Expensive parser function count: 0/100
+-->
+<!--
+Transclusion expansion time report (%,ms,calls,template)
+100.00%   16.588      1 -total
+ 59.13%    9.808     10 Template:Anchor
+-->
+
+<!-- Saved in parser cache with key fpo-mediawiki-en_:pcache:idhash:3246-0!*!*!!en!*!* and timestamp 20180329104801 and revision id 407754
+ -->
+</div><div class="visualClear"></div><div class="printfooter">Retrieved from "<a dir="ltr" href="https://fedoraproject.org/w/index.php?title=Licensing:MIT&amp;oldid=407754">https://fedoraproject.org/w/index.php?title=Licensing:MIT&amp;oldid=407754</a>"</div><div id="catlinks" class="catlinks catlinks-allhidden" data-mw="interface"></div>				</div>
+			</div>
+
+			<div id="mw-footer" class="footer text-muted text-xs-center m-t-3 p-y-3">
+				<p class="copy">
+				Copyright &copy; 2018 Red Hat, Inc. and others.  All Rights Reserved.  For comments or queries, please <a href="/wiki/Communicating_and_getting_help">contact us</a>.
+				</p>
+				<p class="disclaimer">
+				The Fedora Project is maintained and driven by the community and sponsored by Red Hat.  This is a community maintained site.  Red Hat is not responsible for content.
+				</p>
+				<ul id="footer-info" role="contentinfo"><li id="footer-info-lastmod"> This page was last edited on 25 March 2015, at 12:50.</li><li id="footer-info-copyright">Content is available under <a href="/wiki/Legal:Main" title="Legal:Main">Attribution-Share Alike 3.0 Unported</a> unless otherwise noted.</li></ul><ul id="footer-places" role="contentinfo"><li id="footer-places-privacy"><a href="/wiki/Fedora_Project_Wiki:Privacy_policy" class="mw-redirect" title="Fedora Project Wiki:Privacy policy">Privacy policy</a></li><li id="footer-places-about"><a href="/wiki/Fedora_Project_Wiki:About" class="mw-redirect" title="Fedora Project Wiki:About">About Fedora Project Wiki</a></li><li id="footer-places-disclaimer"><a href="/wiki/Fedora_Project_Wiki:General_disclaimer" class="mw-redirect" title="Fedora Project Wiki:General disclaimer">Disclaimers</a></li><li><a href='http://fedoraproject.org/en/sponsors'>Sponsors</a></li><li><a href='http://fedoraproject.org/wiki/Legal:Main'>Legal</a></li><li><a href='http://fedoraproject.org/wiki/Legal:Trademark_guidelines'>Trademark Guidelines</a></li></ul><div class="visualClear"></div>
+			</div>
+		</div>
+
+		<script>(window.RLQ=window.RLQ||[]).push(function(){mw.config.set({"wgPageParseReport":{"limitreport":{"cputime":"0.113","walltime":"0.131","ppvisitednodes":{"value":556,"limit":1000000},"ppgeneratednodes":{"value":1091,"limit":1000000},"postexpandincludesize":{"value":342,"limit":2097152},"templateargumentsize":{"value":76,"limit":2097152},"expansiondepth":{"value":3,"limit":40},"expensivefunctioncount":{"value":0,"limit":100},"timingprofile":["100.00%   16.588      1 -total"," 59.13%    9.808     10 Template:Anchor"]},"cachereport":{"timestamp":"20180329104802","ttl":86400,"transientcontent":false}}});});</script><script>(window.RLQ=window.RLQ||[]).push(function(){mw.config.set({"wgBackendResponseTime":444});});</script>		</body>
+		</html>
+
+		

--- a/docker/licenses/nginx.txt
+++ b/docker/licenses/nginx.txt
@@ -1,0 +1,26 @@
+/* 
+ * Copyright (C) 2002-2018 Igor Sysoev
+ * Copyright (C) 2011-2018 Nginx, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */


### PR DESCRIPTION

This is an attempt to add licenses to the hawtio-online docker image - I'm not sure this is the right way to go about it, but I figured I'd give it an initial shot.    This approach uses a few static files, but I'm not familiar enough with hawtio to know what else we need to list - do we need to list every node.js dependency?

This is a node license reporter from productization that could be used, but the package.json in hawtio-online doesn't contain dependencies, and a license entry also needs to be added : 

 https://docs.engineering.redhat.com/display/JPC/Product+Licensing+Information#ProductLicensingInformation-nodejs_license_reporterNode.jsLicenseReporter
