### PR TITLE
fix(osgi): ENTESB-12241 OSGi pages not working on OCP 4.1

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -12,7 +12,7 @@
     "build": "gulp build"
   },
   "dependencies": {
-    "@hawtio/core": "~4.7.0",
+    "@hawtio/core": "~4.7.2",
     "@hawtio/kubernetes-api": "~4.6.2",
     "eventemitter3": "^3.1.0",
     "jolokia.js": "^1.6.0-1",

--- a/packages/integration/package.json
+++ b/packages/integration/package.json
@@ -8,7 +8,7 @@
     "license": "license-reporter save --xml licenses.xml"
   },
   "dependencies": {
-    "@hawtio/integration": "~4.7.4",
+    "@hawtio/integration": "~4.7.13",
     "@hawtio/oauth": "~4.7.3",
     "@hawtio/online-common": "*",
     "openshift-logos-icon": "^1.6.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8,10 +8,10 @@
   dependencies:
     "@types/jquery" "2.0.53"
 
-"@hawtio/core@~4.7.0":
-  version "4.7.0"
-  resolved "https://registry.yarnpkg.com/@hawtio/core/-/core-4.7.0.tgz#c74657275939899abcd3011bea11efda99f74509"
-  integrity sha512-rW2IXhqGWWS/WXYrq9jFdYV8+DVtYNffNVYGxmVE4NC3HPIWyoooOkea/w6juYLjwECkioiQ7kh9sycJuMXNMw==
+"@hawtio/core@~4.7.0", "@hawtio/core@~4.7.2":
+  version "4.7.2"
+  resolved "https://registry.yarnpkg.com/@hawtio/core/-/core-4.7.2.tgz#72ab3e42fa5e62172f475251e68a4552e81f273c"
+  integrity sha512-KpUUgbcwRx04gpSWGMvJg5eO/Oy4xEgHhmBUc0KiCTOErGPzfWeeR28Ue95FX/rIhcXX8lVSs1CUo9DTW2m6jQ==
   dependencies:
     "@hawtio/core-dts" "~3.3.0"
     "@patternfly/patternfly" "^2.0.0"
@@ -26,27 +26,27 @@
     angular-route "^1.7.7"
     jquery "2.2.4"
     js-logger "1.4.1"
-    lodash "4.17.11"
+    lodash "~4.17.0"
     marked "0.6.1"
     typescript "^3.0.3"
     urijs "1.19.0"
 
-"@hawtio/integration@~4.7.4":
-  version "4.7.4"
-  resolved "https://registry.yarnpkg.com/@hawtio/integration/-/integration-4.7.4.tgz#2e8dbf1168f3e25341e164a95ad61980479d5c79"
-  integrity sha512-NsHcx72bXiHnfOHxTcg5MkRHzqlkkW27P2yy7Itm492rU+SG3dRStpjrqLYbJRHe2Iq6TFKYE2PvZg08NYgcsw==
+"@hawtio/integration@~4.7.13":
+  version "4.7.13"
+  resolved "https://registry.yarnpkg.com/@hawtio/integration/-/integration-4.7.13.tgz#0c6c80d9e4e73b29364b4b1305cb22c20d945de2"
+  integrity sha512-9cvlCRr3H/VYgkmrX/kH+weA06ISUK3FHsowNcSVxfO8CvWN6GcgLHTl66gK67O96sIPzrmdTDV1d2SlrwTvIA==
   dependencies:
     "@hawtio/core" "~4.7.0"
     "@types/angular-mocks" "~1.7.0"
     "@types/angular-ui-bootstrap" "~0.13.46"
     "@types/bootstrap" "3.3.36"
-    "@types/clipboard" "1.5.35"
+    "@types/clipboard" "~2.0.0"
     "@types/jquery" "2.0.53"
     "@types/jqueryui" "1.12.2"
     "@types/js-beautify" "0.0.30"
     angular-resizable "1.2.0"
     angular-ui-bootstrap "2.5.6"
-    clipboard "1.7.1"
+    clipboard "~2.0.0"
     codemirror "5.33.0"
     cubism "^1.6.0"
     dagre-layout "0.8.0"
@@ -136,9 +136,10 @@
   dependencies:
     "@types/d3" "^4"
 
-"@types/clipboard@1.5.35":
-  version "1.5.35"
-  resolved "https://registry.yarnpkg.com/@types/clipboard/-/clipboard-1.5.35.tgz#bceb67a7e0aad3070468929b95a2d626405db464"
+"@types/clipboard@~2.0.0":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@types/clipboard/-/clipboard-2.0.1.tgz#75a74086c293d75b12bc93ff13bc7797fef05a40"
+  integrity sha512-gJJX9Jjdt3bIAePQRRjYWG20dIhAgEqonguyHxXuqALxsoDsDLimihqrSg8fXgVTJ4KZCzkfglKtwsh/8dLfbA==
 
 "@types/d3-array@*":
   version "1.2.6"
@@ -1030,9 +1031,10 @@ cli-usage@^0.1.1:
     marked "^0.3.12"
     marked-terminal "^2.0.0"
 
-clipboard@1.7.1:
-  version "1.7.1"
-  resolved "https://registry.yarnpkg.com/clipboard/-/clipboard-1.7.1.tgz#360d6d6946e99a7a1fef395e42ba92b5e9b5a16b"
+clipboard@~2.0.0:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/clipboard/-/clipboard-2.0.4.tgz#836dafd66cf0fea5d71ce5d5b0bf6e958009112d"
+  integrity sha512-Vw26VSLRpJfBofiVaFb/I8PVfdI1OxKcYShe6fm0sP/DtmiWQNCjhM/okTvdCo0G+lMMm1rMYbk4IK4x1X+kgQ==
   dependencies:
     good-listener "^1.2.2"
     select "^1.1.2"
@@ -1690,7 +1692,7 @@ eventemitter3@3.1.0, eventemitter3@^3.0.0, eventemitter3@^3.1.0, eventemitter3@~
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-3.1.0.tgz#090b4d6cdbd645ed10bf750d4b5407942d7ba163"
 
-execa@^0.7.0, execa@^1.0.0:
+execa@1.0.0, execa@^0.7.0, execa@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/execa/-/execa-1.0.0.tgz#c6236a5bb4df6d6f15e88e7f017798216749ddd8"
   integrity sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==
@@ -2047,7 +2049,7 @@ get-stdin@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-4.0.1.tgz#b968c6b0a04384324902e8bf1a5df32579a450fe"
 
-get-stream@^3.0.0, get-stream@^4.0.0:
+get-stream@4.1.0, get-stream@^3.0.0, get-stream@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-4.1.0.tgz#c1b255575f3dc21d59bfc79cd3d2b46b1c3a54b5"
   integrity sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==
@@ -2632,7 +2634,7 @@ interpret@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.1.0.tgz#7ed1b1410c6a0e0f78cf95d3b8440c63f78b8614"
 
-invert-kv@^1.0.0, invert-kv@^2.0.0:
+invert-kv@2.0.0, invert-kv@^1.0.0, invert-kv@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-2.0.0.tgz#7393f5afa59ec9ff5f67a27620d11c226e3eec02"
   integrity sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==
@@ -3006,7 +3008,7 @@ lazystream@^1.0.0:
   dependencies:
     readable-stream "^2.0.5"
 
-lcid@^1.0.0, lcid@^2.0.0:
+lcid@2.0.0, lcid@^1.0.0, lcid@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/lcid/-/lcid-2.0.0.tgz#6ef5d2df60e52f82eb228a4c373e8d1f397253cf"
   integrity sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==
@@ -3299,7 +3301,7 @@ lodash.uniq@^4.3.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
 
-lodash@4.17.11, lodash@4.17.4, lodash@^4.0.0, lodash@^4.11.1, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.17.11, lodash@^4.17.4, lodash@~1.0.1, lodash@~4.17.10:
+lodash@4.17.4, lodash@^4.0.0, lodash@^4.11.1, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.17.11, lodash@^4.17.4, lodash@~1.0.1, lodash@~4.17.0, lodash@~4.17.10:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
@@ -3393,7 +3395,7 @@ media-typer@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
 
-mem@^1.1.0, mem@^4.0.0:
+mem@4.3.0, mem@^1.1.0, mem@^4.0.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/mem/-/mem-4.3.0.tgz#461af497bc4ae09608cdb2e60eefb69bff744178"
   integrity sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==
@@ -3464,7 +3466,7 @@ microplugin@0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/microplugin/-/microplugin-0.0.3.tgz#1fc2e1bb7c9e19e82bd84bba9137bbe71250d8cd"
 
-mime-db@1.32.0, mime-db@1.40.0, "mime-db@>= 1.33.0 < 2", mime-db@~1.33.0:
+mime-db@1.32.0, mime-db@1.42.0, "mime-db@>= 1.33.0 < 2", mime-db@~1.33.0:
   version "1.32.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.32.0.tgz#485b3848b01a3cda5f968b4882c0771e58e09414"
 
@@ -3478,7 +3480,7 @@ mime@1.3.4, mime@1.4.1, mime@1.6.0, mime@^1.2.11:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
 
-mimic-fn@^1.0.0, mimic-fn@^2.0.0:
+mimic-fn@2.1.0, mimic-fn@^1.0.0, mimic-fn@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
@@ -4186,7 +4188,7 @@ psl@^1.1.24:
   version "1.1.31"
   resolved "https://registry.yarnpkg.com/psl/-/psl-1.1.31.tgz#e9aa86d0101b5b105cbe93ac6b784cd547276184"
 
-pump@^2.0.0, pump@^3.0.0:
+pump@3.0.0, pump@^2.0.0, pump@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/pump/-/pump-3.0.0.tgz#b4a2116815bde2f4e1ea602354e8c75565107a64"
   integrity sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==


### PR DESCRIPTION
Fixed the issue by reordering properties in Hawtio. Couldn't find the reason the properties are received in the wrong order.
Commit: https://github.com/hawtio/hawtio-integration/commit/2f14d4faa3349b95acfd369792821ead469ac4aa

Additionally, added a check to show the OSGi Server tab only when the required MBean is available.
Commit: https://github.com/hawtio/hawtio-integration/commit/b72d1f4b063c88bd673e48af38307b9bc25a1045