### PR TITLE
feat: Add RBAC support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,8 @@ RUN gulp --series build site
 
 FROM docker.io/centos:7
 
-ENV NGINX_VERSION 1.18.0-1.el7
-ENV NGINX_MODULE_NJS_VERSION 1.18.0.0.4.0-1.el7
+ENV NGINX_VERSION 1.17.10-1.el7
+ENV NGINX_MODULE_NJS_VERSION 1.17.10.0.4.0-1.el7
 
 LABEL name="nginxinc/nginx" \
       vendor="NGINX Inc." \

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,8 +61,8 @@ RUN touch config.js && \
     mkdir -p /usr/share/nginx/html/integration/osconsole && \
     ln -sf /config.js /usr/share/nginx/html/integration/osconsole/config.js
 
-COPY docker/nginx.js /etc/nginx/conf.d/
-COPY docker/nginx.conf docker/nginx-gateway.conf docker/osconsole/config.sh docker/nginx.sh docker/ACL.yaml docker/js-yaml.js docker/rbac.js /
+COPY docker/nginx.js docker/rbac.js docker/js-yaml.js /etc/nginx/conf.d/
+COPY docker/nginx.conf docker/nginx-gateway.conf docker/osconsole/config.sh docker/nginx.sh docker/ACL.yaml /
 
 COPY --from=builder /hawtio-online/docker/site /usr/share/nginx/html/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,8 @@ RUN gulp --series build site
 
 FROM docker.io/centos:7
 
-ENV NGINX_VERSION 1.17.9-1.el7
-ENV NGINX_MODULE_NJS_VERSION 1.17.9.0.3.9-1.el7
+ENV NGINX_VERSION 1.18.0-1.el7
+ENV NGINX_MODULE_NJS_VERSION 1.18.0.0.4.0-1.el7
 
 LABEL name="nginxinc/nginx" \
       vendor="NGINX Inc." \

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ RUN ln -sf /dev/stdout /var/log/nginx/access.log && \
     chown -R 998 /var/cache/nginx /etc/nginx && \
     chmod -R g=u /var/cache/nginx /etc/nginx
 
-EXPOSE 443
+EXPOSE 8443
 
 # Add symbolic link to config.json to avoid mounting issues
 RUN ln -sf /usr/share/nginx/html/config/config.json /usr/share/nginx/html/config.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,8 @@ RUN gulp --series build site
 
 FROM docker.io/centos:7
 
-ENV NGINX_VERSION 1.17.1-1.el7
-ENV NGINX_MODULE_NJS_VERSION 1.17.1.0.3.3-1.el7
+ENV NGINX_VERSION 1.17.9-1.el7
+ENV NGINX_MODULE_NJS_VERSION 1.17.9.0.3.9-1.el7
 
 LABEL name="nginxinc/nginx" \
       vendor="NGINX Inc." \

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,7 @@ RUN touch config.js && \
     ln -sf /config.js /usr/share/nginx/html/integration/osconsole/config.js
 
 COPY docker/nginx.js /etc/nginx/conf.d/
-COPY docker/nginx.conf docker/nginx-gateway.conf docker/osconsole/config.sh docker/nginx.sh /
+COPY docker/nginx.conf docker/nginx-gateway.conf docker/osconsole/config.sh docker/nginx.sh docker/ACL.yaml docker/js-yaml.js docker/rbac.js /
 
 COPY --from=builder /hawtio-online/docker/site /usr/share/nginx/html/
 

--- a/deployment-cluster-rbac.yml
+++ b/deployment-cluster-rbac.yml
@@ -125,7 +125,7 @@ objects:
               memory: 32Mi
             limits:
               cpu: 1.0
-              memory: 32Mi
+              memory: 64Mi
           volumeMounts:
           - name: hawtio-online
             mountPath: /usr/share/nginx/html/online/hawtconfig.json

--- a/deployment-cluster-rbac.yml
+++ b/deployment-cluster-rbac.yml
@@ -1,0 +1,688 @@
+apiVersion: v1
+kind: Template
+metadata:
+  name: hawtio-online
+parameters:
+- name: ROUTE_HOSTNAME
+  description: The externally-reachable host name that routes to the Hawtio Online service
+  required: true
+- name: OPENSHIFT_WEB_CONSOLE_URL
+  description: The externally-reachable URL that routes to the OpenShift Web console
+  required: false
+message: |-
+  Hawtio Online is deployed to ${ROUTE_HOSTNAME}.
+objects:
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: hawtio-online
+  data:
+    hawtconfig.json: |
+      {
+        "about": {
+          "title": "Hawtio OpenShift Console",
+          "productInfo": [],
+          "additionalInfo": "The Hawtio OpenShift Console eases the discovery and management of 'hawtio-enabled' applications deployed on OpenShift.",
+          "copyright": ""
+        },
+        "branding": {
+          "appName": "Hawtio OpenShift Console",
+          "appLogoUrl": "img/hawtio-logo.svg"
+        },
+        "disabledRoutes": []
+      }
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: hawtio-integration
+  data:
+    hawtconfig.json: |
+      {
+        "branding": {
+          "appName": "Hawtio Integration Console",
+          "appLogoUrl": "img/hawtio-logo.svg",
+          "aboutDescription": "The Hawtio Integration Console enables introspecting Java applications."
+        },
+        "disabledRoutes": []
+      }
+- apiVersion: v1
+  kind: ImageStream
+  metadata:
+    name: hawtio-online
+    labels:
+      app: hawtio
+      component: online
+  spec:
+    tags:
+    - from:
+        kind: DockerImage
+        name: docker.io/hawtio/online:latest
+      importPolicy:
+        scheduled: true
+      name: latest
+- apiVersion: v1
+  kind: DeploymentConfig
+  metadata:
+    labels:
+      app: hawtio
+      component: online
+    name: hawtio-online
+  spec:
+    replicas: 1
+    selector:
+      app: hawtio
+      component: online
+      deploymentconfig: hawtio-online
+    strategy:
+      rollingParams:
+        intervalSeconds: 1
+        maxSurge: 25%
+        maxUnavailable: 25%
+        timeoutSeconds: 600
+        updatePeriodSeconds: 1
+      type: Rolling
+    template:
+      metadata:
+        labels:
+          app: hawtio
+          component: online
+          deploymentconfig: hawtio-online
+      spec:
+        containers:
+        - image: hawtio/online
+          imagePullPolicy: Always
+          name: hawtio-online
+          ports:
+          - name: nginx
+            containerPort: 8443
+          livenessProbe:
+            httpGet:
+              path: /online
+              port: nginx
+              scheme: HTTPS
+            periodSeconds: 10
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /online
+              port: nginx
+              scheme: HTTPS
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 1
+          env:
+          - name: HAWTIO_ONLINE_MODE
+            value: cluster
+          - name: HAWTIO_ONLINE_RBAC_ACL
+            value: /etc/hawtio/rbac/ACL.yaml
+          - name: OPENSHIFT_WEB_CONSOLE_URL
+            value: ${OPENSHIFT_WEB_CONSOLE_URL}
+          - name: OPENSHIFT_CLUSTER_VERSION
+            value: '4'
+          resources:
+            requests:
+              cpu: 0.2
+              memory: 32Mi
+            limits:
+              cpu: 1.0
+              memory: 32Mi
+          volumeMounts:
+          - name: hawtio-online
+            mountPath: /usr/share/nginx/html/online/hawtconfig.json
+            subPath: hawtconfig.json
+          - name: hawtio-integration
+            mountPath: /usr/share/nginx/html/integration/hawtconfig.json
+            subPath: hawtconfig.json
+          - mountPath: /etc/hawtio/rbac
+            name: hawtio-rbac
+          - mountPath: /etc/tls/private/serving
+            name: hawtio-online-tls-serving
+          - mountPath: /etc/tls/private/proxying
+            name: hawtio-online-tls-proxying
+        volumes:
+        - name: hawtio-online
+          configMap:
+            name: hawtio-online
+        - name: hawtio-integration
+          configMap:
+            name: hawtio-integration
+        - name: hawtio-rbac
+          configMap:
+            name: hawtio-rbac
+        - name: hawtio-online-tls-serving
+          secret:
+            secretName: hawtio-online-tls-serving
+        - name: hawtio-online-tls-proxying
+          secret:
+            secretName: hawtio-online-tls-proxying
+    triggers:
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - hawtio-online
+        from:
+          kind: ImageStreamTag
+          name: hawtio-online:latest
+      type: ImageChange
+    - type: ConfigChange
+- apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      app: hawtio
+      component: online
+    annotations:
+      service.beta.openshift.io/serving-cert-secret-name: hawtio-online-tls-serving
+    name: hawtio-online
+  spec:
+    ports:
+    - port: 443
+      protocol: TCP
+      targetPort: nginx
+    selector:
+      app: hawtio
+      component: online
+- apiVersion: v1
+  kind: Route
+  metadata:
+    labels:
+      app: hawtio
+      component: online
+    name: hawtio-online
+  spec:
+    host: ${ROUTE_HOSTNAME}
+    to:
+      kind: Service
+      name: hawtio-online
+    tls:
+      insecureEdgeTerminationPolicy: Redirect
+      termination: reencrypt
+- apiVersion: v1
+  kind: OAuthClient
+  metadata:
+    name: hawtio-online
+  grantMethod: auto
+  redirectURIs:
+  - https://${ROUTE_HOSTNAME}
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: hawtio-rbac
+  data:
+    ACL.yaml: |
+      # This file defines the roles allowed for MBean operations
+      #
+      # The definition of ACLs for JMX operations works as follows:
+      #
+      # Based on the ObjectName of the JMX MBean, a key composed with the ObjectName
+      # domain, followed by the 'type' attribute optionally, can be declared, using the
+      # convention <domain>.<type>.
+      # For example, the 'java.lang.Threading' key for the MBean with the following
+      # objectName: java.lang:type=Threading can be declared. A more generic key with
+      # the domain only can be declared (e.g. java.lang). A 'default' top-level key can
+      # also be declared.
+      # A key can either be an unordered or ordered map, whose keys can either be
+      # string or regexp, and whose values can either be string or array of strings,
+      # that represent roles that are allowed to invoke the MBean member.
+      #
+      # The system looks for allowed roles using the following process:
+      #
+      # The most specific key is tried first. E.g. for the
+      # above example, the java.lang.Threading key is looked up first.
+      # If the most specific key does not exist, the domain-only key is looked up,
+      # otherwise, the 'default' key is looked up.
+      # Using the matching key, the system looks up its map value for:
+      #   1. An exact match for the operation invocation, using the operation
+      #      signature, and the invocation arguments, e.g.:
+      #      uninstall(java.lang.String)[0]: [] # no roles can perform this operation
+      #   2. A regexp match for the operation invocation, using the operation
+      #      signature, and the invocation arguments, e.g.:
+      #      /update\(java\.lang\.String,java\.lang\.String\)\[[1-4]?[0-9],.*\]/: admin
+      #      Note that, if the value is an ordered map, the iteration order is guaranteed,
+      #      and the first matching regexp key is selected;
+      #   3. An exact match for the operation invocation, using the operation
+      #      signature, without the invocation arguments, e.g.:
+      #      delete(java.lang.String): admin
+      #   4. An exact match for the operation invocation, using the operation
+      #      name, e.g.:
+      #      dumpStatsAsXml: admin, viewer
+      # If the key matches the operation invocation, it is used and the process will not
+      # look for any other keys. So the most specific key always takes precedence.
+      # Its value is used to match the role that impersonates the request, against the roles
+      # that are allowed to invoke the operation.
+      # If the current key does not match, the less specific key is looked up
+      # and matched following the steps 1 to 4 above, up until the 'default' key.
+      # Otherwise, the operation invocation is denied.
+      #
+      # For the time being, only the viewer and admin roles are supported. Once the current
+      # invocation is authenticated, these roles are inferred from the permissions the user
+      # impersonating the request is granted for the pod hosting the operation being invoked.
+      # A user that's granted the 'update' verb on the pod resource is bound to the 'admin' role.
+      # Else, a user granted the 'get' verb on the pod resource is bound the 'viewer' role.
+      # Otherwise the use is not bound any roles.
+
+      # Default, generic rules, declared as an ordered map, so that the most specific keys
+      # are tested first.
+      default:
+        - list: admin, viewer
+        - read: admin, viewer
+        - search: admin, viewer
+        - /list.*/: admin, viewer
+        - /get.*/: admin, viewer
+        - /is.*/: admin, viewer
+        - /set.*/: admin
+        - /.*/: admin
+
+      com.sun.management:
+        dumpHeap: admin, viewer
+        getVMOption: admin, viewer
+        setVMOption: admin
+
+      connector:
+        stop: admin
+        start: admin
+
+      hawtio.plugin:
+        /.*/: /.*/
+      hawtio.ConfigAdmin:
+        configAdminUpdate: admin
+      hawtio.OSGiTools:
+        getResourceURL: admin, viewer
+        getLoadClassOrigin: admin, viewer
+      hawtio.QuartzFacade:
+        updateSimpleTrigger: admin
+        updateCronTrigger: admin
+      hawtio.SchemaLookup:
+        getSchemaForClass: admin, viewer
+      hawtio.security:
+        canInvoke: admin, viewer
+
+      java.lang.Memory:
+        gc: admin
+      java.lang.MemoryPool:
+        resetPeakUsage: admin
+      java.lang.Threading:
+        /find.*/: admin, viewer
+        dumpAllThreads: admin, viewer
+        resetPeakThreadCount: admin
+      java.util.logging:
+        getLoggerLevel: admin, viewer
+        getParentLoggerName: admin, viewer
+        setLoggerLevel: admin
+
+      jolokia.Config.hawtio:
+        /is.*/: admin, viewer
+        /get.*/: admin, viewer
+        /set.*/: admin
+        debugInfo: admin, viewer
+        setHistoryEntriesForAttribute: admin
+        setHistoryEntriesForOperation: admin
+        setHistoryLimitForOperation: admin
+        resetHistoryEntries: admin
+        resetDebugInfo: admin
+        setHistoryLimitForAttribute: admin
+      jolokia.Discovery:
+        lookupAgents: admin, viewer
+        lookupAgentsWithTimeout: admin, viewer
+      jolokia.ServerHandler.hawtio: 
+        mBeanServersInfo: admin, viewer
+
+      org.apache.aries.blueprint.blueprintMetadata:
+        /get.*/: admin, viewer
+      org.apache.aries.blueprint.blueprintState:
+        /get.*/: admin, viewer
+
+      org.apache.camel:
+        /.*/: /.*/
+      org.apache.camel.components:
+        getState: admin, viewer
+        getComponentName: admin, viewer
+        getCamelId: admin, viewer
+      org.apache.camel.consumers:
+        isSuspended: admin, viewer
+        getState: admin, viewer
+        getServiceType: admin, viewer
+        isSupportSuspension: admin, viewer
+        isStaticService: admin, viewer
+        getCamelId: admin, viewer
+        getRouteId: admin, viewer
+        getInflightExchanges: admin, viewer
+        getEndpointUri: admin, viewer
+        stop: admin
+        start: admin
+        suspend: admin
+        resume: admin
+      org.apache.camel.context:
+        getResetTimestamp: admin, viewer
+        getExchangesTotal: admin, viewer
+        getTotalProcessingTime: admin, viewer
+        isStatisticsEnabled: admin, viewer
+        setStatisticsEnabled: admin
+        getExchangesCompleted: admin, viewer
+        getExchangesFailed: admin, viewer
+        getFailuresHandled: admin, viewer
+        getRedeliveries: admin, viewer
+        getExternalRedeliveries: admin, viewer
+        getMinProcessingTime: admin, viewer
+        getMeanProcessingTime: admin, viewer
+        getMaxProcessingTime: admin, viewer
+        getLastProcessingTime: admin, viewer
+        getDeltaProcessingTime: admin, viewer
+        getLastExchangeCompletedTimestamp: admin, viewer
+        getLastExchangeCompletedExchangeId: admin, viewer
+        getFirstExchangeCompletedTimestamp: admin, viewer
+        getFirstExchangeCompletedExchangeId: admin, viewer
+        getLastExchangeFailureTimestamp: admin, viewer
+        getLastExchangeFailureExchangeId: admin, viewer
+        getFirstExchangeFailureTimestamp: admin, viewer
+        getFirstExchangeFailureExchangeId: admin, viewer
+        getCamelId: admin, viewer
+        getTimeout: admin, viewer
+        setTimeout: admin
+        getProperties: admin, viewer
+        getState: admin, viewer
+        getUptime: admin, viewer
+        getInflightExchanges: admin, viewer
+        getTracing: admin, viewer
+        setTracing: admin
+        getLoad01: admin, viewer
+        getLoad05: admin, viewer
+        getLoad15: admin, viewer
+        getCamelVersion: admin, viewer
+        getApplicationContextClassName: admin, viewer
+        getTotalRoutes: admin, viewer
+        getStartedRoutes: admin, viewer
+        isMessageHistory: admin, viewer
+        getTimeUnit: admin, viewer
+        setTimeUnit: admin
+        getClassResolver: admin, viewer
+        getManagementName: admin, viewer
+        getPackageScanClassResolver: admin, viewer
+        isUseMDCLogging: admin, viewer
+        isAllowUseOriginalMessage: admin, viewer
+        isUseBreadcrumb: admin, viewer
+        isShutdownNowOnTimeout: admin, viewer
+        setShutdownNowOnTimeout: admin
+        reset: admin
+        dumpStatsAsXml: admin, viewer
+        setProperty: admin
+        getProperty: admin, viewer
+        createEndpoint: admin
+        restart: admin
+        stop: admin
+        start: admin
+        suspend: admin
+        resume: admin
+        sendStringBody: admin
+        requestStringBody: admin
+        dumpRoutesAsXml: admin, viewer
+        addOrUpdateRoutesFromXml: admin
+        findComponentNames: admin, viewer
+        dumpRoutesStatsAsXml: admin, viewer
+        componentParameterJsonSchema: admin, viewer
+        sendBody: admin
+        sendBodyAndHeaders: admin
+        requestBody: admin
+        requestBodyAndHeaders: admin
+        findComponents: admin, viewer
+        getComponentDocumentation: admin, viewer
+        removeEndpoints:  admin
+        completeEndpointPath: admin, viewer
+      org.apache.camel.endpoints:
+        /is.*/: admin, viewer
+        /get.*/: admin, viewer
+        /set.*/: admin
+      org.apache.camel.errorhandlers:
+        /is.*/: admin, viewer
+        /get.*/: admin, viewer
+        /set.*/: admin
+      org.apache.camel.eventnotifiers:
+        /set.*/: admin
+      org.apache.camel.processors:
+        dumpStatsAsXml: admin, viewer
+        /get.*/: admin, viewer
+        /is.*/: admin, viewer
+        /set.*/: admin
+        reset: admin
+        stop: admin
+        start: admin
+      org.apache.camel.routes:
+        /is.*/: admin, viewer
+        /get.*/: admin, viewer
+        /set.*/: admin
+        reset: admin
+        /dump.*/: admin, viewer
+        remove: admin
+        shutdown: admin
+        stop: admin
+        start: admin
+        suspend: admin
+        resume: admin
+        updateRouteFromXml: admin
+      org.apache.camel.services:
+        /is.*/: admin, viewer
+        /get.*/: admin, viewer
+        /set.*/: admin
+        stop: admin
+        start: admin
+        suspend: admin
+        resume: admin
+        purge: admin
+        hasTypeConverter: admin, viewer
+        resetTypeConversionCounters: admin
+        listTypeConverters: admin, viewer
+      org.apache.camel.threadpools:
+        /is.*/: admin, viewer
+        /get.*/: admin, viewer
+        /set.*/: admin
+        purge: admin
+      org.apache.camel.tracer:
+        /is.*/: admin, viewer
+        /get.*/: admin, viewer
+        /set.*/: admin
+        step: admin, viewer
+        enableDebugger: admin
+        disableDebugger: admin
+        /.*Breakpoint.*/: admin, viewer
+        resumeAll: admin, viewer
+        resetDebugCounter: admin
+        /dump.*/: admin, viewer
+        clear: admin
+        resetTraceCounter: admin
+
+      org.apache.cxf.Bus:
+        shutdown: admin
+      org.apache.cxf.Bus.Service.Endpoint:
+        destroy: admin
+        start: admin
+        stop: admin
+        getState: admin, viewer
+        getTransportId: admin, viewer
+        getAddress: admin, viewer
+      org.apache.cxf.WorkQueueManager:
+        shutdown: admin
+
+      org.apache.karaf.bundle:
+        capabilities: admin, viewer
+        diag: admin, viewer
+        getStartLevel: admin, viewer
+        install: admin
+        refresh: admin
+        resolve: admin
+        restart: admin
+        status: admin, viewer
+        /setStartLevel\(java\.lang\.String,int\)\[[1-4]?[0-9],.*\]/: admin
+        setStartLevel: admin
+        /start\(java\.lang\.String\)\[[1-4]?[0-9]\]/: admin
+        start: admin
+        /stop\(java\.lang\.String\)\[[1-4]?[0-9]\]/: admin
+        stop: admin
+        uninstall(java.lang.String)[0]: [] # no roles can perform this operation
+        uninstall: admin
+        /update\(java\.lang\.String\)\[[1-4]?[0-9]\]/: admin
+        /update\(java\.lang\.String,java\.lang\.String\)\[[1-4]?[0-9],.*\]/: admin
+        update: admin
+      org.apache.karaf.config:
+        listProperties: admin, viewer
+        /appendProperty\(java\.lang\.String,java\.lang\.String,java\.lang\.String\)\[jmx\.acl\..*,.*,.*\]/: admin
+        /appendProperty\(java\.lang\.String,java\.lang\.String,java\.lang\.String\)\[org\.apache\.karaf\.command\.acl\..+,.*,.*\]/: admin
+        /appendProperty\(java\.lang\.String,java\.lang\.String,java\.lang\.String\)\[org\.apache\.karaf\.service\.acl\..+,.*,.*\]/: admin
+        appendProperty(java.lang.String,java.lang.String,java.lang.String): admin
+        /create\(java\.lang\.String\)\[jmx\.acl\..*\]/: admin
+        /create\(java\.lang\.String\)\[org\.apache\.karaf\.command\.acl\..+\]/: admin
+        /create\(java\.lang\.String\)\[org\.apache\.karaf\.service\.acl\..+\]/: admin
+        create(java.lang.String): admin
+        /delete\(java\.lang\.String\)\[jmx\.acl\..*\]/: admin
+        /delete\(java\.lang\.String\)\[org\.apache\.karaf\.command\.acl\..+\]/: admin
+        /delete\(java\.lang\.String\)\[org\.apache\.karaf\.service\.acl\..+\]/: admin
+        delete(java.lang.String): admin
+        /deleteProperty\(java\.lang\.String,java\.lang\.String\)\[jmx\.acl\..*,.*\]/: admin
+        /deleteProperty\(java\.lang\.String,java\.lang\.String\)\[org\.apache\.karaf\.command\.acl\..+,.*\]/: admin
+        /deleteProperty\(java\.lang\.String,java\.lang\.String\)\[org\.apache\.karaf\.service\.acl\..+,.*\]/: admin
+        deleteProperty(java.lang.String,java.lang.String): admin
+        /setProperty\(java\.lang\.String,java\.lang\.String,java\.lang\.String\)\[jmx\.acl\..*,.*,.*\]/: admin
+        /setProperty\(java\.lang\.String,java\.lang\.String,java\.lang\.String\)\[org\.apache\.karaf\.command\.acl\..+,.*,.*\]/: admin
+        /setProperty\(java\.lang\.String,java\.lang\.String,java\.lang\.String\)\[org\.apache\.karaf\.service\.acl\..+,.*,.*\]/: admin
+        setProperty(java.lang.String,java.lang.String,java.lang.String): admin
+        /update\(java\.lang\.String,java\.util\.Map\)\[jmx\.acl\..*,.*\]/: admin
+        /update\(java\.lang\.String,java\.util\.Map\)\[org\.apache\.karaf\.command\.acl\..+,.*\]/: admin
+        /update\(java\.lang\.String,java\.util\.Map\)\[org\.apache\.karaf\.service\.acl\..+,.*\]/: admin
+        update(java.lang.String,java.util.Map): admin
+      org.apache.karaf.diagnostic:
+        createDump: admin, viewer
+      org.apache.karaf.feature:
+        infoFeature: admin, viewer
+        removeRepository: admin
+        addRepository: admin
+        uninstallFeature: admin
+        installFeature: admin
+        refreshRepository: admin
+      org.apache.karaf.instance:
+        createInstance: admin
+        destroyInstance: admin
+        startInstance: admin
+        stopInstance: admin
+        cloneInstance: admin
+        renameInstance: admin
+        changeSshPort: admin
+        changeSshHost: admin
+        ChangeRmiRegistryPort: admin
+        changeRmiServerPort: admin
+        changeJavaOpts: admin
+      org.apache.karaf.log:
+        getLevel: admin, viewer
+        setLevel: admin
+      org.apache.karaf.package:
+        getImports: admin, viewer
+        getExports: admin, viewer
+      org.apache.karaf.service:
+        getServices: admin, viewer
+      org.apache.karaf.system:
+        setProperty: admin
+        /getPropert.*/: admin, viewer
+        halt: admin
+        reboot: admin
+        rebootCleanCache: admin
+        rebootCleanAll: admin
+
+      osgi.compendium.cm:
+        /createFactoryConfiguration\(java\.lang\.String\)\[jmx\.acl\..*\]/: admin
+        /createFactoryConfiguration\(java\.lang\.String\)\[org\.apache\.karaf\.command\.acl\.\..+\]/: admin
+        /createFactoryConfiguration\(java\.lang\.String\)\[org\.apache\.karaf\.service\.acl\.\..+\]/: admin
+        createFactoryConfiguration(java.lang.String): admin
+        /createFactoryConfigurationForLocation\(java\.lang\.String,java\.lang\.String\)\[jmx\.acl\..*,.*\]/: admin
+        /createFactoryConfigurationForLocation\(java\.lang\.String,java\.lang\.String\)\[org\.apache\.karaf\.command\.acl\..+,.*\]/: admin
+        /createFactoryConfigurationForLocation\(java\.lang\.String,java\.lang\.String\)\[org\.apache\.karaf\.service\.acl\..+,.*\]/: admin
+        createFactoryConfigurationForLocation(java.lang.String,java.lang.String): admin
+        /delete\(java\.lang\.String\)\[jmx\.acl\..*\]/: admin
+        /delete\(java\.lang\.String\)\[org\.apache\.karaf\.command\.acl\..+\]/: admin
+        /delete\(java\.lang\.String\)\[org\.apache\.karaf\.service\.acl\..+\]/: admin
+        delete(java.lang.String): admin
+        deleteConfigurations: admin
+        /deleteForLocation\(java\.lang\.String,java\.lang\.String\)\[jmx\.acl\..*,.*\]/: admin
+        /deleteForLocation\(java\.lang\.String,java\.lang\.String\)\[org\.apache\.karaf\.command\.acl\..+,.*\]/: admin
+        /deleteForLocation\(java\.lang\.String,java\.lang\.String\)\[org\.apache\.karaf\.service\.acl\..+,.*\]/: admin
+        deleteForLocation(java.lang.String,java.lang.String): admin
+        /update\(java\.lang\.String,javax\.management\.openmbean\.TabularData\)\[jmx\.acl\..*,.*\]/: admin
+        /update\(java\.lang\.String,javax\.management\.openmbean\.TabularData\)\[org\.apache\.karaf\.command\.acl\..+,.*\]/: admin
+        /update\(java\.lang\.String,javax\.management\.openmbean\.TabularData\)\[org\.apache\.karaf\.service\.acl\..+,.*\]/: admin
+        update(java.lang.String,javax.management.openmbean.TabularData): admin
+        /updateForLocation\(java\.lang\.String,java\.lang\.String,javax\.management\.openmbean\.TabularData\)\[jmx\.acl\..*,.*,.*\]/: admin
+        /updateForLocation\(java\.lang\.String,java\.lang\.String,javax\.management\.openmbean\.TabularData\)\[org\.apache\.karaf\.command\.acl\..+,.*,.*\]/: admin
+        /updateForLocation\(java\.lang\.String,java\.lang\.String,javax\.management\.openmbean\.TabularData\)\[org\.apache\.karaf\.service\.acl\..+,.*,.*\]/: admin
+        updateForLocation(java.lang.String,java.lang.String,javax.management.openmbean.TabularData): admin
+      osgi.core.bundleState:
+        getRequiredBundles: admin, viewer
+        getHosts: admin, viewer
+        getLocation: admin, viewer
+        getState: admin, viewer
+        getBundle: admin, viewer
+        getVersion: admin, viewer
+        getSymbolicName: admin, viewer
+        getRegisteredServices: admin, viewer
+        getServicesInUse: admin, viewer
+        getFragments: admin, viewer
+        getLastModified: admin, viewer
+        getHeaders: admin, viewer
+        getHeader: admin, viewer
+        getStartLevel: admin, viewer
+        getExportedPackages: admin, viewer
+        getRequiringBundles: admin, viewer
+        isFragment: admin, viewer
+        isRemovalPending: admin, viewer
+        isPersistentlyStarted: admin, viewer
+        isActivationPolicyUsed: admin, viewer
+        getImportedPackages: admin, viewer
+        isRequired: admin, viewer
+        listBundles: admin, viewer
+      osgi.core.framework:
+        startBundles: admin
+        getProperty: admin, viewer
+        resolve: admin
+        installBundle: admin
+        setBundleStartLevel: admin
+        startBundle: admin
+        updateBundle: admin
+        stopBundle: admin
+        stopBundle(long)[0]: [] # no roles can perform this operation
+        uninstallBundle: admin
+        resolveBundles: admin
+        getDependencyClosure: admin, viewer
+        refreshBundle: admin
+        refreshBundles: admin
+        installBundleFromURL: admin
+        installBundles: admin
+        installBundlesFromURL: admin
+        refreshBundleAndWait: admin
+        refreshBundlesAndWait: admin
+        resolveBundle: admin
+        restartFramework: admin
+        setBundleStartLevels: admin
+        shutdownFramework: admin
+        stopBundles: admin
+        uninstallBundles: admin
+        updateBundleFromURL: admin
+        updateBundles: admin
+        updateBundlesFromURL: admin
+      osgi.core.packageState:
+        getExportingBundles: admin, viewer
+        listPackages: admin, viewer
+        getImportingBundles: admin, viewer
+        isRemovalPending: admin, viewer
+      osgi.core.serviceState:
+        getProperty: admin, viewer
+        getProperties: admin, viewer
+        getService: admin, viewer
+        getBundleIdentifier: admin, viewer
+        getObjectClass: admin, viewer
+        listServices: admin, viewer
+        getUsingBundles: admin, viewer
+      osgi.core.wiringState:
+        getCurrentRevisionDeclaredCapabilities: admin, viewer
+        getCurrentWiringClosure: admin, viewer
+        getRevisionsDeclaredRequirements: admin, viewer
+        getRevisionsDeclaredCapabilities: admin, viewer
+        getRevisionsWiring: admin, viewer
+        getRevisionsWiringClosure: admin, viewer
+        getCurrentRevisionDeclaredRequirements: admin, viewer
+        getCurrentWiring: admin, viewer

--- a/deployment-cluster-rbac.yml
+++ b/deployment-cluster-rbac.yml
@@ -259,7 +259,7 @@ objects:
       # impersonating the request is granted for the pod hosting the operation being invoked.
       # A user that's granted the 'update' verb on the pod resource is bound to the 'admin' role.
       # Else, a user granted the 'get' verb on the pod resource is bound the 'viewer' role.
-      # Otherwise the use is not bound any roles.
+      # Otherwise the user is not bound any roles.
 
       # Default, generic rules, declared as an ordered map, so that the most specific keys
       # are tested first.

--- a/deployment-namespace-rbac.yml
+++ b/deployment-namespace-rbac.yml
@@ -132,7 +132,7 @@ objects:
               memory: 32Mi
             limits:
               cpu: 1.0
-              memory: 32Mi
+              memory: 64Mi
           volumeMounts:
           - name: hawtio-online
             mountPath: /usr/share/nginx/html/online/hawtconfig.json

--- a/deployment-namespace-rbac.yml
+++ b/deployment-namespace-rbac.yml
@@ -269,7 +269,7 @@ objects:
       # impersonating the request is granted for the pod hosting the operation being invoked.
       # A user that's granted the 'update' verb on the pod resource is bound to the 'admin' role.
       # Else, a user granted the 'get' verb on the pod resource is bound the 'viewer' role.
-      # Otherwise the use is not bound any roles.
+      # Otherwise the user is not bound any roles.
 
       # Default, generic rules, declared as an ordered map, so that the most specific keys
       # are tested first.

--- a/deployment-namespace-rbac.yml
+++ b/deployment-namespace-rbac.yml
@@ -1,0 +1,698 @@
+apiVersion: v1
+kind: Template
+metadata:
+  name: hawtio-online
+parameters:
+- name: ROUTE_HOSTNAME
+  description: The externally-reachable host name that routes to the Hawtio Online service
+- name: OPENSHIFT_WEB_CONSOLE_URL
+  description: The externally-reachable URL that routes to the OpenShift Web console
+message: |-
+  Hawtio Online is deployed.
+objects:
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: hawtio-online
+  data:
+    hawtconfig.json: |
+      {
+        "about": {
+          "title": "Hawtio OpenShift Console",
+          "productInfo": [],
+          "additionalInfo": "The Hawtio OpenShift Console eases the discovery and management of 'hawtio-enabled' applications deployed on OpenShift.",
+          "copyright": ""
+        },
+        "branding": {
+          "appName": "Hawtio OpenShift Console",
+          "appLogoUrl": "img/hawtio-logo.svg"
+        },
+        "disabledRoutes": []
+      }
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: hawtio-integration
+  data:
+    hawtconfig.json: |
+      {
+        "about": {
+          "title": "Hawtio Integration Console",
+          "productInfo": [],
+          "additionalInfo": "The Hawtio Integration Console enables introspecting Java applications.",
+          "copyright": ""
+        },
+        "branding": {
+          "appName": "Hawtio Integration Console",
+          "appLogoUrl": "img/hawtio-logo.svg"
+        },
+        "disabledRoutes": []
+      }
+- apiVersion: v1
+  kind: ImageStream
+  metadata:
+    name: hawtio-online
+    labels:
+      app: hawtio
+      component: online
+  spec:
+    tags:
+    - from:
+        kind: DockerImage
+        name: docker.io/hawtio/online:latest
+      importPolicy:
+        scheduled: true
+      name: latest
+- apiVersion: v1
+  kind: DeploymentConfig
+  metadata:
+    labels:
+      app: hawtio
+      component: online
+    name: hawtio-online
+  spec:
+    replicas: 1
+    selector:
+      app: hawtio
+      component: online
+      deploymentconfig: hawtio-online
+    strategy:
+      rollingParams:
+        intervalSeconds: 1
+        maxSurge: 25%
+        maxUnavailable: 25%
+        timeoutSeconds: 600
+        updatePeriodSeconds: 1
+      type: Rolling
+    template:
+      metadata:
+        labels:
+          app: hawtio
+          component: online
+          deploymentconfig: hawtio-online
+      spec:
+        containers:
+        - image: hawtio/online
+          imagePullPolicy: Always
+          name: hawtio-online
+          ports:
+          - name: nginx
+            containerPort: 8443
+          livenessProbe:
+            httpGet:
+              path: /online
+              port: nginx
+              scheme: HTTPS
+            periodSeconds: 10
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /online
+              port: nginx
+              scheme: HTTPS
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 1
+          env:
+          - name: HAWTIO_ONLINE_MODE
+            value: namespace
+          - name: HAWTIO_ONLINE_RBAC_ACL
+            value: /etc/hawtio/rbac/ACL.yaml
+          - name: HAWTIO_ONLINE_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: OPENSHIFT_WEB_CONSOLE_URL
+            value: ${OPENSHIFT_WEB_CONSOLE_URL}
+          - name: OPENSHIFT_CLUSTER_VERSION
+            value: '4'
+          resources:
+            requests:
+              cpu: 0.2
+              memory: 32Mi
+            limits:
+              cpu: 1.0
+              memory: 32Mi
+          volumeMounts:
+          - name: hawtio-online
+            mountPath: /usr/share/nginx/html/online/hawtconfig.json
+            subPath: hawtconfig.json
+          - name: hawtio-integration
+            mountPath: /usr/share/nginx/html/integration/hawtconfig.json
+            subPath: hawtconfig.json
+          - mountPath: /etc/hawtio/rbac
+            name: hawtio-rbac
+          - mountPath: /etc/tls/private/serving
+            name: hawtio-online-tls-serving
+          - mountPath: /etc/tls/private/proxying
+            name: hawtio-online-tls-proxying
+        volumes:
+        - name: hawtio-online
+          configMap:
+            name: hawtio-online
+        - name: hawtio-integration
+          configMap:
+            name: hawtio-online
+        - name: hawtio-rbac
+          configMap:
+            name: hawtio-rbac
+        - name: hawtio-online-tls-serving
+          secret:
+            secretName: hawtio-online-tls-serving
+        - name: hawtio-online-tls-proxying
+          secret:
+            secretName: hawtio-online-tls-proxying
+    triggers:
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - hawtio-online
+        from:
+          kind: ImageStreamTag
+          name: hawtio-online:latest
+      type: ImageChange
+    - type: ConfigChange
+- apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      app: hawtio
+      component: online
+    annotations:
+      service.beta.openshift.io/serving-cert-secret-name: hawtio-online-tls-serving
+    name: hawtio-online
+  spec:
+    ports:
+    - port: 443
+      protocol: TCP
+      targetPort: nginx
+    selector:
+      app: hawtio
+      component: online
+- apiVersion: v1
+  kind: Route
+  metadata:
+    labels:
+      app: hawtio
+      component: online
+    name: hawtio-online
+  spec:
+    host: ${ROUTE_HOSTNAME}
+    to:
+      kind: Service
+      name: hawtio-online
+    tls:
+      insecureEdgeTerminationPolicy: Redirect
+      termination: reencrypt
+- apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    name: hawtio-online
+    labels:
+      app: hawtio-online
+    annotations:
+      # All HTTPS ingresses for the Hawtio Online route
+      serviceaccounts.openshift.io/oauth-redirecturi.route: https://
+      serviceaccounts.openshift.io/oauth-redirectreference.route: '{"kind": "OAuthRedirectReference", "apiVersion": "v1", "reference": {"kind": "Route", "name": "hawtio-online"}}'
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: hawtio-rbac
+  data:
+    ACL.yaml: |
+      # This file defines the roles allowed for MBean operations
+      #
+      # The definition of ACLs for JMX operations works as follows:
+      #
+      # Based on the ObjectName of the JMX MBean, a key composed with the ObjectName
+      # domain, followed by the 'type' attribute optionally, can be declared, using the
+      # convention <domain>.<type>.
+      # For example, the 'java.lang.Threading' key for the MBean with the following
+      # objectName: java.lang:type=Threading can be declared. A more generic key with
+      # the domain only can be declared (e.g. java.lang). A 'default' top-level key can
+      # also be declared.
+      # A key can either be an unordered or ordered map, whose keys can either be
+      # string or regexp, and whose values can either be string or array of strings,
+      # that represent roles that are allowed to invoke the MBean member.
+      #
+      # The system looks for allowed roles using the following process:
+      #
+      # The most specific key is tried first. E.g. for the
+      # above example, the java.lang.Threading key is looked up first.
+      # If the most specific key does not exist, the domain-only key is looked up,
+      # otherwise, the 'default' key is looked up.
+      # Using the matching key, the system looks up its map value for:
+      #   1. An exact match for the operation invocation, using the operation
+      #      signature, and the invocation arguments, e.g.:
+      #      uninstall(java.lang.String)[0]: [] # no roles can perform this operation
+      #   2. A regexp match for the operation invocation, using the operation
+      #      signature, and the invocation arguments, e.g.:
+      #      /update\(java\.lang\.String,java\.lang\.String\)\[[1-4]?[0-9],.*\]/: admin
+      #      Note that, if the value is an ordered map, the iteration order is guaranteed,
+      #      and the first matching regexp key is selected;
+      #   3. An exact match for the operation invocation, using the operation
+      #      signature, without the invocation arguments, e.g.:
+      #      delete(java.lang.String): admin
+      #   4. An exact match for the operation invocation, using the operation
+      #      name, e.g.:
+      #      dumpStatsAsXml: admin, viewer
+      # If the key matches the operation invocation, it is used and the process will not
+      # look for any other keys. So the most specific key always takes precedence.
+      # Its value is used to match the role that impersonates the request, against the roles
+      # that are allowed to invoke the operation.
+      # If the current key does not match, the less specific key is looked up
+      # and matched following the steps 1 to 4 above, up until the 'default' key.
+      # Otherwise, the operation invocation is denied.
+      #
+      # For the time being, only the viewer and admin roles are supported. Once the current
+      # invocation is authenticated, these roles are inferred from the permissions the user
+      # impersonating the request is granted for the pod hosting the operation being invoked.
+      # A user that's granted the 'update' verb on the pod resource is bound to the 'admin' role.
+      # Else, a user granted the 'get' verb on the pod resource is bound the 'viewer' role.
+      # Otherwise the use is not bound any roles.
+
+      # Default, generic rules, declared as an ordered map, so that the most specific keys
+      # are tested first.
+      default:
+        - list: admin, viewer
+        - read: admin, viewer
+        - search: admin, viewer
+        - /list.*/: admin, viewer
+        - /get.*/: admin, viewer
+        - /is.*/: admin, viewer
+        - /set.*/: admin
+        - /.*/: admin
+
+      com.sun.management:
+        dumpHeap: admin, viewer
+        getVMOption: admin, viewer
+        setVMOption: admin
+
+      connector:
+        stop: admin
+        start: admin
+
+      hawtio.plugin:
+        /.*/: /.*/
+      hawtio.ConfigAdmin:
+        configAdminUpdate: admin
+      hawtio.OSGiTools:
+        getResourceURL: admin, viewer
+        getLoadClassOrigin: admin, viewer
+      hawtio.QuartzFacade:
+        updateSimpleTrigger: admin
+        updateCronTrigger: admin
+      hawtio.SchemaLookup:
+        getSchemaForClass: admin, viewer
+      hawtio.security:
+        canInvoke: admin, viewer
+
+      java.lang.Memory:
+        gc: admin
+      java.lang.MemoryPool:
+        resetPeakUsage: admin
+      java.lang.Threading:
+        /find.*/: admin, viewer
+        dumpAllThreads: admin, viewer
+        resetPeakThreadCount: admin
+      java.util.logging:
+        getLoggerLevel: admin, viewer
+        getParentLoggerName: admin, viewer
+        setLoggerLevel: admin
+
+      jolokia.Config.hawtio:
+        /is.*/: admin, viewer
+        /get.*/: admin, viewer
+        /set.*/: admin
+        debugInfo: admin, viewer
+        setHistoryEntriesForAttribute: admin
+        setHistoryEntriesForOperation: admin
+        setHistoryLimitForOperation: admin
+        resetHistoryEntries: admin
+        resetDebugInfo: admin
+        setHistoryLimitForAttribute: admin
+      jolokia.Discovery:
+        lookupAgents: admin, viewer
+        lookupAgentsWithTimeout: admin, viewer
+      jolokia.ServerHandler.hawtio: 
+        mBeanServersInfo: admin, viewer
+
+      org.apache.aries.blueprint.blueprintMetadata:
+        /get.*/: admin, viewer
+      org.apache.aries.blueprint.blueprintState:
+        /get.*/: admin, viewer
+
+      org.apache.camel:
+        /.*/: /.*/
+      org.apache.camel.components:
+        getState: admin, viewer
+        getComponentName: admin, viewer
+        getCamelId: admin, viewer
+      org.apache.camel.consumers:
+        isSuspended: admin, viewer
+        getState: admin, viewer
+        getServiceType: admin, viewer
+        isSupportSuspension: admin, viewer
+        isStaticService: admin, viewer
+        getCamelId: admin, viewer
+        getRouteId: admin, viewer
+        getInflightExchanges: admin, viewer
+        getEndpointUri: admin, viewer
+        stop: admin
+        start: admin
+        suspend: admin
+        resume: admin
+      org.apache.camel.context:
+        getResetTimestamp: admin, viewer
+        getExchangesTotal: admin, viewer
+        getTotalProcessingTime: admin, viewer
+        isStatisticsEnabled: admin, viewer
+        setStatisticsEnabled: admin
+        getExchangesCompleted: admin, viewer
+        getExchangesFailed: admin, viewer
+        getFailuresHandled: admin, viewer
+        getRedeliveries: admin, viewer
+        getExternalRedeliveries: admin, viewer
+        getMinProcessingTime: admin, viewer
+        getMeanProcessingTime: admin, viewer
+        getMaxProcessingTime: admin, viewer
+        getLastProcessingTime: admin, viewer
+        getDeltaProcessingTime: admin, viewer
+        getLastExchangeCompletedTimestamp: admin, viewer
+        getLastExchangeCompletedExchangeId: admin, viewer
+        getFirstExchangeCompletedTimestamp: admin, viewer
+        getFirstExchangeCompletedExchangeId: admin, viewer
+        getLastExchangeFailureTimestamp: admin, viewer
+        getLastExchangeFailureExchangeId: admin, viewer
+        getFirstExchangeFailureTimestamp: admin, viewer
+        getFirstExchangeFailureExchangeId: admin, viewer
+        getCamelId: admin, viewer
+        getTimeout: admin, viewer
+        setTimeout: admin
+        getProperties: admin, viewer
+        getState: admin, viewer
+        getUptime: admin, viewer
+        getInflightExchanges: admin, viewer
+        getTracing: admin, viewer
+        setTracing: admin
+        getLoad01: admin, viewer
+        getLoad05: admin, viewer
+        getLoad15: admin, viewer
+        getCamelVersion: admin, viewer
+        getApplicationContextClassName: admin, viewer
+        getTotalRoutes: admin, viewer
+        getStartedRoutes: admin, viewer
+        isMessageHistory: admin, viewer
+        getTimeUnit: admin, viewer
+        setTimeUnit: admin
+        getClassResolver: admin, viewer
+        getManagementName: admin, viewer
+        getPackageScanClassResolver: admin, viewer
+        isUseMDCLogging: admin, viewer
+        isAllowUseOriginalMessage: admin, viewer
+        isUseBreadcrumb: admin, viewer
+        isShutdownNowOnTimeout: admin, viewer
+        setShutdownNowOnTimeout: admin
+        reset: admin
+        dumpStatsAsXml: admin, viewer
+        setProperty: admin
+        getProperty: admin, viewer
+        createEndpoint: admin
+        restart: admin
+        stop: admin
+        start: admin
+        suspend: admin
+        resume: admin
+        sendStringBody: admin
+        requestStringBody: admin
+        dumpRoutesAsXml: admin, viewer
+        addOrUpdateRoutesFromXml: admin
+        findComponentNames: admin, viewer
+        dumpRoutesStatsAsXml: admin, viewer
+        componentParameterJsonSchema: admin, viewer
+        sendBody: admin
+        sendBodyAndHeaders: admin
+        requestBody: admin
+        requestBodyAndHeaders: admin
+        findComponents: admin, viewer
+        getComponentDocumentation: admin, viewer
+        removeEndpoints:  admin
+        completeEndpointPath: admin, viewer
+      org.apache.camel.endpoints:
+        /is.*/: admin, viewer
+        /get.*/: admin, viewer
+        /set.*/: admin
+      org.apache.camel.errorhandlers:
+        /is.*/: admin, viewer
+        /get.*/: admin, viewer
+        /set.*/: admin
+      org.apache.camel.eventnotifiers:
+        /set.*/: admin
+      org.apache.camel.processors:
+        dumpStatsAsXml: admin, viewer
+        /get.*/: admin, viewer
+        /is.*/: admin, viewer
+        /set.*/: admin
+        reset: admin
+        stop: admin
+        start: admin
+      org.apache.camel.routes:
+        /is.*/: admin, viewer
+        /get.*/: admin, viewer
+        /set.*/: admin
+        reset: admin
+        /dump.*/: admin, viewer
+        remove: admin
+        shutdown: admin
+        stop: admin
+        start: admin
+        suspend: admin
+        resume: admin
+        updateRouteFromXml: admin
+      org.apache.camel.services:
+        /is.*/: admin, viewer
+        /get.*/: admin, viewer
+        /set.*/: admin
+        stop: admin
+        start: admin
+        suspend: admin
+        resume: admin
+        purge: admin
+        hasTypeConverter: admin, viewer
+        resetTypeConversionCounters: admin
+        listTypeConverters: admin, viewer
+      org.apache.camel.threadpools:
+        /is.*/: admin, viewer
+        /get.*/: admin, viewer
+        /set.*/: admin
+        purge: admin
+      org.apache.camel.tracer:
+        /is.*/: admin, viewer
+        /get.*/: admin, viewer
+        /set.*/: admin
+        step: admin, viewer
+        enableDebugger: admin
+        disableDebugger: admin
+        /.*Breakpoint.*/: admin, viewer
+        resumeAll: admin, viewer
+        resetDebugCounter: admin
+        /dump.*/: admin, viewer
+        clear: admin
+        resetTraceCounter: admin
+
+      org.apache.cxf.Bus:
+        shutdown: admin
+      org.apache.cxf.Bus.Service.Endpoint:
+        destroy: admin
+        start: admin
+        stop: admin
+        getState: admin, viewer
+        getTransportId: admin, viewer
+        getAddress: admin, viewer
+      org.apache.cxf.WorkQueueManager:
+        shutdown: admin
+
+      org.apache.karaf.bundle:
+        capabilities: admin, viewer
+        diag: admin, viewer
+        getStartLevel: admin, viewer
+        install: admin
+        refresh: admin
+        resolve: admin
+        restart: admin
+        status: admin, viewer
+        /setStartLevel\(java\.lang\.String,int\)\[[1-4]?[0-9],.*\]/: admin
+        setStartLevel: admin
+        /start\(java\.lang\.String\)\[[1-4]?[0-9]\]/: admin
+        start: admin
+        /stop\(java\.lang\.String\)\[[1-4]?[0-9]\]/: admin
+        stop: admin
+        uninstall(java.lang.String)[0]: [] # no roles can perform this operation
+        uninstall: admin
+        /update\(java\.lang\.String\)\[[1-4]?[0-9]\]/: admin
+        /update\(java\.lang\.String,java\.lang\.String\)\[[1-4]?[0-9],.*\]/: admin
+        update: admin
+      org.apache.karaf.config:
+        listProperties: admin, viewer
+        /appendProperty\(java\.lang\.String,java\.lang\.String,java\.lang\.String\)\[jmx\.acl\..*,.*,.*\]/: admin
+        /appendProperty\(java\.lang\.String,java\.lang\.String,java\.lang\.String\)\[org\.apache\.karaf\.command\.acl\..+,.*,.*\]/: admin
+        /appendProperty\(java\.lang\.String,java\.lang\.String,java\.lang\.String\)\[org\.apache\.karaf\.service\.acl\..+,.*,.*\]/: admin
+        appendProperty(java.lang.String,java.lang.String,java.lang.String): admin
+        /create\(java\.lang\.String\)\[jmx\.acl\..*\]/: admin
+        /create\(java\.lang\.String\)\[org\.apache\.karaf\.command\.acl\..+\]/: admin
+        /create\(java\.lang\.String\)\[org\.apache\.karaf\.service\.acl\..+\]/: admin
+        create(java.lang.String): admin
+        /delete\(java\.lang\.String\)\[jmx\.acl\..*\]/: admin
+        /delete\(java\.lang\.String\)\[org\.apache\.karaf\.command\.acl\..+\]/: admin
+        /delete\(java\.lang\.String\)\[org\.apache\.karaf\.service\.acl\..+\]/: admin
+        delete(java.lang.String): admin
+        /deleteProperty\(java\.lang\.String,java\.lang\.String\)\[jmx\.acl\..*,.*\]/: admin
+        /deleteProperty\(java\.lang\.String,java\.lang\.String\)\[org\.apache\.karaf\.command\.acl\..+,.*\]/: admin
+        /deleteProperty\(java\.lang\.String,java\.lang\.String\)\[org\.apache\.karaf\.service\.acl\..+,.*\]/: admin
+        deleteProperty(java.lang.String,java.lang.String): admin
+        /setProperty\(java\.lang\.String,java\.lang\.String,java\.lang\.String\)\[jmx\.acl\..*,.*,.*\]/: admin
+        /setProperty\(java\.lang\.String,java\.lang\.String,java\.lang\.String\)\[org\.apache\.karaf\.command\.acl\..+,.*,.*\]/: admin
+        /setProperty\(java\.lang\.String,java\.lang\.String,java\.lang\.String\)\[org\.apache\.karaf\.service\.acl\..+,.*,.*\]/: admin
+        setProperty(java.lang.String,java.lang.String,java.lang.String): admin
+        /update\(java\.lang\.String,java\.util\.Map\)\[jmx\.acl\..*,.*\]/: admin
+        /update\(java\.lang\.String,java\.util\.Map\)\[org\.apache\.karaf\.command\.acl\..+,.*\]/: admin
+        /update\(java\.lang\.String,java\.util\.Map\)\[org\.apache\.karaf\.service\.acl\..+,.*\]/: admin
+        update(java.lang.String,java.util.Map): admin
+      org.apache.karaf.diagnostic:
+        createDump: admin, viewer
+      org.apache.karaf.feature:
+        infoFeature: admin, viewer
+        removeRepository: admin
+        addRepository: admin
+        uninstallFeature: admin
+        installFeature: admin
+        refreshRepository: admin
+      org.apache.karaf.instance:
+        createInstance: admin
+        destroyInstance: admin
+        startInstance: admin
+        stopInstance: admin
+        cloneInstance: admin
+        renameInstance: admin
+        changeSshPort: admin
+        changeSshHost: admin
+        ChangeRmiRegistryPort: admin
+        changeRmiServerPort: admin
+        changeJavaOpts: admin
+      org.apache.karaf.log:
+        getLevel: admin, viewer
+        setLevel: admin
+      org.apache.karaf.package:
+        getImports: admin, viewer
+        getExports: admin, viewer
+      org.apache.karaf.service:
+        getServices: admin, viewer
+      org.apache.karaf.system:
+        setProperty: admin
+        /getPropert.*/: admin, viewer
+        halt: admin
+        reboot: admin
+        rebootCleanCache: admin
+        rebootCleanAll: admin
+
+      osgi.compendium.cm:
+        /createFactoryConfiguration\(java\.lang\.String\)\[jmx\.acl\..*\]/: admin
+        /createFactoryConfiguration\(java\.lang\.String\)\[org\.apache\.karaf\.command\.acl\.\..+\]/: admin
+        /createFactoryConfiguration\(java\.lang\.String\)\[org\.apache\.karaf\.service\.acl\.\..+\]/: admin
+        createFactoryConfiguration(java.lang.String): admin
+        /createFactoryConfigurationForLocation\(java\.lang\.String,java\.lang\.String\)\[jmx\.acl\..*,.*\]/: admin
+        /createFactoryConfigurationForLocation\(java\.lang\.String,java\.lang\.String\)\[org\.apache\.karaf\.command\.acl\..+,.*\]/: admin
+        /createFactoryConfigurationForLocation\(java\.lang\.String,java\.lang\.String\)\[org\.apache\.karaf\.service\.acl\..+,.*\]/: admin
+        createFactoryConfigurationForLocation(java.lang.String,java.lang.String): admin
+        /delete\(java\.lang\.String\)\[jmx\.acl\..*\]/: admin
+        /delete\(java\.lang\.String\)\[org\.apache\.karaf\.command\.acl\..+\]/: admin
+        /delete\(java\.lang\.String\)\[org\.apache\.karaf\.service\.acl\..+\]/: admin
+        delete(java.lang.String): admin
+        deleteConfigurations: admin
+        /deleteForLocation\(java\.lang\.String,java\.lang\.String\)\[jmx\.acl\..*,.*\]/: admin
+        /deleteForLocation\(java\.lang\.String,java\.lang\.String\)\[org\.apache\.karaf\.command\.acl\..+,.*\]/: admin
+        /deleteForLocation\(java\.lang\.String,java\.lang\.String\)\[org\.apache\.karaf\.service\.acl\..+,.*\]/: admin
+        deleteForLocation(java.lang.String,java.lang.String): admin
+        /update\(java\.lang\.String,javax\.management\.openmbean\.TabularData\)\[jmx\.acl\..*,.*\]/: admin
+        /update\(java\.lang\.String,javax\.management\.openmbean\.TabularData\)\[org\.apache\.karaf\.command\.acl\..+,.*\]/: admin
+        /update\(java\.lang\.String,javax\.management\.openmbean\.TabularData\)\[org\.apache\.karaf\.service\.acl\..+,.*\]/: admin
+        update(java.lang.String,javax.management.openmbean.TabularData): admin
+        /updateForLocation\(java\.lang\.String,java\.lang\.String,javax\.management\.openmbean\.TabularData\)\[jmx\.acl\..*,.*,.*\]/: admin
+        /updateForLocation\(java\.lang\.String,java\.lang\.String,javax\.management\.openmbean\.TabularData\)\[org\.apache\.karaf\.command\.acl\..+,.*,.*\]/: admin
+        /updateForLocation\(java\.lang\.String,java\.lang\.String,javax\.management\.openmbean\.TabularData\)\[org\.apache\.karaf\.service\.acl\..+,.*,.*\]/: admin
+        updateForLocation(java.lang.String,java.lang.String,javax.management.openmbean.TabularData): admin
+      osgi.core.bundleState:
+        getRequiredBundles: admin, viewer
+        getHosts: admin, viewer
+        getLocation: admin, viewer
+        getState: admin, viewer
+        getBundle: admin, viewer
+        getVersion: admin, viewer
+        getSymbolicName: admin, viewer
+        getRegisteredServices: admin, viewer
+        getServicesInUse: admin, viewer
+        getFragments: admin, viewer
+        getLastModified: admin, viewer
+        getHeaders: admin, viewer
+        getHeader: admin, viewer
+        getStartLevel: admin, viewer
+        getExportedPackages: admin, viewer
+        getRequiringBundles: admin, viewer
+        isFragment: admin, viewer
+        isRemovalPending: admin, viewer
+        isPersistentlyStarted: admin, viewer
+        isActivationPolicyUsed: admin, viewer
+        getImportedPackages: admin, viewer
+        isRequired: admin, viewer
+        listBundles: admin, viewer
+      osgi.core.framework:
+        startBundles: admin
+        getProperty: admin, viewer
+        resolve: admin
+        installBundle: admin
+        setBundleStartLevel: admin
+        startBundle: admin
+        updateBundle: admin
+        stopBundle: admin
+        stopBundle(long)[0]: [] # no roles can perform this operation
+        uninstallBundle: admin
+        resolveBundles: admin
+        getDependencyClosure: admin, viewer
+        refreshBundle: admin
+        refreshBundles: admin
+        installBundleFromURL: admin
+        installBundles: admin
+        installBundlesFromURL: admin
+        refreshBundleAndWait: admin
+        refreshBundlesAndWait: admin
+        resolveBundle: admin
+        restartFramework: admin
+        setBundleStartLevels: admin
+        shutdownFramework: admin
+        stopBundles: admin
+        uninstallBundles: admin
+        updateBundleFromURL: admin
+        updateBundles: admin
+        updateBundlesFromURL: admin
+      osgi.core.packageState:
+        getExportingBundles: admin, viewer
+        listPackages: admin, viewer
+        getImportingBundles: admin, viewer
+        isRemovalPending: admin, viewer
+      osgi.core.serviceState:
+        getProperty: admin, viewer
+        getProperties: admin, viewer
+        getService: admin, viewer
+        getBundleIdentifier: admin, viewer
+        getObjectClass: admin, viewer
+        listServices: admin, viewer
+        getUsingBundles: admin, viewer
+      osgi.core.wiringState:
+        getCurrentRevisionDeclaredCapabilities: admin, viewer
+        getCurrentWiringClosure: admin, viewer
+        getRevisionsDeclaredRequirements: admin, viewer
+        getRevisionsDeclaredCapabilities: admin, viewer
+        getRevisionsWiring: admin, viewer
+        getRevisionsWiringClosure: admin, viewer
+        getCurrentRevisionDeclaredRequirements: admin, viewer
+        getCurrentWiring: admin, viewer

--- a/docker/.dockerignore
+++ b/docker/.dockerignore
@@ -1,10 +1,13 @@
 *
+!ACL.yaml
 !branding
+!js-yaml.js
 !licenses
-!site
 !osconsole/config.sh
 !nginx.conf
 !nginx-gateway.conf
 !nginx.repo
 !nginx.js
 !nginx.sh
+!rbac.js
+!site

--- a/docker/ACL.yaml
+++ b/docker/ACL.yaml
@@ -1,6 +1,8 @@
 # TODO: complete and document
 
 default:
+  - list: admin, viewer
+  - read: admin, viewer
   - search: admin, viewer
   - /list.*/: admin, viewer
   - /get.*/: admin, viewer

--- a/docker/ACL.yaml
+++ b/docker/ACL.yaml
@@ -243,42 +243,42 @@ org.apache.karaf.bundle:
   resolve: admin
   restart: admin
   status: admin, viewer
-  setStartLevel(java.lang.String,int)[/([1-4])?[0-9]/,/.*/]: admin
+  /setStartLevel\(java\.lang\.String,int\)\[[1-4]?[0-9],.*\]/: admin
   setStartLevel: admin
-  start(java.lang.String)[/([1-4])?[0-9]/]: admin
+  /start\(java\.lang\.String\)\[[1-4]?[0-9]\]/: admin
   start: admin
-  stop(java.lang.String)[/([1-4])?[0-9]/]: admin
+  /stop\(java\.lang\.String\)\[[1-4]?[0-9]\]/: admin
   stop: admin
-  uninstall(java.lang.String)["0"]: #this is a comment, no roles can perform this operation
+  uninstall(java.lang.String)[0]: [] # no roles can perform this operation
   uninstall: admin
-  update(java.lang.String)[/([1-4])?[0-9]/]: admin
-  update(java.lang.String,java.lang.String)[/([1-4])?[0-9]/,/.*/]: admin
+  /update\(java\.lang\.String\)\[[1-4]?[0-9]\]/: admin
+  /update\(java\.lang\.String,java\.lang\.String\)\[[1-4]?[0-9],.*\]/: admin
   update: admin
 org.apache.karaf.config:
   listProperties: admin, viewer
-  appendProperty(java.lang.String,java.lang.String,java.lang.String)[/jmx[.]acl.*/,/.*/,/.*/]: admin
-  appendProperty(java.lang.String,java.lang.String,java.lang.String)[/org[.]apache[.]karaf[.]command[.]acl.+/,/.*/,/.*/]: admin
-  appendProperty(java.lang.String,java.lang.String,java.lang.String)[/org[.]apache[.]karaf[.]service[.]acl.+/,/.*/,/.*/]: admin
+  /appendProperty\(java\.lang\.String,java\.lang\.String,java\.lang\.String\)\[jmx\.acl\..*,.*,.*\]/: admin
+  /appendProperty\(java\.lang\.String,java\.lang\.String,java\.lang\.String\)\[org\.apache\.karaf\.command\.acl\..+,.*,.*\]/: admin
+  /appendProperty\(java\.lang\.String,java\.lang\.String,java\.lang\.String\)\[org\.apache\.karaf\.service\.acl\..+,.*,.*\]/: admin
   appendProperty(java.lang.String,java.lang.String,java.lang.String): admin
-  create(java.lang.String)[/jmx[.]acl.*/]: admin
-  create(java.lang.String)[/org[.]apache[.]karaf[.]command[.]acl.+/]: admin
-  create(java.lang.String)[/org[.]apache[.]karaf[.]service[.]acl.+/]: admin
+  /create\(java\.lang\.String\)\[jmx\.acl\..*\]/: admin
+  /create\(java\.lang\.String\)\[org\.apache\.karaf\.command\.acl\..+\]/: admin
+  /create\(java\.lang\.String\)\[org\.apache\.karaf\.service\.acl\..+\]/: admin
   create(java.lang.String): admin
-  delete(java.lang.String)[/jmx[.]acl.*/]: admin
-  delete(java.lang.String)[/org[.]apache[.]karaf[.]command[.]acl.+/]: admin
-  delete(java.lang.String)[/org[.]apache[.]karaf[.]service[.]acl.+/]: admin
+  /delete\(java\.lang\.String\)\[jmx\.acl\..*\]/: admin
+  /delete\(java\.lang\.String\)\[org\.apache\.karaf\.command\.acl\..+\]/: admin
+  /delete\(java\.lang\.String\)\[org\.apache\.karaf\.service\.acl\..+\]/: admin
   delete(java.lang.String): admin
-  deleteProperty(java.lang.String,java.lang.String)[/jmx[.]acl.*/,/.*/]: admin
-  deleteProperty(java.lang.String,java.lang.String)[/org[.]apache[.]karaf[.]command[.]acl.+/,/.*/]: admin
-  deleteProperty(java.lang.String,java.lang.String)[/org[.]apache[.]karaf[.]service[.]acl.+/,/.*/]: admin
+  /deleteProperty\(java\.lang\.String,java\.lang\.String\)\[jmx\.acl\..*,.*\]/: admin
+  /deleteProperty\(java\.lang\.String,java\.lang\.String\)\[org\.apache\.karaf\.command\.acl\..+,.*\]/: admin
+  /deleteProperty\(java\.lang\.String,java\.lang\.String\)\[org\.apache\.karaf\.service\.acl\..+,.*\]/: admin
   deleteProperty(java.lang.String,java.lang.String): admin
-  setProperty(java.lang.String,java.lang.String,java.lang.String)[/jmx[.]acl.*/,/.*/,/.*/]: admin
-  setProperty(java.lang.String,java.lang.String,java.lang.String)[/org[.]apache[.]karaf[.]command[.]acl.+/,/.*/,/.*/]: admin
-  setProperty(java.lang.String,java.lang.String,java.lang.String)[/org[.]apache[.]karaf[.]service[.]acl.+/,/.*/,/.*/]: admin
+  /setProperty\(java\.lang\.String,java\.lang\.String,java\.lang\.String\)\[jmx\.acl\..*,.*,.*\]/: admin
+  /setProperty\(java\.lang\.String,java\.lang\.String,java\.lang\.String\)\[org\.apache\.karaf\.command\.acl\..+,.*,.*\]/: admin
+  /setProperty\(java\.lang\.String,java\.lang\.String,java\.lang\.String\)\[org\.apache\.karaf\.service\.acl\..+,.*,.*\]/: admin
   setProperty(java.lang.String,java.lang.String,java.lang.String): admin
-  update(java.lang.String,java.util.Map)[/jmx[.]acl.*/,/.*/]: admin
-  update(java.lang.String,java.util.Map)[/org[.]apache[.]karaf[.]command[.]acl.+/,/.*/]: admin
-  update(java.lang.String,java.util.Map)[/org[.]apache[.]karaf[.]service[.]acl.+/,/.*/]: admin
+  /update\(java\.lang\.String,java\.util\.Map\)\[jmx\.acl\..*,.*\]/: admin
+  /update\(java\.lang\.String,java\.util\.Map\)\[org\.apache\.karaf\.command\.acl\..+,.*\]/: admin
+  /update\(java\.lang\.String,java\.util\.Map\)\[org\.apache\.karaf\.service\.acl\..+,.*\]/: admin
   update(java.lang.String,java.util.Map): admin
 org.apache.karaf.diagnostic:
   createDump: admin, viewer
@@ -320,30 +320,30 @@ org.apache.karaf.system:
   rebootCleanAll: admin
 
 osgi.compendium.cm:
-  createFactoryConfiguration(java.lang.String)[/jmx[.]acl.*/]: admin
-  createFactoryConfiguration(java.lang.String)[/org[.]apache[.]karaf[.]command[.]acl[.].+/]: admin
-  createFactoryConfiguration(java.lang.String)[/org[.]apache[.]karaf[.]service[.]acl[.].+/]: admin
+  /createFactoryConfiguration\(java\.lang\.String\)\[jmx\.acl\..*\]/: admin
+  /createFactoryConfiguration\(java\.lang\.String\)\[org\.apache\.karaf\.command\.acl\.\..+\]/: admin
+  /createFactoryConfiguration\(java\.lang\.String\)\[org\.apache\.karaf\.service\.acl\.\..+\]/: admin
   createFactoryConfiguration(java.lang.String): admin
-  createFactoryConfigurationForLocation(java.lang.String,java.lang.String)[/jmx[.]acl.*/,/.*/]: admin
-  createFactoryConfigurationForLocation(java.lang.String,java.lang.String)[/org[.]apache[.]karaf[.]command[.]acl[.].+/,/.*/]: admin
-  createFactoryConfigurationForLocation(java.lang.String,java.lang.String)[/org[.]apache[.]karaf[.]service[.]acl[.].+/,/.*/]: admin
+  /createFactoryConfigurationForLocation\(java\.lang\.String,java\.lang\.String\)\[jmx\.acl\..*,.*\]/: admin
+  /createFactoryConfigurationForLocation\(java\.lang\.String,java\.lang\.String\)\[org\.apache\.karaf\.command\.acl\..+,.*\]/: admin
+  /createFactoryConfigurationForLocation\(java\.lang\.String,java\.lang\.String\)\[org\.apache\.karaf\.service\.acl\..+,.*\]/: admin
   createFactoryConfigurationForLocation(java.lang.String,java.lang.String): admin
-  delete(java.lang.String)[/jmx[.]acl.*/]: admin
-  delete(java.lang.String)[/org[.]apache[.]karaf[.]command[.]acl[.].+/]: admin
-  delete(java.lang.String)[/org[.]apache[.]karaf[.]service[.]acl[.].+/]: admin
+  /delete\(java\.lang\.String\)\[jmx\.acl\..*\]/: admin
+  /delete\(java\.lang\.String\)\[org\.apache\.karaf\.command\.acl\..+\]/: admin
+  /delete\(java\.lang\.String\)\[org\.apache\.karaf\.service\.acl\..+\]/: admin
   delete(java.lang.String): admin
   deleteConfigurations: admin
-  deleteForLocation(java.lang.String,java.lang.String)[/jmx[.]acl.*/,/.*/]: admin
-  deleteForLocation(java.lang.String,java.lang.String)[/org[.]apache[.]karaf[.]command[.]acl[.].+/,/.*/]: admin
-  deleteForLocation(java.lang.String,java.lang.String)[/org[.]apache[.]karaf[.]service[.]acl[.].+/,/.*/]: admin
+  /deleteForLocation\(java\.lang\.String,java\.lang\.String\)\[jmx\.acl\..*,.*\]/: admin
+  /deleteForLocation\(java\.lang\.String,java\.lang\.String\)\[org\.apache\.karaf\.command\.acl\..+,.*\]/: admin
+  /deleteForLocation\(java\.lang\.String,java\.lang\.String\)\[org\.apache\.karaf\.service\.acl\..+,.*\]/: admin
   deleteForLocation(java.lang.String,java.lang.String): admin
-  update(java.lang.String,javax.management.openmbean.TabularData)[/jmx[.]acl.*/,/.*/]: admin
-  update(java.lang.String,javax.management.openmbean.TabularData)[/org[.]apache[.]karaf[.]command[.]acl[.].+/,/.*/]: admin
-  update(java.lang.String,javax.management.openmbean.TabularData)[/org[.]apache[.]karaf[.]service[.]acl[.].+/,/.*/]: admin
+  /update\(java\.lang\.String,javax\.management\.openmbean\.TabularData\)\[jmx\.acl\..*,.*\]/: admin
+  /update\(java\.lang\.String,javax\.management\.openmbean\.TabularData\)\[org\.apache\.karaf\.command\.acl\..+,.*\]/: admin
+  /update\(java\.lang\.String,javax\.management\.openmbean\.TabularData\)\[org\.apache\.karaf\.service\.acl\..+,.*\]/: admin
   update(java.lang.String,javax.management.openmbean.TabularData): admin
-  updateForLocation(java.lang.String,java.lang.String,javax.management.openmbean.TabularData)[/jmx[.]acl.*/,/.*/,/.*/]: admin
-  updateForLocation(java.lang.String,java.lang.String,javax.management.openmbean.TabularData)[/org[.]apache[.]karaf[.]command[.]acl[.].+/,/.*/,/.*/]: admin
-  updateForLocation(java.lang.String,java.lang.String,javax.management.openmbean.TabularData)[/org[.]apache[.]karaf[.]service[.]acl[.].+/,/.*/,/.*/]: admin
+  /updateForLocation\(java\.lang\.String,java\.lang\.String,javax\.management\.openmbean\.TabularData\)\[jmx\.acl\..*,.*,.*\]/: admin
+  /updateForLocation\(java\.lang\.String,java\.lang\.String,javax\.management\.openmbean\.TabularData\)\[org\.apache\.karaf\.command\.acl\..+,.*,.*\]/: admin
+  /updateForLocation\(java\.lang\.String,java\.lang\.String,javax\.management\.openmbean\.TabularData\)\[org\.apache\.karaf\.service\.acl\..+,.*,.*\]/: admin
   updateForLocation(java.lang.String,java.lang.String,javax.management.openmbean.TabularData): admin
 osgi.core.bundleState:
   getRequiredBundles: admin, viewer
@@ -378,7 +378,7 @@ osgi.core.framework:
   startBundle: admin
   updateBundle: admin
   stopBundle: admin
-  stopBundle(long)["0"]: #this is a comment, no roles can perform this operation
+  stopBundle(long)[0]: [] # no roles can perform this operation
   uninstallBundle: admin
   resolveBundles: admin
   getDependencyClosure: admin, viewer

--- a/docker/ACL.yaml
+++ b/docker/ACL.yaml
@@ -1,6 +1,7 @@
 # TODO: complete and document
 
 default:
+  - search: admin, viewer
   - /list.*/: admin, viewer
   - /get.*/: admin, viewer
   - /is.*/: admin, viewer

--- a/docker/ACL.yaml
+++ b/docker/ACL.yaml
@@ -1,15 +1,15 @@
 # TODO: complete and document
 
 default:
-  - /list.*/: [admin, viewer]
-  - /get.*/: [admin, viewer]
-  - /is.*/: [admin, viewer]
+  - /list.*/: admin, viewer
+  - /get.*/: admin, viewer
+  - /is.*/: admin, viewer
   - /set.*/: admin
   - /.*/: admin
 
 com.sun.management:
-  dumpHeap: [admin, viewer]
-  getVMOption: [admin, viewer]
+  dumpHeap: admin, viewer
+  getVMOption: admin, viewer
   setVMOption: admin
 
 java.lang.Memory:
@@ -17,12 +17,12 @@ java.lang.Memory:
 java.lang.MemoryPool:
   resetPeakUsage: admin
 java.lang.Threading:
-  /find.*/: [admin, viewer]
-  dumpAllThreads: [admin, viewer]
+  /find.*/: admin, viewer
+  dumpAllThreads: admin, viewer
   resetPeakThreadCount: admin
 
 org.apache.camel:
   /.*/: /.*/
 
 org.apache.camel.context:
-  dumpRoutesAsXml: [admin, viewer]
+  dumpRoutesAsXml: admin, viewer

--- a/docker/ACL.yaml
+++ b/docker/ACL.yaml
@@ -1,4 +1,46 @@
-# TODO: complete and document
+# This file defines the roles allowed for MBean operations
+#
+# The definition of ACLs for JMX operations works as follows:
+#
+# Based on the ObjectName of the JMX MBean, a key composed with the ObjectName
+# domain, followed by the 'type' attribute optionally, can be declared, using the
+# convention <domain>.<type>.
+# For example, the 'java.lang.Threading' key for the MBean with the following
+# objectName: java.lang:type=Threading can be declared. A more generic key with
+# the domain only can be declared (e.g. java.lang). A 'default' top-level key can
+# also be declared.
+# A key can either be an unordered or ordered map, whose keys can either be
+# string or regexp, and whose values can either be string or array of strings,
+# that represent roles that are allowed to invoke the MBean member.
+#
+# The system looks for required roles using the following process:
+#
+# The most specific key is tried first. E.g. for the
+# above example, the java.lang.Threading key is looked up first.
+# If the most specific key does not exist, the domain-only key is looked up,
+# otherwise, the 'default' key is looked up.
+# Using the matching key, the system looks up its map value for:
+#   1. An exact match for the operation invocation, using the operation
+#      signature, and the invocation arguments, e.g.:
+#      uninstall(java.lang.String)[0]: [] # no roles can perform this operation
+#   2. A regexp match for the operation invocation, using the operation
+#      signature, and the invocation arguments, e.g.:
+#      /update\(java\.lang\.String,java\.lang\.String\)\[[1-4]?[0-9],.*\]/: admin
+#      Note that, if the value is an ordered map, the iteration order is guaranteed,
+#      and the first matching regexp key is selected;
+#   3. An exact match for the operation invocation, using the operation
+#      signature, without the invocation arguments, e.g.:
+#      delete(java.lang.String): admin
+#   4. An exact match for the operation invocation, using the operation
+#      name, e.g.:
+#      dumpStatsAsXml: admin, viewer
+# If the key matches the operation invocation, it is used and the process will not
+# look for any other keys. So the most specific key always takes precedence.
+# Its value is used to match the role that impersonate the request, against the roles
+# that are allowed to invoke the operation.
+# If the current key does not match, the less specific key is looked up
+# and matched following the steps 1 to 4 above, up until the 'default' key.
+# Otherwise, the operation invocation is denied.
 
 default:
   - list: admin, viewer

--- a/docker/ACL.yaml
+++ b/docker/ACL.yaml
@@ -47,7 +47,7 @@
 # impersonating the request is granted for the pod hosting the operation being invoked.
 # A user that's granted the 'update' verb on the pod resource is bound to the 'admin' role.
 # Else, a user granted the 'get' verb on the pod resource is bound the 'viewer' role.
-# Otherwise the use is not bound any roles.
+# Otherwise the user is not bound any roles.
 
 # Default, generic rules, declared as an ordered map, so that the most specific keys
 # are tested first.

--- a/docker/ACL.yaml
+++ b/docker/ACL.yaml
@@ -17,7 +17,7 @@ connector:
   stop: admin
   start: admin
 
-hawio.plugin:
+hawtio.plugin:
   /.*/: /.*/
 hawtio.ConfigAdmin:
   configAdminUpdate: admin
@@ -29,6 +29,8 @@ hawtio.QuartzFacade:
   updateCronTrigger: admin
 hawtio.SchemaLookup:
   getSchemaForClass: admin, viewer
+hawtio.security:
+  canInvoke: admin, viewer
 
 java.lang.Memory:
   gc: admin
@@ -308,8 +310,6 @@ org.apache.karaf.log:
 org.apache.karaf.package:
   getImports: admin, viewer
   getExports: admin, viewer
-org.apache.karaf.security:
-  canInvoke: admin, viewer
 org.apache.karaf.service:
   getServices: admin, viewer
 org.apache.karaf.system:

--- a/docker/ACL.yaml
+++ b/docker/ACL.yaml
@@ -12,17 +12,411 @@ com.sun.management:
   getVMOption: admin, viewer
   setVMOption: admin
 
+connector:
+  stop: admin
+  start: admin
+
+hawio.plugin:
+  /.*/: /.*/
+hawtio.ConfigAdmin:
+  configAdminUpdate: admin
+hawtio.OSGiTools:
+  getResourceURL: admin, viewer
+  getLoadClassOrigin: admin, viewer
+hawtio.QuartzFacade:
+  updateSimpleTrigger: admin
+  updateCronTrigger: admin
+hawtio.SchemaLookup:
+  getSchemaForClass: admin, viewer
+
 java.lang.Memory:
-  gc: admin  
+  gc: admin
 java.lang.MemoryPool:
   resetPeakUsage: admin
 java.lang.Threading:
   /find.*/: admin, viewer
   dumpAllThreads: admin, viewer
   resetPeakThreadCount: admin
+java.util.logging:
+  getLoggerLevel: admin, viewer
+  getParentLoggerName: admin, viewer
+  setLoggerLevel: admin
+
+jolokia.Config.hawtio:
+  /is.*/: admin, viewer
+  /get.*/: admin, viewer
+  /set.*/: admin
+  debugInfo: admin, viewer
+  setHistoryEntriesForAttribute: admin
+  setHistoryEntriesForOperation: admin
+  setHistoryLimitForOperation: admin
+  resetHistoryEntries: admin
+  resetDebugInfo: admin
+  setHistoryLimitForAttribute: admin
+jolokia.Discovery:
+  lookupAgents: admin, viewer
+  lookupAgentsWithTimeout: admin, viewer
+jolokia.ServerHandler.hawtio: 
+  mBeanServersInfo: admin, viewer
+
+org.apache.aries.blueprint.blueprintMetadata:
+  /get.*/: admin, viewer
+org.apache.aries.blueprint.blueprintState:
+  /get.*/: admin, viewer
 
 org.apache.camel:
   /.*/: /.*/
-
+org.apache.camel.components:
+  getState: admin, viewer
+  getComponentName: admin, viewer
+  getCamelId: admin, viewer
+org.apache.camel.consumers:
+  isSuspended: admin, viewer
+  getState: admin, viewer
+  getServiceType: admin, viewer
+  isSupportSuspension: admin, viewer
+  isStaticService: admin, viewer
+  getCamelId: admin, viewer
+  getRouteId: admin, viewer
+  getInflightExchanges: admin, viewer
+  getEndpointUri: admin, viewer
+  stop: admin
+  start: admin
+  suspend: admin
+  resume: admin
 org.apache.camel.context:
+  getResetTimestamp: admin, viewer
+  getExchangesTotal: admin, viewer
+  getTotalProcessingTime: admin, viewer
+  isStatisticsEnabled: admin, viewer
+  setStatisticsEnabled: admin
+  getExchangesCompleted: admin, viewer
+  getExchangesFailed: admin, viewer
+  getFailuresHandled: admin, viewer
+  getRedeliveries: admin, viewer
+  getExternalRedeliveries: admin, viewer
+  getMinProcessingTime: admin, viewer
+  getMeanProcessingTime: admin, viewer
+  getMaxProcessingTime: admin, viewer
+  getLastProcessingTime: admin, viewer
+  getDeltaProcessingTime: admin, viewer
+  getLastExchangeCompletedTimestamp: admin, viewer
+  getLastExchangeCompletedExchangeId: admin, viewer
+  getFirstExchangeCompletedTimestamp: admin, viewer
+  getFirstExchangeCompletedExchangeId: admin, viewer
+  getLastExchangeFailureTimestamp: admin, viewer
+  getLastExchangeFailureExchangeId: admin, viewer
+  getFirstExchangeFailureTimestamp: admin, viewer
+  getFirstExchangeFailureExchangeId: admin, viewer
+  getCamelId: admin, viewer
+  getTimeout: admin, viewer
+  setTimeout: admin
+  getProperties: admin, viewer
+  getState: admin, viewer
+  getUptime: admin, viewer
+  getInflightExchanges: admin, viewer
+  getTracing: admin, viewer
+  setTracing: admin
+  getLoad01: admin, viewer
+  getLoad05: admin, viewer
+  getLoad15: admin, viewer
+  getCamelVersion: admin, viewer
+  getApplicationContextClassName: admin, viewer
+  getTotalRoutes: admin, viewer
+  getStartedRoutes: admin, viewer
+  isMessageHistory: admin, viewer
+  getTimeUnit: admin, viewer
+  setTimeUnit: admin
+  getClassResolver: admin, viewer
+  getManagementName: admin, viewer
+  getPackageScanClassResolver: admin, viewer
+  isUseMDCLogging: admin, viewer
+  isAllowUseOriginalMessage: admin, viewer
+  isUseBreadcrumb: admin, viewer
+  isShutdownNowOnTimeout: admin, viewer
+  setShutdownNowOnTimeout: admin
+  reset: admin
+  dumpStatsAsXml: admin, viewer
+  setProperty: admin
+  getProperty: admin, viewer
+  createEndpoint: admin
+  restart: admin
+  stop: admin
+  start: admin
+  suspend: admin
+  resume: admin
+  sendStringBody: admin
+  requestStringBody: admin
   dumpRoutesAsXml: admin, viewer
+  addOrUpdateRoutesFromXml: admin
+  findComponentNames: admin, viewer
+  dumpRoutesStatsAsXml: admin, viewer
+  componentParameterJsonSchema: admin, viewer
+  sendBody: admin
+  sendBodyAndHeaders: admin
+  requestBody: admin
+  requestBodyAndHeaders: admin
+  findComponents: admin, viewer
+  getComponentDocumentation: admin, viewer
+  removeEndpoints:  admin
+  completeEndpointPath: admin, viewer
+org.apache.camel.endpoints:
+  /is.*/: admin, viewer
+  /get.*/: admin, viewer
+  /set.*/: admin
+org.apache.camel.errorhandlers:
+  /is.*/: admin, viewer
+  /get.*/: admin, viewer
+  /set.*/: admin
+org.apache.camel.eventnotifiers:
+  /set.*/: admin
+org.apache.camel.processors:
+  dumpStatsAsXml: admin, viewer
+  /get.*/: admin, viewer
+  /is.*/: admin, viewer
+  /set.*/: admin
+  reset: admin
+  stop: admin
+  start: admin
+org.apache.camel.routes:
+  /is.*/: admin, viewer
+  /get.*/: admin, viewer
+  /set.*/: admin
+  reset: admin
+  /dump.*/: admin, viewer
+  remove: admin
+  shutdown: admin
+  stop: admin
+  start: admin
+  suspend: admin
+  resume: admin
+  updateRouteFromXml: admin
+org.apache.camel.services:
+  /is.*/: admin, viewer
+  /get.*/: admin, viewer
+  /set.*/: admin
+  stop: admin
+  start: admin
+  suspend: admin
+  resume: admin
+  purge: admin
+  hasTypeConverter: admin, viewer
+  resetTypeConversionCounters: admin
+  listTypeConverters: admin, viewer
+org.apache.camel.threadpools:
+  /is.*/: admin, viewer
+  /get.*/: admin, viewer
+  /set.*/: admin
+  purge: admin
+org.apache.camel.tracer:
+  /is.*/: admin, viewer
+  /get.*/: admin, viewer
+  /set.*/: admin
+  step: admin, viewer
+  enableDebugger: admin
+  disableDebugger: admin
+  /.*Breakpoint.*/: admin, viewer
+  resumeAll: admin, viewer
+  resetDebugCounter: admin
+  /dump.*/: admin, viewer
+  clear: admin
+  resetTraceCounter: admin
+
+org.apache.cxf.Bus:
+  shutdown: admin
+org.apache.cxf.Bus.Service.Endpoint:
+  destroy: admin
+  start: admin
+  stop: admin
+  getState: admin, viewer
+  getTransportId: admin, viewer
+  getAddress: admin, viewer
+org.apache.cxf.WorkQueueManager:
+  shutdown: admin
+
+org.apache.karaf.bundle:
+  capabilities: admin, viewer
+  diag: admin, viewer
+  getStartLevel: admin, viewer
+  install: admin
+  refresh: admin
+  resolve: admin
+  restart: admin
+  status: admin, viewer
+  setStartLevel(java.lang.String,int)[/([1-4])?[0-9]/,/.*/]: admin
+  setStartLevel: admin
+  start(java.lang.String)[/([1-4])?[0-9]/]: admin
+  start: admin
+  stop(java.lang.String)[/([1-4])?[0-9]/]: admin
+  stop: admin
+  uninstall(java.lang.String)["0"]: #this is a comment, no roles can perform this operation
+  uninstall: admin
+  update(java.lang.String)[/([1-4])?[0-9]/]: admin
+  update(java.lang.String,java.lang.String)[/([1-4])?[0-9]/,/.*/]: admin
+  update: admin
+org.apache.karaf.config:
+  listProperties: admin, viewer
+  appendProperty(java.lang.String,java.lang.String,java.lang.String)[/jmx[.]acl.*/,/.*/,/.*/]: admin
+  appendProperty(java.lang.String,java.lang.String,java.lang.String)[/org[.]apache[.]karaf[.]command[.]acl.+/,/.*/,/.*/]: admin
+  appendProperty(java.lang.String,java.lang.String,java.lang.String)[/org[.]apache[.]karaf[.]service[.]acl.+/,/.*/,/.*/]: admin
+  appendProperty(java.lang.String,java.lang.String,java.lang.String): admin
+  create(java.lang.String)[/jmx[.]acl.*/]: admin
+  create(java.lang.String)[/org[.]apache[.]karaf[.]command[.]acl.+/]: admin
+  create(java.lang.String)[/org[.]apache[.]karaf[.]service[.]acl.+/]: admin
+  create(java.lang.String): admin
+  delete(java.lang.String)[/jmx[.]acl.*/]: admin
+  delete(java.lang.String)[/org[.]apache[.]karaf[.]command[.]acl.+/]: admin
+  delete(java.lang.String)[/org[.]apache[.]karaf[.]service[.]acl.+/]: admin
+  delete(java.lang.String): admin
+  deleteProperty(java.lang.String,java.lang.String)[/jmx[.]acl.*/,/.*/]: admin
+  deleteProperty(java.lang.String,java.lang.String)[/org[.]apache[.]karaf[.]command[.]acl.+/,/.*/]: admin
+  deleteProperty(java.lang.String,java.lang.String)[/org[.]apache[.]karaf[.]service[.]acl.+/,/.*/]: admin
+  deleteProperty(java.lang.String,java.lang.String): admin
+  setProperty(java.lang.String,java.lang.String,java.lang.String)[/jmx[.]acl.*/,/.*/,/.*/]: admin
+  setProperty(java.lang.String,java.lang.String,java.lang.String)[/org[.]apache[.]karaf[.]command[.]acl.+/,/.*/,/.*/]: admin
+  setProperty(java.lang.String,java.lang.String,java.lang.String)[/org[.]apache[.]karaf[.]service[.]acl.+/,/.*/,/.*/]: admin
+  setProperty(java.lang.String,java.lang.String,java.lang.String): admin
+  update(java.lang.String,java.util.Map)[/jmx[.]acl.*/,/.*/]: admin
+  update(java.lang.String,java.util.Map)[/org[.]apache[.]karaf[.]command[.]acl.+/,/.*/]: admin
+  update(java.lang.String,java.util.Map)[/org[.]apache[.]karaf[.]service[.]acl.+/,/.*/]: admin
+  update(java.lang.String,java.util.Map): admin
+org.apache.karaf.diagnostic:
+  createDump: admin, viewer
+org.apache.karaf.feature:
+  infoFeature: admin, viewer
+  removeRepository: admin
+  addRepository: admin
+  uninstallFeature: admin
+  installFeature: admin
+  refreshRepository: admin
+org.apache.karaf.instance:
+  createInstance: admin
+  destroyInstance: admin
+  startInstance: admin
+  stopInstance: admin
+  cloneInstance: admin
+  renameInstance: admin
+  changeSshPort: admin
+  changeSshHost: admin
+  ChangeRmiRegistryPort: admin
+  changeRmiServerPort: admin
+  changeJavaOpts: admin
+org.apache.karaf.log:
+  getLevel: admin, viewer
+  setLevel: admin
+org.apache.karaf.package:
+  getImports: admin, viewer
+  getExports: admin, viewer
+org.apache.karaf.security:
+  canInvoke: admin, viewer
+org.apache.karaf.service:
+  getServices: admin, viewer
+org.apache.karaf.system:
+  setProperty: admin
+  /getPropert.*/: admin, viewer
+  halt: admin
+  reboot: admin
+  rebootCleanCache: admin
+  rebootCleanAll: admin
+
+osgi.compendium.cm:
+  createFactoryConfiguration(java.lang.String)[/jmx[.]acl.*/]: admin
+  createFactoryConfiguration(java.lang.String)[/org[.]apache[.]karaf[.]command[.]acl[.].+/]: admin
+  createFactoryConfiguration(java.lang.String)[/org[.]apache[.]karaf[.]service[.]acl[.].+/]: admin
+  createFactoryConfiguration(java.lang.String): admin
+  createFactoryConfigurationForLocation(java.lang.String,java.lang.String)[/jmx[.]acl.*/,/.*/]: admin
+  createFactoryConfigurationForLocation(java.lang.String,java.lang.String)[/org[.]apache[.]karaf[.]command[.]acl[.].+/,/.*/]: admin
+  createFactoryConfigurationForLocation(java.lang.String,java.lang.String)[/org[.]apache[.]karaf[.]service[.]acl[.].+/,/.*/]: admin
+  createFactoryConfigurationForLocation(java.lang.String,java.lang.String): admin
+  delete(java.lang.String)[/jmx[.]acl.*/]: admin
+  delete(java.lang.String)[/org[.]apache[.]karaf[.]command[.]acl[.].+/]: admin
+  delete(java.lang.String)[/org[.]apache[.]karaf[.]service[.]acl[.].+/]: admin
+  delete(java.lang.String): admin
+  deleteConfigurations: admin
+  deleteForLocation(java.lang.String,java.lang.String)[/jmx[.]acl.*/,/.*/]: admin
+  deleteForLocation(java.lang.String,java.lang.String)[/org[.]apache[.]karaf[.]command[.]acl[.].+/,/.*/]: admin
+  deleteForLocation(java.lang.String,java.lang.String)[/org[.]apache[.]karaf[.]service[.]acl[.].+/,/.*/]: admin
+  deleteForLocation(java.lang.String,java.lang.String): admin
+  update(java.lang.String,javax.management.openmbean.TabularData)[/jmx[.]acl.*/,/.*/]: admin
+  update(java.lang.String,javax.management.openmbean.TabularData)[/org[.]apache[.]karaf[.]command[.]acl[.].+/,/.*/]: admin
+  update(java.lang.String,javax.management.openmbean.TabularData)[/org[.]apache[.]karaf[.]service[.]acl[.].+/,/.*/]: admin
+  update(java.lang.String,javax.management.openmbean.TabularData): admin
+  updateForLocation(java.lang.String,java.lang.String,javax.management.openmbean.TabularData)[/jmx[.]acl.*/,/.*/,/.*/]: admin
+  updateForLocation(java.lang.String,java.lang.String,javax.management.openmbean.TabularData)[/org[.]apache[.]karaf[.]command[.]acl[.].+/,/.*/,/.*/]: admin
+  updateForLocation(java.lang.String,java.lang.String,javax.management.openmbean.TabularData)[/org[.]apache[.]karaf[.]service[.]acl[.].+/,/.*/,/.*/]: admin
+  updateForLocation(java.lang.String,java.lang.String,javax.management.openmbean.TabularData): admin
+osgi.core.bundleState:
+  getRequiredBundles: admin, viewer
+  getHosts: admin, viewer
+  getLocation: admin, viewer
+  getState: admin, viewer
+  getBundle: admin, viewer
+  getVersion: admin, viewer
+  getSymbolicName: admin, viewer
+  getRegisteredServices: admin, viewer
+  getServicesInUse: admin, viewer
+  getFragments: admin, viewer
+  getLastModified: admin, viewer
+  getHeaders: admin, viewer
+  getHeader: admin, viewer
+  getStartLevel: admin, viewer
+  getExportedPackages: admin, viewer
+  getRequiringBundles: admin, viewer
+  isFragment: admin, viewer
+  isRemovalPending: admin, viewer
+  isPersistentlyStarted: admin, viewer
+  isActivationPolicyUsed: admin, viewer
+  getImportedPackages: admin, viewer
+  isRequired: admin, viewer
+  listBundles: admin, viewer
+osgi.core.framework:
+  startBundles: admin
+  getProperty: admin, viewer
+  resolve: admin
+  installBundle: admin
+  setBundleStartLevel: admin
+  startBundle: admin
+  updateBundle: admin
+  stopBundle: admin
+  stopBundle(long)["0"]: #this is a comment, no roles can perform this operation
+  uninstallBundle: admin
+  resolveBundles: admin
+  getDependencyClosure: admin, viewer
+  refreshBundle: admin
+  refreshBundles: admin
+  installBundleFromURL: admin
+  installBundles: admin
+  installBundlesFromURL: admin
+  refreshBundleAndWait: admin
+  refreshBundlesAndWait: admin
+  resolveBundle: admin
+  restartFramework: admin
+  setBundleStartLevels: admin
+  shutdownFramework: admin
+  stopBundles: admin
+  uninstallBundles: admin
+  updateBundleFromURL: admin
+  updateBundles: admin
+  updateBundlesFromURL: admin
+osgi.core.packageState:
+  getExportingBundles: admin, viewer
+  listPackages: admin, viewer
+  getImportingBundles: admin, viewer
+  isRemovalPending: admin, viewer
+osgi.core.serviceState:
+  getProperty: admin, viewer
+  getProperties: admin, viewer
+  getService: admin, viewer
+  getBundleIdentifier: admin, viewer
+  getObjectClass: admin, viewer
+  listServices: admin, viewer
+  getUsingBundles: admin, viewer
+osgi.core.wiringState:
+  getCurrentRevisionDeclaredCapabilities: admin, viewer
+  getCurrentWiringClosure: admin, viewer
+  getRevisionsDeclaredRequirements: admin, viewer
+  getRevisionsDeclaredCapabilities: admin, viewer
+  getRevisionsWiring: admin, viewer
+  getRevisionsWiringClosure: admin, viewer
+  getCurrentRevisionDeclaredRequirements: admin, viewer
+  getCurrentWiring: admin, viewer

--- a/docker/ACL.yaml
+++ b/docker/ACL.yaml
@@ -1,0 +1,28 @@
+# TODO: complete and document
+
+default:
+  - /list.*/: [admin, viewer]
+  - /get.*/: [admin, viewer]
+  - /is.*/: [admin, viewer]
+  - /set.*/: admin
+  - /.*/: admin
+
+com.sun.management:
+  dumpHeap: [admin, viewer]
+  getVMOption: [admin, viewer]
+  setVMOption: admin
+
+java.lang.Memory:
+  gc: admin  
+java.lang.MemoryPool:
+  resetPeakUsage: admin
+java.lang.Threading:
+  /find.*/: [admin, viewer]
+  dumpAllThreads: [admin, viewer]
+  resetPeakThreadCount: admin
+
+org.apache.camel:
+  /.*/: /.*/
+
+org.apache.camel.context:
+  dumpRoutesAsXml: [admin, viewer]

--- a/docker/ACL.yaml
+++ b/docker/ACL.yaml
@@ -13,7 +13,7 @@
 # string or regexp, and whose values can either be string or array of strings,
 # that represent roles that are allowed to invoke the MBean member.
 #
-# The system looks for required roles using the following process:
+# The system looks for allowed roles using the following process:
 #
 # The most specific key is tried first. E.g. for the
 # above example, the java.lang.Threading key is looked up first.
@@ -36,12 +36,21 @@
 #      dumpStatsAsXml: admin, viewer
 # If the key matches the operation invocation, it is used and the process will not
 # look for any other keys. So the most specific key always takes precedence.
-# Its value is used to match the role that impersonate the request, against the roles
+# Its value is used to match the role that impersonates the request, against the roles
 # that are allowed to invoke the operation.
 # If the current key does not match, the less specific key is looked up
 # and matched following the steps 1 to 4 above, up until the 'default' key.
 # Otherwise, the operation invocation is denied.
+#
+# For the time being, only the viewer and admin roles are supported. Once the current
+# invocation is authenticated, these roles are inferred from the permissions the user
+# impersonating the request is granted for the pod hosting the operation being invoked.
+# A user that's granted the 'update' verb on the pod resource is bound to the 'admin' role.
+# Else, a user granted the 'get' verb on the pod resource is bound the 'viewer' role.
+# Otherwise the use is not bound any roles.
 
+# Default, generic rules, declared as an ordered map, so that the most specific keys
+# are tested first.
 default:
   - list: admin, viewer
   - read: admin, viewer

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM docker.io/centos:7
 
-ENV NGINX_VERSION 1.17.1-1.el7
-ENV NGINX_MODULE_NJS_VERSION 1.17.1.0.3.3-1.el7
+ENV NGINX_VERSION 1.17.10-1.el7
+ENV NGINX_MODULE_NJS_VERSION 1.17.10.0.4.0-1.el7
 
 LABEL name="nginxinc/nginx" \
       vendor="NGINX Inc." \
@@ -41,7 +41,7 @@ RUN ln -sf /dev/stdout /var/log/nginx/access.log && \
 
 #VOLUME ["/var/cache/nginx"]
 
-EXPOSE 443
+EXPOSE 8443
 
 # Add symbolic link to config.json to avoid mounting issues
 RUN ln -sf /usr/share/nginx/html/config/config.json /usr/share/nginx/html/config.json
@@ -57,8 +57,8 @@ RUN touch config.js && \
 
 USER 998
 
-COPY nginx.js /etc/nginx/conf.d/
-COPY nginx.conf nginx-gateway.conf osconsole/config.sh nginx.sh ./
+COPY nginx.js rbac.js js-yaml.js /etc/nginx/conf.d/
+COPY nginx.conf nginx-gateway.conf osconsole/config.sh nginx.sh ACL.yaml /
 COPY site /usr/share/nginx/html
 COPY branding/favicon.ico branding/Logo-Red_Hat-Fuse-A-Reverse-RGB.png branding/Logo-RedHat-A-Reverse-RGB.png /usr/share/nginx/html/online/img/
 COPY branding/hawtconfig.json /usr/share/nginx/html/online

--- a/docker/js-yaml.js
+++ b/docker/js-yaml.js
@@ -1,0 +1,3907 @@
+export default (function(f){ return f()})(function(){var define,module,exports;return (function(){function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s}return e})()({1:[function(require,module,exports){
+'use strict';
+
+
+var loader = require('./js-yaml/loader');
+var dumper = require('./js-yaml/dumper');
+
+
+function deprecated(name) {
+  return function () {
+    throw new Error('Function ' + name + ' is deprecated and cannot be used.');
+  };
+}
+
+
+module.exports.Type                = require('./js-yaml/type');
+module.exports.Schema              = require('./js-yaml/schema');
+module.exports.FAILSAFE_SCHEMA     = require('./js-yaml/schema/failsafe');
+module.exports.JSON_SCHEMA         = require('./js-yaml/schema/json');
+module.exports.CORE_SCHEMA         = require('./js-yaml/schema/core');
+module.exports.DEFAULT_SAFE_SCHEMA = require('./js-yaml/schema/default_safe');
+module.exports.DEFAULT_FULL_SCHEMA = require('./js-yaml/schema/default_full');
+module.exports.load                = loader.load;
+module.exports.loadAll             = loader.loadAll;
+module.exports.safeLoad            = loader.safeLoad;
+module.exports.safeLoadAll         = loader.safeLoadAll;
+module.exports.dump                = dumper.dump;
+module.exports.safeDump            = dumper.safeDump;
+module.exports.YAMLException       = require('./js-yaml/exception');
+
+// Deprecated schema names from JS-YAML 2.0.x
+module.exports.MINIMAL_SCHEMA = require('./js-yaml/schema/failsafe');
+module.exports.SAFE_SCHEMA    = require('./js-yaml/schema/default_safe');
+module.exports.DEFAULT_SCHEMA = require('./js-yaml/schema/default_full');
+
+// Deprecated functions from JS-YAML 1.x.x
+module.exports.scan           = deprecated('scan');
+module.exports.parse          = deprecated('parse');
+module.exports.compose        = deprecated('compose');
+module.exports.addConstructor = deprecated('addConstructor');
+
+},{"./js-yaml/dumper":3,"./js-yaml/exception":4,"./js-yaml/loader":5,"./js-yaml/schema":7,"./js-yaml/schema/core":8,"./js-yaml/schema/default_full":9,"./js-yaml/schema/default_safe":10,"./js-yaml/schema/failsafe":11,"./js-yaml/schema/json":12,"./js-yaml/type":13}],2:[function(require,module,exports){
+'use strict';
+
+
+function isNothing(subject) {
+  return (typeof subject === 'undefined') || (subject === null);
+}
+
+
+function isObject(subject) {
+  return (typeof subject === 'object') && (subject !== null);
+}
+
+
+function toArray(sequence) {
+  if (Array.isArray(sequence)) return sequence;
+  else if (isNothing(sequence)) return [];
+
+  return [ sequence ];
+}
+
+
+function extend(target, source) {
+  var index, length, key, sourceKeys;
+
+  if (source) {
+    sourceKeys = Object.keys(source);
+
+    for (index = 0, length = sourceKeys.length; index < length; index += 1) {
+      key = sourceKeys[index];
+      target[key] = source[key];
+    }
+  }
+
+  return target;
+}
+
+
+function repeat(string, count) {
+  var result = '', cycle;
+
+  for (cycle = 0; cycle < count; cycle += 1) {
+    result += string;
+  }
+
+  return result;
+}
+
+
+function isNegativeZero(number) {
+  return (number === 0) && (Number.NEGATIVE_INFINITY === 1 / number);
+}
+
+
+module.exports.isNothing      = isNothing;
+module.exports.isObject       = isObject;
+module.exports.toArray        = toArray;
+module.exports.repeat         = repeat;
+module.exports.isNegativeZero = isNegativeZero;
+module.exports.extend         = extend;
+
+},{}],3:[function(require,module,exports){
+'use strict';
+
+/*eslint-disable no-use-before-define*/
+
+var common              = require('./common');
+var YAMLException       = require('./exception');
+var DEFAULT_FULL_SCHEMA = require('./schema/default_full');
+var DEFAULT_SAFE_SCHEMA = require('./schema/default_safe');
+
+var _toString       = Object.prototype.toString;
+var _hasOwnProperty = Object.prototype.hasOwnProperty;
+
+var CHAR_TAB                  = 0x09; /* Tab */
+var CHAR_LINE_FEED            = 0x0A; /* LF */
+var CHAR_SPACE                = 0x20; /* Space */
+var CHAR_EXCLAMATION          = 0x21; /* ! */
+var CHAR_DOUBLE_QUOTE         = 0x22; /* " */
+var CHAR_SHARP                = 0x23; /* # */
+var CHAR_PERCENT              = 0x25; /* % */
+var CHAR_AMPERSAND            = 0x26; /* & */
+var CHAR_SINGLE_QUOTE         = 0x27; /* ' */
+var CHAR_ASTERISK             = 0x2A; /* * */
+var CHAR_COMMA                = 0x2C; /* , */
+var CHAR_MINUS                = 0x2D; /* - */
+var CHAR_COLON                = 0x3A; /* : */
+var CHAR_GREATER_THAN         = 0x3E; /* > */
+var CHAR_QUESTION             = 0x3F; /* ? */
+var CHAR_COMMERCIAL_AT        = 0x40; /* @ */
+var CHAR_LEFT_SQUARE_BRACKET  = 0x5B; /* [ */
+var CHAR_RIGHT_SQUARE_BRACKET = 0x5D; /* ] */
+var CHAR_GRAVE_ACCENT         = 0x60; /* ` */
+var CHAR_LEFT_CURLY_BRACKET   = 0x7B; /* { */
+var CHAR_VERTICAL_LINE        = 0x7C; /* | */
+var CHAR_RIGHT_CURLY_BRACKET  = 0x7D; /* } */
+
+var ESCAPE_SEQUENCES = {};
+
+ESCAPE_SEQUENCES[0x00]   = '\\0';
+ESCAPE_SEQUENCES[0x07]   = '\\a';
+ESCAPE_SEQUENCES[0x08]   = '\\b';
+ESCAPE_SEQUENCES[0x09]   = '\\t';
+ESCAPE_SEQUENCES[0x0A]   = '\\n';
+ESCAPE_SEQUENCES[0x0B]   = '\\v';
+ESCAPE_SEQUENCES[0x0C]   = '\\f';
+ESCAPE_SEQUENCES[0x0D]   = '\\r';
+ESCAPE_SEQUENCES[0x1B]   = '\\e';
+ESCAPE_SEQUENCES[0x22]   = '\\"';
+ESCAPE_SEQUENCES[0x5C]   = '\\\\';
+ESCAPE_SEQUENCES[0x85]   = '\\N';
+ESCAPE_SEQUENCES[0xA0]   = '\\_';
+ESCAPE_SEQUENCES[0x2028] = '\\L';
+ESCAPE_SEQUENCES[0x2029] = '\\P';
+
+var DEPRECATED_BOOLEANS_SYNTAX = [
+  'y', 'Y', 'yes', 'Yes', 'YES', 'on', 'On', 'ON',
+  'n', 'N', 'no', 'No', 'NO', 'off', 'Off', 'OFF'
+];
+
+function compileStyleMap(schema, map) {
+  var result, keys, index, length, tag, style, type;
+
+  if (map === null) return {};
+
+  result = {};
+  keys = Object.keys(map);
+
+  for (index = 0, length = keys.length; index < length; index += 1) {
+    tag = keys[index];
+    style = String(map[tag]);
+
+    if (tag.slice(0, 2) === '!!') {
+      tag = 'tag:yaml.org,2002:' + tag.slice(2);
+    }
+    type = schema.compiledTypeMap['fallback'][tag];
+
+    if (type && _hasOwnProperty.call(type.styleAliases, style)) {
+      style = type.styleAliases[style];
+    }
+
+    result[tag] = style;
+  }
+
+  return result;
+}
+
+function encodeHex(character) {
+  var string, handle, length;
+
+  string = character.toString(16).toUpperCase();
+
+  if (character <= 0xFF) {
+    handle = 'x';
+    length = 2;
+  } else if (character <= 0xFFFF) {
+    handle = 'u';
+    length = 4;
+  } else if (character <= 0xFFFFFFFF) {
+    handle = 'U';
+    length = 8;
+  } else {
+    throw new YAMLException('code point within a string may not be greater than 0xFFFFFFFF');
+  }
+
+  return '\\' + handle + common.repeat('0', length - string.length) + string;
+}
+
+function State(options) {
+  this.schema       = options['schema'] || DEFAULT_FULL_SCHEMA;
+  this.indent       = Math.max(1, (options['indent'] || 2));
+  this.skipInvalid  = options['skipInvalid'] || false;
+  this.flowLevel    = (common.isNothing(options['flowLevel']) ? -1 : options['flowLevel']);
+  this.styleMap     = compileStyleMap(this.schema, options['styles'] || null);
+  this.sortKeys     = options['sortKeys'] || false;
+  this.lineWidth    = options['lineWidth'] || 80;
+  this.noRefs       = options['noRefs'] || false;
+  this.noCompatMode = options['noCompatMode'] || false;
+  this.condenseFlow = options['condenseFlow'] || false;
+
+  this.implicitTypes = this.schema.compiledImplicit;
+  this.explicitTypes = this.schema.compiledExplicit;
+
+  this.tag = null;
+  this.result = '';
+
+  this.duplicates = [];
+  this.usedDuplicates = null;
+}
+
+// Indents every line in a string. Empty lines (\n only) are not indented.
+function indentString(string, spaces) {
+  var ind = common.repeat(' ', spaces),
+      position = 0,
+      next = -1,
+      result = '',
+      line,
+      length = string.length;
+
+  while (position < length) {
+    next = string.indexOf('\n', position);
+    if (next === -1) {
+      line = string.slice(position);
+      position = length;
+    } else {
+      line = string.slice(position, next + 1);
+      position = next + 1;
+    }
+
+    if (line.length && line !== '\n') result += ind;
+
+    result += line;
+  }
+
+  return result;
+}
+
+function generateNextLine(state, level) {
+  return '\n' + common.repeat(' ', state.indent * level);
+}
+
+function testImplicitResolving(state, str) {
+  var index, length, type;
+
+  for (index = 0, length = state.implicitTypes.length; index < length; index += 1) {
+    type = state.implicitTypes[index];
+
+    if (type.resolve(str)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+// [33] s-white ::= s-space | s-tab
+function isWhitespace(c) {
+  return c === CHAR_SPACE || c === CHAR_TAB;
+}
+
+// Returns true if the character can be printed without escaping.
+// From YAML 1.2: "any allowed characters known to be non-printable
+// should also be escaped. [However,] This isn’t mandatory"
+// Derived from nb-char - \t - #x85 - #xA0 - #x2028 - #x2029.
+function isPrintable(c) {
+  return  (0x00020 <= c && c <= 0x00007E)
+      || ((0x000A1 <= c && c <= 0x00D7FF) && c !== 0x2028 && c !== 0x2029)
+      || ((0x0E000 <= c && c <= 0x00FFFD) && c !== 0xFEFF /* BOM */)
+      ||  (0x10000 <= c && c <= 0x10FFFF);
+}
+
+// Simplified test for values allowed after the first character in plain style.
+function isPlainSafe(c) {
+  // Uses a subset of nb-char - c-flow-indicator - ":" - "#"
+  // where nb-char ::= c-printable - b-char - c-byte-order-mark.
+  return isPrintable(c) && c !== 0xFEFF
+    // - c-flow-indicator
+    && c !== CHAR_COMMA
+    && c !== CHAR_LEFT_SQUARE_BRACKET
+    && c !== CHAR_RIGHT_SQUARE_BRACKET
+    && c !== CHAR_LEFT_CURLY_BRACKET
+    && c !== CHAR_RIGHT_CURLY_BRACKET
+    // - ":" - "#"
+    && c !== CHAR_COLON
+    && c !== CHAR_SHARP;
+}
+
+// Simplified test for values allowed as the first character in plain style.
+function isPlainSafeFirst(c) {
+  // Uses a subset of ns-char - c-indicator
+  // where ns-char = nb-char - s-white.
+  return isPrintable(c) && c !== 0xFEFF
+    && !isWhitespace(c) // - s-white
+    // - (c-indicator ::=
+    // “-” | “?” | “:” | “,” | “[” | “]” | “{” | “}”
+    && c !== CHAR_MINUS
+    && c !== CHAR_QUESTION
+    && c !== CHAR_COLON
+    && c !== CHAR_COMMA
+    && c !== CHAR_LEFT_SQUARE_BRACKET
+    && c !== CHAR_RIGHT_SQUARE_BRACKET
+    && c !== CHAR_LEFT_CURLY_BRACKET
+    && c !== CHAR_RIGHT_CURLY_BRACKET
+    // | “#” | “&” | “*” | “!” | “|” | “>” | “'” | “"”
+    && c !== CHAR_SHARP
+    && c !== CHAR_AMPERSAND
+    && c !== CHAR_ASTERISK
+    && c !== CHAR_EXCLAMATION
+    && c !== CHAR_VERTICAL_LINE
+    && c !== CHAR_GREATER_THAN
+    && c !== CHAR_SINGLE_QUOTE
+    && c !== CHAR_DOUBLE_QUOTE
+    // | “%” | “@” | “`”)
+    && c !== CHAR_PERCENT
+    && c !== CHAR_COMMERCIAL_AT
+    && c !== CHAR_GRAVE_ACCENT;
+}
+
+var STYLE_PLAIN   = 1,
+    STYLE_SINGLE  = 2,
+    STYLE_LITERAL = 3,
+    STYLE_FOLDED  = 4,
+    STYLE_DOUBLE  = 5;
+
+// Determines which scalar styles are possible and returns the preferred style.
+// lineWidth = -1 => no limit.
+// Pre-conditions: str.length > 0.
+// Post-conditions:
+//    STYLE_PLAIN or STYLE_SINGLE => no \n are in the string.
+//    STYLE_LITERAL => no lines are suitable for folding (or lineWidth is -1).
+//    STYLE_FOLDED => a line > lineWidth and can be folded (and lineWidth != -1).
+function chooseScalarStyle(string, singleLineOnly, indentPerLevel, lineWidth, testAmbiguousType) {
+  var i;
+  var char;
+  var hasLineBreak = false;
+  var hasFoldableLine = false; // only checked if shouldTrackWidth
+  var shouldTrackWidth = lineWidth !== -1;
+  var previousLineBreak = -1; // count the first line correctly
+  var plain = isPlainSafeFirst(string.charCodeAt(0))
+          && !isWhitespace(string.charCodeAt(string.length - 1));
+
+  if (singleLineOnly) {
+    // Case: no block styles.
+    // Check for disallowed characters to rule out plain and single.
+    for (i = 0; i < string.length; i++) {
+      char = string.charCodeAt(i);
+      if (!isPrintable(char)) {
+        return STYLE_DOUBLE;
+      }
+      plain = plain && isPlainSafe(char);
+    }
+  } else {
+    // Case: block styles permitted.
+    for (i = 0; i < string.length; i++) {
+      char = string.charCodeAt(i);
+      if (char === CHAR_LINE_FEED) {
+        hasLineBreak = true;
+        // Check if any line can be folded.
+        if (shouldTrackWidth) {
+          hasFoldableLine = hasFoldableLine ||
+            // Foldable line = too long, and not more-indented.
+            (i - previousLineBreak - 1 > lineWidth &&
+             string[previousLineBreak + 1] !== ' ');
+          previousLineBreak = i;
+        }
+      } else if (!isPrintable(char)) {
+        return STYLE_DOUBLE;
+      }
+      plain = plain && isPlainSafe(char);
+    }
+    // in case the end is missing a \n
+    hasFoldableLine = hasFoldableLine || (shouldTrackWidth &&
+      (i - previousLineBreak - 1 > lineWidth &&
+       string[previousLineBreak + 1] !== ' '));
+  }
+  // Although every style can represent \n without escaping, prefer block styles
+  // for multiline, since they're more readable and they don't add empty lines.
+  // Also prefer folding a super-long line.
+  if (!hasLineBreak && !hasFoldableLine) {
+    // Strings interpretable as another type have to be quoted;
+    // e.g. the string 'true' vs. the boolean true.
+    return plain && !testAmbiguousType(string)
+      ? STYLE_PLAIN : STYLE_SINGLE;
+  }
+  // Edge case: block indentation indicator can only have one digit.
+  if (string[0] === ' ' && indentPerLevel > 9) {
+    return STYLE_DOUBLE;
+  }
+  // At this point we know block styles are valid.
+  // Prefer literal style unless we want to fold.
+  return hasFoldableLine ? STYLE_FOLDED : STYLE_LITERAL;
+}
+
+// Note: line breaking/folding is implemented for only the folded style.
+// NB. We drop the last trailing newline (if any) of a returned block scalar
+//  since the dumper adds its own newline. This always works:
+//    • No ending newline => unaffected; already using strip "-" chomping.
+//    • Ending newline    => removed then restored.
+//  Importantly, this keeps the "+" chomp indicator from gaining an extra line.
+function writeScalar(state, string, level, iskey) {
+  state.dump = (function () {
+    if (string.length === 0) {
+      return "''";
+    }
+    if (!state.noCompatMode &&
+        DEPRECATED_BOOLEANS_SYNTAX.indexOf(string) !== -1) {
+      return "'" + string + "'";
+    }
+
+    var indent = state.indent * Math.max(1, level); // no 0-indent scalars
+    // As indentation gets deeper, let the width decrease monotonically
+    // to the lower bound min(state.lineWidth, 40).
+    // Note that this implies
+    //  state.lineWidth ≤ 40 + state.indent: width is fixed at the lower bound.
+    //  state.lineWidth > 40 + state.indent: width decreases until the lower bound.
+    // This behaves better than a constant minimum width which disallows narrower options,
+    // or an indent threshold which causes the width to suddenly increase.
+    var lineWidth = state.lineWidth === -1
+      ? -1 : Math.max(Math.min(state.lineWidth, 40), state.lineWidth - indent);
+
+    // Without knowing if keys are implicit/explicit, assume implicit for safety.
+    var singleLineOnly = iskey
+      // No block styles in flow mode.
+      || (state.flowLevel > -1 && level >= state.flowLevel);
+    function testAmbiguity(string) {
+      return testImplicitResolving(state, string);
+    }
+
+    switch (chooseScalarStyle(string, singleLineOnly, state.indent, lineWidth, testAmbiguity)) {
+      case STYLE_PLAIN:
+        return string;
+      case STYLE_SINGLE:
+        return "'" + string.replace(/'/g, "''") + "'";
+      case STYLE_LITERAL:
+        return '|' + blockHeader(string, state.indent)
+          + dropEndingNewline(indentString(string, indent));
+      case STYLE_FOLDED:
+        return '>' + blockHeader(string, state.indent)
+          + dropEndingNewline(indentString(foldString(string, lineWidth), indent));
+      case STYLE_DOUBLE:
+        return '"' + escapeString(string, lineWidth) + '"';
+      default:
+        throw new YAMLException('impossible error: invalid scalar style');
+    }
+  }());
+}
+
+// Pre-conditions: string is valid for a block scalar, 1 <= indentPerLevel <= 9.
+function blockHeader(string, indentPerLevel) {
+  var indentIndicator = (string[0] === ' ') ? String(indentPerLevel) : '';
+
+  // note the special case: the string '\n' counts as a "trailing" empty line.
+  var clip =          string[string.length - 1] === '\n';
+  var keep = clip && (string[string.length - 2] === '\n' || string === '\n');
+  var chomp = keep ? '+' : (clip ? '' : '-');
+
+  return indentIndicator + chomp + '\n';
+}
+
+// (See the note for writeScalar.)
+function dropEndingNewline(string) {
+  return string[string.length - 1] === '\n' ? string.slice(0, -1) : string;
+}
+
+// Note: a long line without a suitable break point will exceed the width limit.
+// Pre-conditions: every char in str isPrintable, str.length > 0, width > 0.
+function foldString(string, width) {
+  // In folded style, $k$ consecutive newlines output as $k+1$ newlines—
+  // unless they're before or after a more-indented line, or at the very
+  // beginning or end, in which case $k$ maps to $k$.
+  // Therefore, parse each chunk as newline(s) followed by a content line.
+  var lineRe = /(\n+)([^\n]*)/g;
+
+  // first line (possibly an empty line)
+  var result = (function () {
+    var nextLF = string.indexOf('\n');
+    nextLF = nextLF !== -1 ? nextLF : string.length;
+    lineRe.lastIndex = nextLF;
+    return foldLine(string.slice(0, nextLF), width);
+  }());
+  // If we haven't reached the first content line yet, don't add an extra \n.
+  var prevMoreIndented = string[0] === '\n' || string[0] === ' ';
+  var moreIndented;
+
+  // rest of the lines
+  var match;
+  while ((match = lineRe.exec(string))) {
+    var prefix = match[1], line = match[2];
+    moreIndented = (line[0] === ' ');
+    result += prefix
+      + (!prevMoreIndented && !moreIndented && line !== ''
+        ? '\n' : '')
+      + foldLine(line, width);
+    prevMoreIndented = moreIndented;
+  }
+
+  return result;
+}
+
+// Greedy line breaking.
+// Picks the longest line under the limit each time,
+// otherwise settles for the shortest line over the limit.
+// NB. More-indented lines *cannot* be folded, as that would add an extra \n.
+function foldLine(line, width) {
+  if (line === '' || line[0] === ' ') return line;
+
+  // Since a more-indented line adds a \n, breaks can't be followed by a space.
+  var breakRe = / [^ ]/g; // note: the match index will always be <= length-2.
+  var match;
+  // start is an inclusive index. end, curr, and next are exclusive.
+  var start = 0, end, curr = 0, next = 0;
+  var result = '';
+
+  // Invariants: 0 <= start <= length-1.
+  //   0 <= curr <= next <= max(0, length-2). curr - start <= width.
+  // Inside the loop:
+  //   A match implies length >= 2, so curr and next are <= length-2.
+  while ((match = breakRe.exec(line))) {
+    next = match.index;
+    // maintain invariant: curr - start <= width
+    if (next - start > width) {
+      end = (curr > start) ? curr : next; // derive end <= length-2
+      result += '\n' + line.slice(start, end);
+      // skip the space that was output as \n
+      start = end + 1;                    // derive start <= length-1
+    }
+    curr = next;
+  }
+
+  // By the invariants, start <= length-1, so there is something left over.
+  // It is either the whole string or a part starting from non-whitespace.
+  result += '\n';
+  // Insert a break if the remainder is too long and there is a break available.
+  if (line.length - start > width && curr > start) {
+    result += line.slice(start, curr) + '\n' + line.slice(curr + 1);
+  } else {
+    result += line.slice(start);
+  }
+
+  return result.slice(1); // drop extra \n joiner
+}
+
+// Escapes a double-quoted string.
+function escapeString(string) {
+  var result = '';
+  var char, nextChar;
+  var escapeSeq;
+
+  for (var i = 0; i < string.length; i++) {
+    char = string.charCodeAt(i);
+    // Check for surrogate pairs (reference Unicode 3.0 section "3.7 Surrogates").
+    if (char >= 0xD800 && char <= 0xDBFF/* high surrogate */) {
+      nextChar = string.charCodeAt(i + 1);
+      if (nextChar >= 0xDC00 && nextChar <= 0xDFFF/* low surrogate */) {
+        // Combine the surrogate pair and store it escaped.
+        result += encodeHex((char - 0xD800) * 0x400 + nextChar - 0xDC00 + 0x10000);
+        // Advance index one extra since we already used that char here.
+        i++; continue;
+      }
+    }
+    escapeSeq = ESCAPE_SEQUENCES[char];
+    result += !escapeSeq && isPrintable(char)
+      ? string[i]
+      : escapeSeq || encodeHex(char);
+  }
+
+  return result;
+}
+
+function writeFlowSequence(state, level, object) {
+  var _result = '',
+      _tag    = state.tag,
+      index,
+      length;
+
+  for (index = 0, length = object.length; index < length; index += 1) {
+    // Write only valid elements.
+    if (writeNode(state, level, object[index], false, false)) {
+      if (index !== 0) _result += ',' + (!state.condenseFlow ? ' ' : '');
+      _result += state.dump;
+    }
+  }
+
+  state.tag = _tag;
+  state.dump = '[' + _result + ']';
+}
+
+function writeBlockSequence(state, level, object, compact) {
+  var _result = '',
+      _tag    = state.tag,
+      index,
+      length;
+
+  for (index = 0, length = object.length; index < length; index += 1) {
+    // Write only valid elements.
+    if (writeNode(state, level + 1, object[index], true, true)) {
+      if (!compact || index !== 0) {
+        _result += generateNextLine(state, level);
+      }
+
+      if (state.dump && CHAR_LINE_FEED === state.dump.charCodeAt(0)) {
+        _result += '-';
+      } else {
+        _result += '- ';
+      }
+
+      _result += state.dump;
+    }
+  }
+
+  state.tag = _tag;
+  state.dump = _result || '[]'; // Empty sequence if no valid values.
+}
+
+function writeFlowMapping(state, level, object) {
+  var _result       = '',
+      _tag          = state.tag,
+      objectKeyList = Object.keys(object),
+      index,
+      length,
+      objectKey,
+      objectValue,
+      pairBuffer;
+
+  for (index = 0, length = objectKeyList.length; index < length; index += 1) {
+    pairBuffer = state.condenseFlow ? '"' : '';
+
+    if (index !== 0) pairBuffer += ', ';
+
+    objectKey = objectKeyList[index];
+    objectValue = object[objectKey];
+
+    if (!writeNode(state, level, objectKey, false, false)) {
+      continue; // Skip this pair because of invalid key;
+    }
+
+    if (state.dump.length > 1024) pairBuffer += '? ';
+
+    pairBuffer += state.dump + (state.condenseFlow ? '"' : '') + ':' + (state.condenseFlow ? '' : ' ');
+
+    if (!writeNode(state, level, objectValue, false, false)) {
+      continue; // Skip this pair because of invalid value.
+    }
+
+    pairBuffer += state.dump;
+
+    // Both key and value are valid.
+    _result += pairBuffer;
+  }
+
+  state.tag = _tag;
+  state.dump = '{' + _result + '}';
+}
+
+function writeBlockMapping(state, level, object, compact) {
+  var _result       = '',
+      _tag          = state.tag,
+      objectKeyList = Object.keys(object),
+      index,
+      length,
+      objectKey,
+      objectValue,
+      explicitPair,
+      pairBuffer;
+
+  // Allow sorting keys so that the output file is deterministic
+  if (state.sortKeys === true) {
+    // Default sorting
+    objectKeyList.sort();
+  } else if (typeof state.sortKeys === 'function') {
+    // Custom sort function
+    objectKeyList.sort(state.sortKeys);
+  } else if (state.sortKeys) {
+    // Something is wrong
+    throw new YAMLException('sortKeys must be a boolean or a function');
+  }
+
+  for (index = 0, length = objectKeyList.length; index < length; index += 1) {
+    pairBuffer = '';
+
+    if (!compact || index !== 0) {
+      pairBuffer += generateNextLine(state, level);
+    }
+
+    objectKey = objectKeyList[index];
+    objectValue = object[objectKey];
+
+    if (!writeNode(state, level + 1, objectKey, true, true, true)) {
+      continue; // Skip this pair because of invalid key.
+    }
+
+    explicitPair = (state.tag !== null && state.tag !== '?') ||
+                   (state.dump && state.dump.length > 1024);
+
+    if (explicitPair) {
+      if (state.dump && CHAR_LINE_FEED === state.dump.charCodeAt(0)) {
+        pairBuffer += '?';
+      } else {
+        pairBuffer += '? ';
+      }
+    }
+
+    pairBuffer += state.dump;
+
+    if (explicitPair) {
+      pairBuffer += generateNextLine(state, level);
+    }
+
+    if (!writeNode(state, level + 1, objectValue, true, explicitPair)) {
+      continue; // Skip this pair because of invalid value.
+    }
+
+    if (state.dump && CHAR_LINE_FEED === state.dump.charCodeAt(0)) {
+      pairBuffer += ':';
+    } else {
+      pairBuffer += ': ';
+    }
+
+    pairBuffer += state.dump;
+
+    // Both key and value are valid.
+    _result += pairBuffer;
+  }
+
+  state.tag = _tag;
+  state.dump = _result || '{}'; // Empty mapping if no valid pairs.
+}
+
+function detectType(state, object, explicit) {
+  var _result, typeList, index, length, type, style;
+
+  typeList = explicit ? state.explicitTypes : state.implicitTypes;
+
+  for (index = 0, length = typeList.length; index < length; index += 1) {
+    type = typeList[index];
+
+    if ((type.instanceOf  || type.predicate) &&
+        (!type.instanceOf || ((typeof object === 'object') && (object instanceof type.instanceOf))) &&
+        (!type.predicate  || type.predicate(object))) {
+
+      state.tag = explicit ? type.tag : '?';
+
+      if (type.represent) {
+        style = state.styleMap[type.tag] || type.defaultStyle;
+
+        if (_toString.call(type.represent) === '[object Function]') {
+          _result = type.represent(object, style);
+        } else if (_hasOwnProperty.call(type.represent, style)) {
+          _result = type.represent[style](object, style);
+        } else {
+          throw new YAMLException('!<' + type.tag + '> tag resolver accepts not "' + style + '" style');
+        }
+
+        state.dump = _result;
+      }
+
+      return true;
+    }
+  }
+
+  return false;
+}
+
+// Serializes `object` and writes it to global `result`.
+// Returns true on success, or false on invalid object.
+//
+function writeNode(state, level, object, block, compact, iskey) {
+  state.tag = null;
+  state.dump = object;
+
+  if (!detectType(state, object, false)) {
+    detectType(state, object, true);
+  }
+
+  var type = _toString.call(state.dump);
+
+  if (block) {
+    block = (state.flowLevel < 0 || state.flowLevel > level);
+  }
+
+  var objectOrArray = type === '[object Object]' || type === '[object Array]',
+      duplicateIndex,
+      duplicate;
+
+  if (objectOrArray) {
+    duplicateIndex = state.duplicates.indexOf(object);
+    duplicate = duplicateIndex !== -1;
+  }
+
+  if ((state.tag !== null && state.tag !== '?') || duplicate || (state.indent !== 2 && level > 0)) {
+    compact = false;
+  }
+
+  if (duplicate && state.usedDuplicates[duplicateIndex]) {
+    state.dump = '*ref_' + duplicateIndex;
+  } else {
+    if (objectOrArray && duplicate && !state.usedDuplicates[duplicateIndex]) {
+      state.usedDuplicates[duplicateIndex] = true;
+    }
+    if (type === '[object Object]') {
+      if (block && (Object.keys(state.dump).length !== 0)) {
+        writeBlockMapping(state, level, state.dump, compact);
+        if (duplicate) {
+          state.dump = '&ref_' + duplicateIndex + state.dump;
+        }
+      } else {
+        writeFlowMapping(state, level, state.dump);
+        if (duplicate) {
+          state.dump = '&ref_' + duplicateIndex + ' ' + state.dump;
+        }
+      }
+    } else if (type === '[object Array]') {
+      if (block && (state.dump.length !== 0)) {
+        writeBlockSequence(state, level, state.dump, compact);
+        if (duplicate) {
+          state.dump = '&ref_' + duplicateIndex + state.dump;
+        }
+      } else {
+        writeFlowSequence(state, level, state.dump);
+        if (duplicate) {
+          state.dump = '&ref_' + duplicateIndex + ' ' + state.dump;
+        }
+      }
+    } else if (type === '[object String]') {
+      if (state.tag !== '?') {
+        writeScalar(state, state.dump, level, iskey);
+      }
+    } else {
+      if (state.skipInvalid) return false;
+      throw new YAMLException('unacceptable kind of an object to dump ' + type);
+    }
+
+    if (state.tag !== null && state.tag !== '?') {
+      state.dump = '!<' + state.tag + '> ' + state.dump;
+    }
+  }
+
+  return true;
+}
+
+function getDuplicateReferences(object, state) {
+  var objects = [],
+      duplicatesIndexes = [],
+      index,
+      length;
+
+  inspectNode(object, objects, duplicatesIndexes);
+
+  for (index = 0, length = duplicatesIndexes.length; index < length; index += 1) {
+    state.duplicates.push(objects[duplicatesIndexes[index]]);
+  }
+  state.usedDuplicates = new Array(length);
+}
+
+function inspectNode(object, objects, duplicatesIndexes) {
+  var objectKeyList,
+      index,
+      length;
+
+  if (object !== null && typeof object === 'object') {
+    index = objects.indexOf(object);
+    if (index !== -1) {
+      if (duplicatesIndexes.indexOf(index) === -1) {
+        duplicatesIndexes.push(index);
+      }
+    } else {
+      objects.push(object);
+
+      if (Array.isArray(object)) {
+        for (index = 0, length = object.length; index < length; index += 1) {
+          inspectNode(object[index], objects, duplicatesIndexes);
+        }
+      } else {
+        objectKeyList = Object.keys(object);
+
+        for (index = 0, length = objectKeyList.length; index < length; index += 1) {
+          inspectNode(object[objectKeyList[index]], objects, duplicatesIndexes);
+        }
+      }
+    }
+  }
+}
+
+function dump(input, options) {
+  options = options || {};
+
+  var state = new State(options);
+
+  if (!state.noRefs) getDuplicateReferences(input, state);
+
+  if (writeNode(state, 0, input, true, true)) return state.dump + '\n';
+
+  return '';
+}
+
+function safeDump(input, options) {
+  return dump(input, common.extend({ schema: DEFAULT_SAFE_SCHEMA }, options));
+}
+
+module.exports.dump     = dump;
+module.exports.safeDump = safeDump;
+
+},{"./common":2,"./exception":4,"./schema/default_full":9,"./schema/default_safe":10}],4:[function(require,module,exports){
+// YAML error class. http://stackoverflow.com/questions/8458984
+//
+'use strict';
+
+function YAMLException(reason, mark) {
+  // Super constructor
+  Error.call(this);
+
+  this.name = 'YAMLException';
+  this.reason = reason;
+  this.mark = mark;
+  this.message = (this.reason || '(unknown reason)') + (this.mark ? ' ' + this.mark.toString() : '');
+
+  // Include stack trace in error object
+  if (Error.captureStackTrace) {
+    // Chrome and NodeJS
+    Error.captureStackTrace(this, this.constructor);
+  } else {
+    // FF, IE 10+ and Safari 6+. Fallback for others
+    this.stack = (new Error()).stack || '';
+  }
+}
+
+
+// Inherit from Error
+YAMLException.prototype = Object.create(Error.prototype);
+YAMLException.prototype.constructor = YAMLException;
+
+
+YAMLException.prototype.toString = function toString(compact) {
+  var result = this.name + ': ';
+
+  result += this.reason || '(unknown reason)';
+
+  if (!compact && this.mark) {
+    result += ' ' + this.mark.toString();
+  }
+
+  return result;
+};
+
+
+module.exports = YAMLException;
+
+},{}],5:[function(require,module,exports){
+'use strict';
+
+/*eslint-disable max-len,no-use-before-define*/
+
+var common              = require('./common');
+var YAMLException       = require('./exception');
+var Mark                = require('./mark');
+var DEFAULT_SAFE_SCHEMA = require('./schema/default_safe');
+var DEFAULT_FULL_SCHEMA = require('./schema/default_full');
+
+
+var _hasOwnProperty = Object.prototype.hasOwnProperty;
+
+
+var CONTEXT_FLOW_IN   = 1;
+var CONTEXT_FLOW_OUT  = 2;
+var CONTEXT_BLOCK_IN  = 3;
+var CONTEXT_BLOCK_OUT = 4;
+
+
+var CHOMPING_CLIP  = 1;
+var CHOMPING_STRIP = 2;
+var CHOMPING_KEEP  = 3;
+
+
+var PATTERN_NON_PRINTABLE         = /[\x00-\x08\x0B\x0C\x0E-\x1F\x7F-\x84\x86-\x9F\uFFFE\uFFFF]/;
+var PATTERN_NON_ASCII_LINE_BREAKS = /[\x85\u2028\u2029]/;
+var PATTERN_FLOW_INDICATORS       = /[,\[\]\{\}]/;
+var PATTERN_TAG_HANDLE            = /^(?:!|!!|![a-z\-]+!)$/i;
+var PATTERN_TAG_URI               = /^(?:!|[^,\[\]\{\}])(?:%[0-9a-f]{2}|[0-9a-z\-#;\/\?:@&=\+\$,_\.!~\*'\(\)\[\]])*$/i;
+
+
+function is_EOL(c) {
+  return (c === 0x0A/* LF */) || (c === 0x0D/* CR */);
+}
+
+function is_WHITE_SPACE(c) {
+  return (c === 0x09/* Tab */) || (c === 0x20/* Space */);
+}
+
+function is_WS_OR_EOL(c) {
+  return (c === 0x09/* Tab */) ||
+         (c === 0x20/* Space */) ||
+         (c === 0x0A/* LF */) ||
+         (c === 0x0D/* CR */);
+}
+
+function is_FLOW_INDICATOR(c) {
+  return c === 0x2C/* , */ ||
+         c === 0x5B/* [ */ ||
+         c === 0x5D/* ] */ ||
+         c === 0x7B/* { */ ||
+         c === 0x7D/* } */;
+}
+
+function fromHexCode(c) {
+  var lc;
+
+  if ((0x30/* 0 */ <= c) && (c <= 0x39/* 9 */)) {
+    return c - 0x30;
+  }
+
+  /*eslint-disable no-bitwise*/
+  lc = c | 0x20;
+
+  if ((0x61/* a */ <= lc) && (lc <= 0x66/* f */)) {
+    return lc - 0x61 + 10;
+  }
+
+  return -1;
+}
+
+function escapedHexLen(c) {
+  if (c === 0x78/* x */) { return 2; }
+  if (c === 0x75/* u */) { return 4; }
+  if (c === 0x55/* U */) { return 8; }
+  return 0;
+}
+
+function fromDecimalCode(c) {
+  if ((0x30/* 0 */ <= c) && (c <= 0x39/* 9 */)) {
+    return c - 0x30;
+  }
+
+  return -1;
+}
+
+function simpleEscapeSequence(c) {
+  /* eslint-disable indent */
+  return (c === 0x30/* 0 */) ? '\x00' :
+        (c === 0x61/* a */) ? '\x07' :
+        (c === 0x62/* b */) ? '\x08' :
+        (c === 0x74/* t */) ? '\x09' :
+        (c === 0x09/* Tab */) ? '\x09' :
+        (c === 0x6E/* n */) ? '\x0A' :
+        (c === 0x76/* v */) ? '\x0B' :
+        (c === 0x66/* f */) ? '\x0C' :
+        (c === 0x72/* r */) ? '\x0D' :
+        (c === 0x65/* e */) ? '\x1B' :
+        (c === 0x20/* Space */) ? ' ' :
+        (c === 0x22/* " */) ? '\x22' :
+        (c === 0x2F/* / */) ? '/' :
+        (c === 0x5C/* \ */) ? '\x5C' :
+        (c === 0x4E/* N */) ? '\x85' :
+        (c === 0x5F/* _ */) ? '\xA0' :
+        (c === 0x4C/* L */) ? '\u2028' :
+        (c === 0x50/* P */) ? '\u2029' : '';
+}
+
+function charFromCodepoint(c) {
+  if (c <= 0xFFFF) {
+    return String.fromCharCode(c);
+  }
+  // Encode UTF-16 surrogate pair
+  // https://en.wikipedia.org/wiki/UTF-16#Code_points_U.2B010000_to_U.2B10FFFF
+  return String.fromCharCode(
+    ((c - 0x010000) >> 10) + 0xD800,
+    ((c - 0x010000) & 0x03FF) + 0xDC00
+  );
+}
+
+var simpleEscapeCheck = new Array(256); // integer, for fast access
+var simpleEscapeMap = new Array(256);
+for (var i = 0; i < 256; i++) {
+  simpleEscapeCheck[i] = simpleEscapeSequence(i) ? 1 : 0;
+  simpleEscapeMap[i] = simpleEscapeSequence(i);
+}
+
+
+function State(input, options) {
+  this.input = input;
+
+  this.filename  = options['filename']  || null;
+  this.schema    = options['schema']    || DEFAULT_FULL_SCHEMA;
+  this.onWarning = options['onWarning'] || null;
+  this.legacy    = options['legacy']    || false;
+  this.json      = options['json']      || false;
+  this.listener  = options['listener']  || null;
+
+  this.implicitTypes = this.schema.compiledImplicit;
+  this.typeMap       = this.schema.compiledTypeMap;
+
+  this.length     = input.length;
+  this.position   = 0;
+  this.line       = 0;
+  this.lineStart  = 0;
+  this.lineIndent = 0;
+
+  this.documents = [];
+
+  /*
+  this.version;
+  this.checkLineBreaks;
+  this.tagMap;
+  this.anchorMap;
+  this.tag;
+  this.anchor;
+  this.kind;
+  this.result;*/
+
+}
+
+
+function generateError(state, message) {
+  return new YAMLException(
+    message,
+    new Mark(state.filename, state.input, state.position, state.line, (state.position - state.lineStart)));
+}
+
+function throwError(state, message) {
+  throw generateError(state, message);
+}
+
+function throwWarning(state, message) {
+  if (state.onWarning) {
+    state.onWarning.call(null, generateError(state, message));
+  }
+}
+
+
+var directiveHandlers = {
+
+  YAML: function handleYamlDirective(state, name, args) {
+
+    var match, major, minor;
+
+    if (state.version !== null) {
+      throwError(state, 'duplication of %YAML directive');
+    }
+
+    if (args.length !== 1) {
+      throwError(state, 'YAML directive accepts exactly one argument');
+    }
+
+    match = /^([0-9]+)\.([0-9]+)$/.exec(args[0]);
+
+    if (match === null) {
+      throwError(state, 'ill-formed argument of the YAML directive');
+    }
+
+    major = parseInt(match[1], 10);
+    minor = parseInt(match[2], 10);
+
+    if (major !== 1) {
+      throwError(state, 'unacceptable YAML version of the document');
+    }
+
+    state.version = args[0];
+    state.checkLineBreaks = (minor < 2);
+
+    if (minor !== 1 && minor !== 2) {
+      throwWarning(state, 'unsupported YAML version of the document');
+    }
+  },
+
+  TAG: function handleTagDirective(state, name, args) {
+
+    var handle, prefix;
+
+    if (args.length !== 2) {
+      throwError(state, 'TAG directive accepts exactly two arguments');
+    }
+
+    handle = args[0];
+    prefix = args[1];
+
+    if (!PATTERN_TAG_HANDLE.test(handle)) {
+      throwError(state, 'ill-formed tag handle (first argument) of the TAG directive');
+    }
+
+    if (_hasOwnProperty.call(state.tagMap, handle)) {
+      throwError(state, 'there is a previously declared suffix for "' + handle + '" tag handle');
+    }
+
+    if (!PATTERN_TAG_URI.test(prefix)) {
+      throwError(state, 'ill-formed tag prefix (second argument) of the TAG directive');
+    }
+
+    state.tagMap[handle] = prefix;
+  }
+};
+
+
+function captureSegment(state, start, end, checkJson) {
+  var _position, _length, _character, _result;
+
+  if (start < end) {
+    _result = state.input.slice(start, end);
+
+    if (checkJson) {
+      for (_position = 0, _length = _result.length; _position < _length; _position += 1) {
+        _character = _result.charCodeAt(_position);
+        if (!(_character === 0x09 ||
+              (0x20 <= _character && _character <= 0x10FFFF))) {
+          throwError(state, 'expected valid JSON character');
+        }
+      }
+    } else if (PATTERN_NON_PRINTABLE.test(_result)) {
+      throwError(state, 'the stream contains non-printable characters');
+    }
+
+    state.result += _result;
+  }
+}
+
+function mergeMappings(state, destination, source, overridableKeys) {
+  var sourceKeys, key, index, quantity;
+
+  if (!common.isObject(source)) {
+    throwError(state, 'cannot merge mappings; the provided source object is unacceptable');
+  }
+
+  sourceKeys = Object.keys(source);
+
+  for (index = 0, quantity = sourceKeys.length; index < quantity; index += 1) {
+    key = sourceKeys[index];
+
+    if (!_hasOwnProperty.call(destination, key)) {
+      destination[key] = source[key];
+      overridableKeys[key] = true;
+    }
+  }
+}
+
+function storeMappingPair(state, _result, overridableKeys, keyTag, keyNode, valueNode, startLine, startPos) {
+  var index, quantity;
+
+  // keyNode = String(keyNode);
+
+  if (_result === null) {
+    _result = {};
+  }
+
+  if (keyTag === 'tag:yaml.org,2002:merge') {
+    if (Array.isArray(valueNode)) {
+      for (index = 0, quantity = valueNode.length; index < quantity; index += 1) {
+        mergeMappings(state, _result, valueNode[index], overridableKeys);
+      }
+    } else {
+      mergeMappings(state, _result, valueNode, overridableKeys);
+    }
+  } else {
+    if (!state.json &&
+        !_hasOwnProperty.call(overridableKeys, keyNode) &&
+        _hasOwnProperty.call(_result, keyNode)) {
+      state.line = startLine || state.line;
+      state.position = startPos || state.position;
+      throwError(state, 'duplicated mapping key');
+    }
+    _result[keyNode] = valueNode;
+    delete overridableKeys[keyNode];
+  }
+
+  return _result;
+}
+
+function readLineBreak(state) {
+  var ch;
+
+  ch = state.input.charCodeAt(state.position);
+
+  if (ch === 0x0A/* LF */) {
+    state.position++;
+  } else if (ch === 0x0D/* CR */) {
+    state.position++;
+    if (state.input.charCodeAt(state.position) === 0x0A/* LF */) {
+      state.position++;
+    }
+  } else {
+    throwError(state, 'a line break is expected');
+  }
+
+  state.line += 1;
+  state.lineStart = state.position;
+}
+
+function skipSeparationSpace(state, allowComments, checkIndent) {
+  var lineBreaks = 0,
+      ch = state.input.charCodeAt(state.position);
+
+  while (ch !== 0) {
+    while (is_WHITE_SPACE(ch)) {
+      ch = state.input.charCodeAt(++state.position);
+    }
+
+    if (allowComments && ch === 0x23/* # */) {
+      do {
+        ch = state.input.charCodeAt(++state.position);
+      } while (ch !== 0x0A/* LF */ && ch !== 0x0D/* CR */ && ch !== 0);
+    }
+
+    if (is_EOL(ch)) {
+      readLineBreak(state);
+
+      ch = state.input.charCodeAt(state.position);
+      lineBreaks++;
+      state.lineIndent = 0;
+
+      while (ch === 0x20/* Space */) {
+        state.lineIndent++;
+        ch = state.input.charCodeAt(++state.position);
+      }
+    } else {
+      break;
+    }
+  }
+
+  if (checkIndent !== -1 && lineBreaks !== 0 && state.lineIndent < checkIndent) {
+    throwWarning(state, 'deficient indentation');
+  }
+
+  return lineBreaks;
+}
+
+function testDocumentSeparator(state) {
+  var _position = state.position,
+      ch;
+
+  ch = state.input.charCodeAt(_position);
+
+  // Condition state.position === state.lineStart is tested
+  // in parent on each call, for efficiency. No needs to test here again.
+  if ((ch === 0x2D/* - */ || ch === 0x2E/* . */) &&
+      ch === state.input.charCodeAt(_position + 1) &&
+      ch === state.input.charCodeAt(_position + 2)) {
+
+    _position += 3;
+
+    ch = state.input.charCodeAt(_position);
+
+    if (ch === 0 || is_WS_OR_EOL(ch)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function writeFoldedLines(state, count) {
+  if (count === 1) {
+    state.result += ' ';
+  } else if (count > 1) {
+    state.result += common.repeat('\n', count - 1);
+  }
+}
+
+
+function readPlainScalar(state, nodeIndent, withinFlowCollection) {
+  var preceding,
+      following,
+      captureStart,
+      captureEnd,
+      hasPendingContent,
+      _line,
+      _lineStart,
+      _lineIndent,
+      _kind = state.kind,
+      _result = state.result,
+      ch;
+
+  ch = state.input.charCodeAt(state.position);
+
+  if (is_WS_OR_EOL(ch)      ||
+      is_FLOW_INDICATOR(ch) ||
+      ch === 0x23/* # */    ||
+      ch === 0x26/* & */    ||
+      ch === 0x2A/* * */    ||
+      ch === 0x21/* ! */    ||
+      ch === 0x7C/* | */    ||
+      ch === 0x3E/* > */    ||
+      ch === 0x27/* ' */    ||
+      ch === 0x22/* " */    ||
+      ch === 0x25/* % */    ||
+      ch === 0x40/* @ */    ||
+      ch === 0x60/* ` */) {
+    return false;
+  }
+
+  if (ch === 0x3F/* ? */ || ch === 0x2D/* - */) {
+    following = state.input.charCodeAt(state.position + 1);
+
+    if (is_WS_OR_EOL(following) ||
+        withinFlowCollection && is_FLOW_INDICATOR(following)) {
+      return false;
+    }
+  }
+
+  state.kind = 'scalar';
+  state.result = '';
+  captureStart = captureEnd = state.position;
+  hasPendingContent = false;
+
+  while (ch !== 0) {
+    if (ch === 0x3A/* : */) {
+      following = state.input.charCodeAt(state.position + 1);
+
+      if (is_WS_OR_EOL(following) ||
+          withinFlowCollection && is_FLOW_INDICATOR(following)) {
+        break;
+      }
+
+    } else if (ch === 0x23/* # */) {
+      preceding = state.input.charCodeAt(state.position - 1);
+
+      if (is_WS_OR_EOL(preceding)) {
+        break;
+      }
+
+    } else if ((state.position === state.lineStart && testDocumentSeparator(state)) ||
+               withinFlowCollection && is_FLOW_INDICATOR(ch)) {
+      break;
+
+    } else if (is_EOL(ch)) {
+      _line = state.line;
+      _lineStart = state.lineStart;
+      _lineIndent = state.lineIndent;
+      skipSeparationSpace(state, false, -1);
+
+      if (state.lineIndent >= nodeIndent) {
+        hasPendingContent = true;
+        ch = state.input.charCodeAt(state.position);
+        continue;
+      } else {
+        state.position = captureEnd;
+        state.line = _line;
+        state.lineStart = _lineStart;
+        state.lineIndent = _lineIndent;
+        break;
+      }
+    }
+
+    if (hasPendingContent) {
+      captureSegment(state, captureStart, captureEnd, false);
+      writeFoldedLines(state, state.line - _line);
+      captureStart = captureEnd = state.position;
+      hasPendingContent = false;
+    }
+
+    if (!is_WHITE_SPACE(ch)) {
+      captureEnd = state.position + 1;
+    }
+
+    ch = state.input.charCodeAt(++state.position);
+  }
+
+  captureSegment(state, captureStart, captureEnd, false);
+
+  if (state.result) {
+    return true;
+  }
+
+  state.kind = _kind;
+  state.result = _result;
+  return false;
+}
+
+function readSingleQuotedScalar(state, nodeIndent) {
+  var ch,
+      captureStart, captureEnd;
+
+  ch = state.input.charCodeAt(state.position);
+
+  if (ch !== 0x27/* ' */) {
+    return false;
+  }
+
+  state.kind = 'scalar';
+  state.result = '';
+  state.position++;
+  captureStart = captureEnd = state.position;
+
+  while ((ch = state.input.charCodeAt(state.position)) !== 0) {
+    if (ch === 0x27/* ' */) {
+      captureSegment(state, captureStart, state.position, true);
+      ch = state.input.charCodeAt(++state.position);
+
+      if (ch === 0x27/* ' */) {
+        captureStart = state.position;
+        state.position++;
+        captureEnd = state.position;
+      } else {
+        return true;
+      }
+
+    } else if (is_EOL(ch)) {
+      captureSegment(state, captureStart, captureEnd, true);
+      writeFoldedLines(state, skipSeparationSpace(state, false, nodeIndent));
+      captureStart = captureEnd = state.position;
+
+    } else if (state.position === state.lineStart && testDocumentSeparator(state)) {
+      throwError(state, 'unexpected end of the document within a single quoted scalar');
+
+    } else {
+      state.position++;
+      captureEnd = state.position;
+    }
+  }
+
+  throwError(state, 'unexpected end of the stream within a single quoted scalar');
+}
+
+function readDoubleQuotedScalar(state, nodeIndent) {
+  var captureStart,
+      captureEnd,
+      hexLength,
+      hexResult,
+      tmp,
+      ch;
+
+  ch = state.input.charCodeAt(state.position);
+
+  if (ch !== 0x22/* " */) {
+    return false;
+  }
+
+  state.kind = 'scalar';
+  state.result = '';
+  state.position++;
+  captureStart = captureEnd = state.position;
+
+  while ((ch = state.input.charCodeAt(state.position)) !== 0) {
+    if (ch === 0x22/* " */) {
+      captureSegment(state, captureStart, state.position, true);
+      state.position++;
+      return true;
+
+    } else if (ch === 0x5C/* \ */) {
+      captureSegment(state, captureStart, state.position, true);
+      ch = state.input.charCodeAt(++state.position);
+
+      if (is_EOL(ch)) {
+        skipSeparationSpace(state, false, nodeIndent);
+
+        // TODO: rework to inline fn with no type cast?
+      } else if (ch < 256 && simpleEscapeCheck[ch]) {
+        state.result += simpleEscapeMap[ch];
+        state.position++;
+
+      } else if ((tmp = escapedHexLen(ch)) > 0) {
+        hexLength = tmp;
+        hexResult = 0;
+
+        for (; hexLength > 0; hexLength--) {
+          ch = state.input.charCodeAt(++state.position);
+
+          if ((tmp = fromHexCode(ch)) >= 0) {
+            hexResult = (hexResult << 4) + tmp;
+
+          } else {
+            throwError(state, 'expected hexadecimal character');
+          }
+        }
+
+        state.result += charFromCodepoint(hexResult);
+
+        state.position++;
+
+      } else {
+        throwError(state, 'unknown escape sequence');
+      }
+
+      captureStart = captureEnd = state.position;
+
+    } else if (is_EOL(ch)) {
+      captureSegment(state, captureStart, captureEnd, true);
+      writeFoldedLines(state, skipSeparationSpace(state, false, nodeIndent));
+      captureStart = captureEnd = state.position;
+
+    } else if (state.position === state.lineStart && testDocumentSeparator(state)) {
+      throwError(state, 'unexpected end of the document within a double quoted scalar');
+
+    } else {
+      state.position++;
+      captureEnd = state.position;
+    }
+  }
+
+  throwError(state, 'unexpected end of the stream within a double quoted scalar');
+}
+
+function readFlowCollection(state, nodeIndent) {
+  var readNext = true,
+      _line,
+      _tag     = state.tag,
+      _result,
+      _anchor  = state.anchor,
+      following,
+      terminator,
+      isPair,
+      isExplicitPair,
+      isMapping,
+      overridableKeys = {},
+      keyNode,
+      keyTag,
+      valueNode,
+      ch;
+
+  ch = state.input.charCodeAt(state.position);
+
+  if (ch === 0x5B/* [ */) {
+    terminator = 0x5D;/* ] */
+    isMapping = false;
+    _result = [];
+  } else if (ch === 0x7B/* { */) {
+    terminator = 0x7D;/* } */
+    isMapping = true;
+    _result = {};
+  } else {
+    return false;
+  }
+
+  if (state.anchor !== null) {
+    state.anchorMap[state.anchor] = _result;
+  }
+
+  ch = state.input.charCodeAt(++state.position);
+
+  while (ch !== 0) {
+    skipSeparationSpace(state, true, nodeIndent);
+
+    ch = state.input.charCodeAt(state.position);
+
+    if (ch === terminator) {
+      state.position++;
+      state.tag = _tag;
+      state.anchor = _anchor;
+      state.kind = isMapping ? 'mapping' : 'sequence';
+      state.result = _result;
+      return true;
+    } else if (!readNext) {
+      throwError(state, 'missed comma between flow collection entries');
+    }
+
+    keyTag = keyNode = valueNode = null;
+    isPair = isExplicitPair = false;
+
+    if (ch === 0x3F/* ? */) {
+      following = state.input.charCodeAt(state.position + 1);
+
+      if (is_WS_OR_EOL(following)) {
+        isPair = isExplicitPair = true;
+        state.position++;
+        skipSeparationSpace(state, true, nodeIndent);
+      }
+    }
+
+    _line = state.line;
+    composeNode(state, nodeIndent, CONTEXT_FLOW_IN, false, true);
+    keyTag = state.tag;
+    keyNode = state.result;
+    skipSeparationSpace(state, true, nodeIndent);
+
+    ch = state.input.charCodeAt(state.position);
+
+    if ((isExplicitPair || state.line === _line) && ch === 0x3A/* : */) {
+      isPair = true;
+      ch = state.input.charCodeAt(++state.position);
+      skipSeparationSpace(state, true, nodeIndent);
+      composeNode(state, nodeIndent, CONTEXT_FLOW_IN, false, true);
+      valueNode = state.result;
+    }
+
+    if (isMapping) {
+      storeMappingPair(state, _result, overridableKeys, keyTag, keyNode, valueNode);
+    } else if (isPair) {
+      _result.push(storeMappingPair(state, null, overridableKeys, keyTag, keyNode, valueNode));
+    } else {
+      _result.push(keyNode);
+    }
+
+    skipSeparationSpace(state, true, nodeIndent);
+
+    ch = state.input.charCodeAt(state.position);
+
+    if (ch === 0x2C/* , */) {
+      readNext = true;
+      ch = state.input.charCodeAt(++state.position);
+    } else {
+      readNext = false;
+    }
+  }
+
+  throwError(state, 'unexpected end of the stream within a flow collection');
+}
+
+function readBlockScalar(state, nodeIndent) {
+  var captureStart,
+      folding,
+      chomping       = CHOMPING_CLIP,
+      didReadContent = false,
+      detectedIndent = false,
+      textIndent     = nodeIndent,
+      emptyLines     = 0,
+      atMoreIndented = false,
+      tmp,
+      ch;
+
+  ch = state.input.charCodeAt(state.position);
+
+  if (ch === 0x7C/* | */) {
+    folding = false;
+  } else if (ch === 0x3E/* > */) {
+    folding = true;
+  } else {
+    return false;
+  }
+
+  state.kind = 'scalar';
+  state.result = '';
+
+  while (ch !== 0) {
+    ch = state.input.charCodeAt(++state.position);
+
+    if (ch === 0x2B/* + */ || ch === 0x2D/* - */) {
+      if (CHOMPING_CLIP === chomping) {
+        chomping = (ch === 0x2B/* + */) ? CHOMPING_KEEP : CHOMPING_STRIP;
+      } else {
+        throwError(state, 'repeat of a chomping mode identifier');
+      }
+
+    } else if ((tmp = fromDecimalCode(ch)) >= 0) {
+      if (tmp === 0) {
+        throwError(state, 'bad explicit indentation width of a block scalar; it cannot be less than one');
+      } else if (!detectedIndent) {
+        textIndent = nodeIndent + tmp - 1;
+        detectedIndent = true;
+      } else {
+        throwError(state, 'repeat of an indentation width identifier');
+      }
+
+    } else {
+      break;
+    }
+  }
+
+  if (is_WHITE_SPACE(ch)) {
+    do { ch = state.input.charCodeAt(++state.position); }
+    while (is_WHITE_SPACE(ch));
+
+    if (ch === 0x23/* # */) {
+      do { ch = state.input.charCodeAt(++state.position); }
+      while (!is_EOL(ch) && (ch !== 0));
+    }
+  }
+
+  while (ch !== 0) {
+    readLineBreak(state);
+    state.lineIndent = 0;
+
+    ch = state.input.charCodeAt(state.position);
+
+    while ((!detectedIndent || state.lineIndent < textIndent) &&
+           (ch === 0x20/* Space */)) {
+      state.lineIndent++;
+      ch = state.input.charCodeAt(++state.position);
+    }
+
+    if (!detectedIndent && state.lineIndent > textIndent) {
+      textIndent = state.lineIndent;
+    }
+
+    if (is_EOL(ch)) {
+      emptyLines++;
+      continue;
+    }
+
+    // End of the scalar.
+    if (state.lineIndent < textIndent) {
+
+      // Perform the chomping.
+      if (chomping === CHOMPING_KEEP) {
+        state.result += common.repeat('\n', didReadContent ? 1 + emptyLines : emptyLines);
+      } else if (chomping === CHOMPING_CLIP) {
+        if (didReadContent) { // i.e. only if the scalar is not empty.
+          state.result += '\n';
+        }
+      }
+
+      // Break this `while` cycle and go to the funciton's epilogue.
+      break;
+    }
+
+    // Folded style: use fancy rules to handle line breaks.
+    if (folding) {
+
+      // Lines starting with white space characters (more-indented lines) are not folded.
+      if (is_WHITE_SPACE(ch)) {
+        atMoreIndented = true;
+        // except for the first content line (cf. Example 8.1)
+        state.result += common.repeat('\n', didReadContent ? 1 + emptyLines : emptyLines);
+
+      // End of more-indented block.
+      } else if (atMoreIndented) {
+        atMoreIndented = false;
+        state.result += common.repeat('\n', emptyLines + 1);
+
+      // Just one line break - perceive as the same line.
+      } else if (emptyLines === 0) {
+        if (didReadContent) { // i.e. only if we have already read some scalar content.
+          state.result += ' ';
+        }
+
+      // Several line breaks - perceive as different lines.
+      } else {
+        state.result += common.repeat('\n', emptyLines);
+      }
+
+    // Literal style: just add exact number of line breaks between content lines.
+    } else {
+      // Keep all line breaks except the header line break.
+      state.result += common.repeat('\n', didReadContent ? 1 + emptyLines : emptyLines);
+    }
+
+    didReadContent = true;
+    detectedIndent = true;
+    emptyLines = 0;
+    captureStart = state.position;
+
+    while (!is_EOL(ch) && (ch !== 0)) {
+      ch = state.input.charCodeAt(++state.position);
+    }
+
+    captureSegment(state, captureStart, state.position, false);
+  }
+
+  return true;
+}
+
+function readBlockSequence(state, nodeIndent) {
+  var _line,
+      _tag      = state.tag,
+      _anchor   = state.anchor,
+      _result   = [],
+      following,
+      detected  = false,
+      ch;
+
+  if (state.anchor !== null) {
+    state.anchorMap[state.anchor] = _result;
+  }
+
+  ch = state.input.charCodeAt(state.position);
+
+  while (ch !== 0) {
+
+    if (ch !== 0x2D/* - */) {
+      break;
+    }
+
+    following = state.input.charCodeAt(state.position + 1);
+
+    if (!is_WS_OR_EOL(following)) {
+      break;
+    }
+
+    detected = true;
+    state.position++;
+
+    if (skipSeparationSpace(state, true, -1)) {
+      if (state.lineIndent <= nodeIndent) {
+        _result.push(null);
+        ch = state.input.charCodeAt(state.position);
+        continue;
+      }
+    }
+
+    _line = state.line;
+    composeNode(state, nodeIndent, CONTEXT_BLOCK_IN, false, true);
+    _result.push(state.result);
+    skipSeparationSpace(state, true, -1);
+
+    ch = state.input.charCodeAt(state.position);
+
+    if ((state.line === _line || state.lineIndent > nodeIndent) && (ch !== 0)) {
+      throwError(state, 'bad indentation of a sequence entry');
+    } else if (state.lineIndent < nodeIndent) {
+      break;
+    }
+  }
+
+  if (detected) {
+    state.tag = _tag;
+    state.anchor = _anchor;
+    state.kind = 'sequence';
+    state.result = _result;
+    return true;
+  }
+  return false;
+}
+
+function readBlockMapping(state, nodeIndent, flowIndent) {
+  var following,
+      allowCompact,
+      _line,
+      _pos,
+      _tag          = state.tag,
+      _anchor       = state.anchor,
+      _result       = {},
+      overridableKeys = {},
+      keyTag        = null,
+      keyNode       = null,
+      valueNode     = null,
+      atExplicitKey = false,
+      detected      = false,
+      ch;
+
+  if (state.anchor !== null) {
+    state.anchorMap[state.anchor] = _result;
+  }
+
+  ch = state.input.charCodeAt(state.position);
+
+  while (ch !== 0) {
+    following = state.input.charCodeAt(state.position + 1);
+    _line = state.line; // Save the current line.
+    _pos = state.position;
+
+    //
+    // Explicit notation case. There are two separate blocks:
+    // first for the key (denoted by "?") and second for the value (denoted by ":")
+    //
+    if ((ch === 0x3F/* ? */ || ch === 0x3A/* : */) && is_WS_OR_EOL(following)) {
+
+      if (ch === 0x3F/* ? */) {
+        if (atExplicitKey) {
+          storeMappingPair(state, _result, overridableKeys, keyTag, keyNode, null);
+          keyTag = keyNode = valueNode = null;
+        }
+
+        detected = true;
+        atExplicitKey = true;
+        allowCompact = true;
+
+      } else if (atExplicitKey) {
+        // i.e. 0x3A/* : */ === character after the explicit key.
+        atExplicitKey = false;
+        allowCompact = true;
+
+      } else {
+        throwError(state, 'incomplete explicit mapping pair; a key node is missed; or followed by a non-tabulated empty line');
+      }
+
+      state.position += 1;
+      ch = following;
+
+    //
+    // Implicit notation case. Flow-style node as the key first, then ":", and the value.
+    //
+    } else if (composeNode(state, flowIndent, CONTEXT_FLOW_OUT, false, true)) {
+
+      if (state.line === _line) {
+        ch = state.input.charCodeAt(state.position);
+
+        while (is_WHITE_SPACE(ch)) {
+          ch = state.input.charCodeAt(++state.position);
+        }
+
+        if (ch === 0x3A/* : */) {
+          ch = state.input.charCodeAt(++state.position);
+
+          if (!is_WS_OR_EOL(ch)) {
+            throwError(state, 'a whitespace character is expected after the key-value separator within a block mapping');
+          }
+
+          if (atExplicitKey) {
+            storeMappingPair(state, _result, overridableKeys, keyTag, keyNode, null);
+            keyTag = keyNode = valueNode = null;
+          }
+
+          detected = true;
+          atExplicitKey = false;
+          allowCompact = false;
+          keyTag = state.tag;
+          keyNode = state.result;
+
+        } else if (detected) {
+          throwError(state, 'can not read an implicit mapping pair; a colon is missed');
+
+        } else {
+          state.tag = _tag;
+          state.anchor = _anchor;
+          return true; // Keep the result of `composeNode`.
+        }
+
+      } else if (detected) {
+        throwError(state, 'can not read a block mapping entry; a multiline key may not be an implicit key');
+
+      } else {
+        state.tag = _tag;
+        state.anchor = _anchor;
+        return true; // Keep the result of `composeNode`.
+      }
+
+    } else {
+      break; // Reading is done. Go to the epilogue.
+    }
+
+    //
+    // Common reading code for both explicit and implicit notations.
+    //
+    if (state.line === _line || state.lineIndent > nodeIndent) {
+      if (composeNode(state, nodeIndent, CONTEXT_BLOCK_OUT, true, allowCompact)) {
+        if (atExplicitKey) {
+          keyNode = state.result;
+        } else {
+          valueNode = state.result;
+        }
+      }
+
+      if (!atExplicitKey) {
+        storeMappingPair(state, _result, overridableKeys, keyTag, keyNode, valueNode, _line, _pos);
+        keyTag = keyNode = valueNode = null;
+      }
+
+      skipSeparationSpace(state, true, -1);
+      ch = state.input.charCodeAt(state.position);
+    }
+
+    if (state.lineIndent > nodeIndent && (ch !== 0)) {
+      throwError(state, 'bad indentation of a mapping entry');
+    } else if (state.lineIndent < nodeIndent) {
+      break;
+    }
+  }
+
+  //
+  // Epilogue.
+  //
+
+  // Special case: last mapping's node contains only the key in explicit notation.
+  if (atExplicitKey) {
+    storeMappingPair(state, _result, overridableKeys, keyTag, keyNode, null);
+  }
+
+  // Expose the resulting mapping.
+  if (detected) {
+    state.tag = _tag;
+    state.anchor = _anchor;
+    state.kind = 'mapping';
+    state.result = _result;
+  }
+
+  return detected;
+}
+
+function readTagProperty(state) {
+  var _position,
+      isVerbatim = false,
+      isNamed    = false,
+      tagHandle,
+      tagName,
+      ch;
+
+  ch = state.input.charCodeAt(state.position);
+
+  if (ch !== 0x21/* ! */) return false;
+
+  if (state.tag !== null) {
+    throwError(state, 'duplication of a tag property');
+  }
+
+  ch = state.input.charCodeAt(++state.position);
+
+  if (ch === 0x3C/* < */) {
+    isVerbatim = true;
+    ch = state.input.charCodeAt(++state.position);
+
+  } else if (ch === 0x21/* ! */) {
+    isNamed = true;
+    tagHandle = '!!';
+    ch = state.input.charCodeAt(++state.position);
+
+  } else {
+    tagHandle = '!';
+  }
+
+  _position = state.position;
+
+  if (isVerbatim) {
+    do { ch = state.input.charCodeAt(++state.position); }
+    while (ch !== 0 && ch !== 0x3E/* > */);
+
+    if (state.position < state.length) {
+      tagName = state.input.slice(_position, state.position);
+      ch = state.input.charCodeAt(++state.position);
+    } else {
+      throwError(state, 'unexpected end of the stream within a verbatim tag');
+    }
+  } else {
+    while (ch !== 0 && !is_WS_OR_EOL(ch)) {
+
+      if (ch === 0x21/* ! */) {
+        if (!isNamed) {
+          tagHandle = state.input.slice(_position - 1, state.position + 1);
+
+          if (!PATTERN_TAG_HANDLE.test(tagHandle)) {
+            throwError(state, 'named tag handle cannot contain such characters');
+          }
+
+          isNamed = true;
+          _position = state.position + 1;
+        } else {
+          throwError(state, 'tag suffix cannot contain exclamation marks');
+        }
+      }
+
+      ch = state.input.charCodeAt(++state.position);
+    }
+
+    tagName = state.input.slice(_position, state.position);
+
+    if (PATTERN_FLOW_INDICATORS.test(tagName)) {
+      throwError(state, 'tag suffix cannot contain flow indicator characters');
+    }
+  }
+
+  if (tagName && !PATTERN_TAG_URI.test(tagName)) {
+    throwError(state, 'tag name cannot contain such characters: ' + tagName);
+  }
+
+  if (isVerbatim) {
+    state.tag = tagName;
+
+  } else if (_hasOwnProperty.call(state.tagMap, tagHandle)) {
+    state.tag = state.tagMap[tagHandle] + tagName;
+
+  } else if (tagHandle === '!') {
+    state.tag = '!' + tagName;
+
+  } else if (tagHandle === '!!') {
+    state.tag = 'tag:yaml.org,2002:' + tagName;
+
+  } else {
+    throwError(state, 'undeclared tag handle "' + tagHandle + '"');
+  }
+
+  return true;
+}
+
+function readAnchorProperty(state) {
+  var _position,
+      ch;
+
+  ch = state.input.charCodeAt(state.position);
+
+  if (ch !== 0x26/* & */) return false;
+
+  if (state.anchor !== null) {
+    throwError(state, 'duplication of an anchor property');
+  }
+
+  ch = state.input.charCodeAt(++state.position);
+  _position = state.position;
+
+  while (ch !== 0 && !is_WS_OR_EOL(ch) && !is_FLOW_INDICATOR(ch)) {
+    ch = state.input.charCodeAt(++state.position);
+  }
+
+  if (state.position === _position) {
+    throwError(state, 'name of an anchor node must contain at least one character');
+  }
+
+  state.anchor = state.input.slice(_position, state.position);
+  return true;
+}
+
+function readAlias(state) {
+  var _position, alias,
+      ch;
+
+  ch = state.input.charCodeAt(state.position);
+
+  if (ch !== 0x2A/* * */) return false;
+
+  ch = state.input.charCodeAt(++state.position);
+  _position = state.position;
+
+  while (ch !== 0 && !is_WS_OR_EOL(ch) && !is_FLOW_INDICATOR(ch)) {
+    ch = state.input.charCodeAt(++state.position);
+  }
+
+  if (state.position === _position) {
+    throwError(state, 'name of an alias node must contain at least one character');
+  }
+
+  alias = state.input.slice(_position, state.position);
+
+  if (!state.anchorMap.hasOwnProperty(alias)) {
+    throwError(state, 'unidentified alias "' + alias + '"');
+  }
+
+  state.result = state.anchorMap[alias];
+  skipSeparationSpace(state, true, -1);
+  return true;
+}
+
+function composeNode(state, parentIndent, nodeContext, allowToSeek, allowCompact) {
+  var allowBlockStyles,
+      allowBlockScalars,
+      allowBlockCollections,
+      indentStatus = 1, // 1: this>parent, 0: this=parent, -1: this<parent
+      atNewLine  = false,
+      hasContent = false,
+      typeIndex,
+      typeQuantity,
+      type,
+      flowIndent,
+      blockIndent;
+
+  if (state.listener !== null) {
+    state.listener('open', state);
+  }
+
+  state.tag    = null;
+  state.anchor = null;
+  state.kind   = null;
+  state.result = null;
+
+  allowBlockStyles = allowBlockScalars = allowBlockCollections =
+    CONTEXT_BLOCK_OUT === nodeContext ||
+    CONTEXT_BLOCK_IN  === nodeContext;
+
+  if (allowToSeek) {
+    if (skipSeparationSpace(state, true, -1)) {
+      atNewLine = true;
+
+      if (state.lineIndent > parentIndent) {
+        indentStatus = 1;
+      } else if (state.lineIndent === parentIndent) {
+        indentStatus = 0;
+      } else if (state.lineIndent < parentIndent) {
+        indentStatus = -1;
+      }
+    }
+  }
+
+  if (indentStatus === 1) {
+    while (readTagProperty(state) || readAnchorProperty(state)) {
+      if (skipSeparationSpace(state, true, -1)) {
+        atNewLine = true;
+        allowBlockCollections = allowBlockStyles;
+
+        if (state.lineIndent > parentIndent) {
+          indentStatus = 1;
+        } else if (state.lineIndent === parentIndent) {
+          indentStatus = 0;
+        } else if (state.lineIndent < parentIndent) {
+          indentStatus = -1;
+        }
+      } else {
+        allowBlockCollections = false;
+      }
+    }
+  }
+
+  if (allowBlockCollections) {
+    allowBlockCollections = atNewLine || allowCompact;
+  }
+
+  if (indentStatus === 1 || CONTEXT_BLOCK_OUT === nodeContext) {
+    if (CONTEXT_FLOW_IN === nodeContext || CONTEXT_FLOW_OUT === nodeContext) {
+      flowIndent = parentIndent;
+    } else {
+      flowIndent = parentIndent + 1;
+    }
+
+    blockIndent = state.position - state.lineStart;
+
+    if (indentStatus === 1) {
+      if (allowBlockCollections &&
+          (readBlockSequence(state, blockIndent) ||
+           readBlockMapping(state, blockIndent, flowIndent)) ||
+          readFlowCollection(state, flowIndent)) {
+        hasContent = true;
+      } else {
+        if ((allowBlockScalars && readBlockScalar(state, flowIndent)) ||
+            readSingleQuotedScalar(state, flowIndent) ||
+            readDoubleQuotedScalar(state, flowIndent)) {
+          hasContent = true;
+
+        } else if (readAlias(state)) {
+          hasContent = true;
+
+          if (state.tag !== null || state.anchor !== null) {
+            throwError(state, 'alias node should not have any properties');
+          }
+
+        } else if (readPlainScalar(state, flowIndent, CONTEXT_FLOW_IN === nodeContext)) {
+          hasContent = true;
+
+          if (state.tag === null) {
+            state.tag = '?';
+          }
+        }
+
+        if (state.anchor !== null) {
+          state.anchorMap[state.anchor] = state.result;
+        }
+      }
+    } else if (indentStatus === 0) {
+      // Special case: block sequences are allowed to have same indentation level as the parent.
+      // http://www.yaml.org/spec/1.2/spec.html#id2799784
+      hasContent = allowBlockCollections && readBlockSequence(state, blockIndent);
+    }
+  }
+
+  if (state.tag !== null && state.tag !== '!') {
+    if (state.tag === '?') {
+      for (typeIndex = 0, typeQuantity = state.implicitTypes.length; typeIndex < typeQuantity; typeIndex += 1) {
+        type = state.implicitTypes[typeIndex];
+
+        // Implicit resolving is not allowed for non-scalar types, and '?'
+        // non-specific tag is only assigned to plain scalars. So, it isn't
+        // needed to check for 'kind' conformity.
+
+        if (type.resolve(state.result)) { // `state.result` updated in resolver if matched
+          state.result = type.construct(state.result);
+          state.tag = type.tag;
+          if (state.anchor !== null) {
+            state.anchorMap[state.anchor] = state.result;
+          }
+          break;
+        }
+      }
+    } else if (_hasOwnProperty.call(state.typeMap[state.kind || 'fallback'], state.tag)) {
+      type = state.typeMap[state.kind || 'fallback'][state.tag];
+
+      if (state.result !== null && type.kind !== state.kind) {
+        throwError(state, 'unacceptable node kind for !<' + state.tag + '> tag; it should be "' + type.kind + '", not "' + state.kind + '"');
+      }
+
+      if (!type.resolve(state.result)) { // `state.result` updated in resolver if matched
+        throwError(state, 'cannot resolve a node with !<' + state.tag + '> explicit tag');
+      } else {
+        state.result = type.construct(state.result);
+        if (state.anchor !== null) {
+          state.anchorMap[state.anchor] = state.result;
+        }
+      }
+    } else {
+      throwError(state, 'unknown tag !<' + state.tag + '>');
+    }
+  }
+
+  if (state.listener !== null) {
+    state.listener('close', state);
+  }
+  return state.tag !== null ||  state.anchor !== null || hasContent;
+}
+
+function readDocument(state) {
+  var documentStart = state.position,
+      _position,
+      directiveName,
+      directiveArgs,
+      hasDirectives = false,
+      ch;
+
+  state.version = null;
+  state.checkLineBreaks = state.legacy;
+  state.tagMap = {};
+  state.anchorMap = {};
+
+  while ((ch = state.input.charCodeAt(state.position)) !== 0) {
+    skipSeparationSpace(state, true, -1);
+
+    ch = state.input.charCodeAt(state.position);
+
+    if (state.lineIndent > 0 || ch !== 0x25/* % */) {
+      break;
+    }
+
+    hasDirectives = true;
+    ch = state.input.charCodeAt(++state.position);
+    _position = state.position;
+
+    while (ch !== 0 && !is_WS_OR_EOL(ch)) {
+      ch = state.input.charCodeAt(++state.position);
+    }
+
+    directiveName = state.input.slice(_position, state.position);
+    directiveArgs = [];
+
+    if (directiveName.length < 1) {
+      throwError(state, 'directive name must not be less than one character in length');
+    }
+
+    while (ch !== 0) {
+      while (is_WHITE_SPACE(ch)) {
+        ch = state.input.charCodeAt(++state.position);
+      }
+
+      if (ch === 0x23/* # */) {
+        do { ch = state.input.charCodeAt(++state.position); }
+        while (ch !== 0 && !is_EOL(ch));
+        break;
+      }
+
+      if (is_EOL(ch)) break;
+
+      _position = state.position;
+
+      while (ch !== 0 && !is_WS_OR_EOL(ch)) {
+        ch = state.input.charCodeAt(++state.position);
+      }
+
+      directiveArgs.push(state.input.slice(_position, state.position));
+    }
+
+    if (ch !== 0) readLineBreak(state);
+
+    if (_hasOwnProperty.call(directiveHandlers, directiveName)) {
+      directiveHandlers[directiveName](state, directiveName, directiveArgs);
+    } else {
+      throwWarning(state, 'unknown document directive "' + directiveName + '"');
+    }
+  }
+
+  skipSeparationSpace(state, true, -1);
+
+  if (state.lineIndent === 0 &&
+      state.input.charCodeAt(state.position)     === 0x2D/* - */ &&
+      state.input.charCodeAt(state.position + 1) === 0x2D/* - */ &&
+      state.input.charCodeAt(state.position + 2) === 0x2D/* - */) {
+    state.position += 3;
+    skipSeparationSpace(state, true, -1);
+
+  } else if (hasDirectives) {
+    throwError(state, 'directives end mark is expected');
+  }
+
+  composeNode(state, state.lineIndent - 1, CONTEXT_BLOCK_OUT, false, true);
+  skipSeparationSpace(state, true, -1);
+
+  if (state.checkLineBreaks &&
+      PATTERN_NON_ASCII_LINE_BREAKS.test(state.input.slice(documentStart, state.position))) {
+    throwWarning(state, 'non-ASCII line breaks are interpreted as content');
+  }
+
+  state.documents.push(state.result);
+
+  if (state.position === state.lineStart && testDocumentSeparator(state)) {
+
+    if (state.input.charCodeAt(state.position) === 0x2E/* . */) {
+      state.position += 3;
+      skipSeparationSpace(state, true, -1);
+    }
+    return;
+  }
+
+  if (state.position < (state.length - 1)) {
+    throwError(state, 'end of the stream or a document separator is expected');
+  } else {
+    return;
+  }
+}
+
+
+function loadDocuments(input, options) {
+  // input = String(input);
+  options = options || {};
+
+  if (input.length !== 0) {
+
+    // Add tailing `\n` if not exists
+    if (input.charCodeAt(input.length - 1) !== 0x0A/* LF */ &&
+        input.charCodeAt(input.length - 1) !== 0x0D/* CR */) {
+      input += '\n';
+    }
+
+    // Strip BOM
+    if (input.charCodeAt(0) === 0xFEFF) {
+      input = input.slice(1);
+    }
+  }
+
+  var state = new State(input, options);
+
+  // console.log('STATE:', state)
+
+  // Use 0 as string terminator. That significantly simplifies bounds check.
+  state.input += '\0';
+
+  while (state.input.charCodeAt(state.position) === 0x20/* Space */) {
+    state.lineIndent += 1;
+    state.position += 1;
+  }
+
+  while (state.position < (state.length - 1)) {
+    readDocument(state);
+  }
+
+  return state.documents;
+}
+
+
+function loadAll(input, iterator, options) {
+  var documents = loadDocuments(input, options), index, length;
+
+  if (typeof iterator !== 'function') {
+    return documents;
+  }
+
+  for (index = 0, length = documents.length; index < length; index += 1) {
+    iterator(documents[index]);
+  }
+}
+
+
+function load(input, options) {
+  var documents = loadDocuments(input, options);
+
+  if (documents.length === 0) {
+    /*eslint-disable no-undefined*/
+    return undefined;
+  } else if (documents.length === 1) {
+    return documents[0];
+  }
+  throw new YAMLException('expected a single document in the stream, but found more');
+}
+
+
+function safeLoadAll(input, output, options) {
+  if (typeof output === 'function') {
+    loadAll(input, output, common.extend({ schema: DEFAULT_SAFE_SCHEMA }, options));
+  } else {
+    return loadAll(input, common.extend({ schema: DEFAULT_SAFE_SCHEMA }, options));
+  }
+}
+
+
+function safeLoad(input, options) {
+  return load(input, common.extend({ schema: DEFAULT_SAFE_SCHEMA }, options));
+}
+
+
+module.exports.loadAll     = loadAll;
+module.exports.load        = load;
+module.exports.safeLoadAll = safeLoadAll;
+module.exports.safeLoad    = safeLoad;
+
+},{"./common":2,"./exception":4,"./mark":6,"./schema/default_full":9,"./schema/default_safe":10}],6:[function(require,module,exports){
+'use strict';
+
+
+var common = require('./common');
+
+
+function Mark(name, buffer, position, line, column) {
+  this.name     = name;
+  this.buffer   = buffer;
+  this.position = position;
+  this.line     = line;
+  this.column   = column;
+}
+
+
+Mark.prototype.getSnippet = function getSnippet(indent, maxLength) {
+  var head, start, tail, end, snippet;
+
+  if (!this.buffer) return null;
+
+  indent = indent || 4;
+  maxLength = maxLength || 75;
+
+  head = '';
+  start = this.position;
+
+  while (start > 0 && '\x00\r\n\x85\u2028\u2029'.indexOf(this.buffer.charAt(start - 1)) === -1) {
+    start -= 1;
+    if (this.position - start > (maxLength / 2 - 1)) {
+      head = ' ... ';
+      start += 5;
+      break;
+    }
+  }
+
+  tail = '';
+  end = this.position;
+
+  while (end < this.buffer.length && '\x00\r\n\x85\u2028\u2029'.indexOf(this.buffer.charAt(end)) === -1) {
+    end += 1;
+    if (end - this.position > (maxLength / 2 - 1)) {
+      tail = ' ... ';
+      end -= 5;
+      break;
+    }
+  }
+
+  snippet = this.buffer.slice(start, end);
+
+  return common.repeat(' ', indent) + head + snippet + tail + '\n' +
+         common.repeat(' ', indent + this.position - start + head.length) + '^';
+};
+
+
+Mark.prototype.toString = function toString(compact) {
+  var snippet, where = '';
+
+  if (this.name) {
+    where += 'in "' + this.name + '" ';
+  }
+
+  where += 'at line ' + (this.line + 1) + ', column ' + (this.column + 1);
+
+  if (!compact) {
+    snippet = this.getSnippet();
+
+    if (snippet) {
+      where += ':\n' + snippet;
+    }
+  }
+
+  return where;
+};
+
+
+module.exports = Mark;
+
+},{"./common":2}],7:[function(require,module,exports){
+'use strict';
+
+/*eslint-disable max-len*/
+
+var common        = require('./common');
+var YAMLException = require('./exception');
+var Type          = require('./type');
+
+
+function compileList(schema, name, result) {
+  var exclude = [];
+
+  schema.include.forEach(function (includedSchema) {
+    result = compileList(includedSchema, name, result);
+  });
+
+  schema[name].forEach(function (currentType) {
+    result.forEach(function (previousType, previousIndex) {
+      if (previousType.tag === currentType.tag && previousType.kind === currentType.kind) {
+        exclude.push(previousIndex);
+      }
+    });
+
+    result.push(currentType);
+  });
+
+  return result.filter(function (type, index) {
+    return exclude.indexOf(index) === -1;
+  });
+}
+
+
+function compileMap(/* lists... */) {
+  var result = {
+        scalar: {},
+        sequence: {},
+        mapping: {},
+        fallback: {}
+      }, index, length;
+
+  function collectType(type) {
+    result[type.kind][type.tag] = result['fallback'][type.tag] = type;
+  }
+
+  for (index = 0, length = arguments.length; index < length; index += 1) {
+    arguments[index].forEach(collectType);
+  }
+  return result;
+}
+
+
+function Schema(definition) {
+  this.include  = definition.include  || [];
+  this.implicit = definition.implicit || [];
+  this.explicit = definition.explicit || [];
+
+  this.implicit.forEach(function (type) {
+    if (type.loadKind && type.loadKind !== 'scalar') {
+      throw new YAMLException('There is a non-scalar type in the implicit list of a schema. Implicit resolving of such types is not supported.');
+    }
+  });
+
+  this.compiledImplicit = compileList(this, 'implicit', []);
+  this.compiledExplicit = compileList(this, 'explicit', []);
+  this.compiledTypeMap  = compileMap(this.compiledImplicit, this.compiledExplicit);
+}
+
+
+Schema.DEFAULT = null;
+
+
+Schema.create = function createSchema() {
+  var schemas, types;
+
+  switch (arguments.length) {
+    case 1:
+      schemas = Schema.DEFAULT;
+      types = arguments[0];
+      break;
+
+    case 2:
+      schemas = arguments[0];
+      types = arguments[1];
+      break;
+
+    default:
+      throw new YAMLException('Wrong number of arguments for Schema.create function');
+  }
+
+  schemas = common.toArray(schemas);
+  types = common.toArray(types);
+
+  if (!schemas.every(function (schema) { return schema instanceof Schema; })) {
+    throw new YAMLException('Specified list of super schemas (or a single Schema object) contains a non-Schema object.');
+  }
+
+  if (!types.every(function (type) { return type instanceof Type; })) {
+    throw new YAMLException('Specified list of YAML types (or a single Type object) contains a non-Type object.');
+  }
+
+  return new Schema({
+    include: schemas,
+    explicit: types
+  });
+};
+
+
+module.exports = Schema;
+
+},{"./common":2,"./exception":4,"./type":13}],8:[function(require,module,exports){
+// Standard YAML's Core schema.
+// http://www.yaml.org/spec/1.2/spec.html#id2804923
+//
+// NOTE: JS-YAML does not support schema-specific tag resolution restrictions.
+// So, Core schema has no distinctions from JSON schema is JS-YAML.
+
+
+'use strict';
+
+
+var Schema = require('../schema');
+
+
+module.exports = new Schema({
+  include: [
+    require('./json')
+  ]
+});
+
+},{"../schema":7,"./json":12}],9:[function(require,module,exports){
+// JS-YAML's default schema for `load` function.
+// It is not described in the YAML specification.
+//
+// This schema is based on JS-YAML's default safe schema and includes
+// JavaScript-specific types: !!js/undefined, !!js/regexp and !!js/function.
+//
+// Also this schema is used as default base schema at `Schema.create` function.
+
+
+'use strict';
+
+
+var Schema = require('../schema');
+
+
+module.exports = Schema.DEFAULT = new Schema({
+  include: [
+    require('./default_safe')
+  ],
+  explicit: [
+    require('../type/js/undefined'),
+    require('../type/js/regexp'),
+    require('../type/js/function')
+  ]
+});
+
+},{"../schema":7,"../type/js/function":18,"../type/js/regexp":19,"../type/js/undefined":20,"./default_safe":10}],10:[function(require,module,exports){
+// JS-YAML's default schema for `safeLoad` function.
+// It is not described in the YAML specification.
+//
+// This schema is based on standard YAML's Core schema and includes most of
+// extra types described at YAML tag repository. (http://yaml.org/type/)
+
+
+'use strict';
+
+
+var Schema = require('../schema');
+
+
+module.exports = new Schema({
+  include: [
+    require('./core')
+  ],
+  implicit: [
+    require('../type/timestamp'),
+    require('../type/merge')
+  ],
+  explicit: [
+    require('../type/binary'),
+    require('../type/omap'),
+    require('../type/pairs'),
+    require('../type/set')
+  ]
+});
+
+},{"../schema":7,"../type/binary":14,"../type/merge":22,"../type/omap":24,"../type/pairs":25,"../type/set":27,"../type/timestamp":29,"./core":8}],11:[function(require,module,exports){
+// Standard YAML's Failsafe schema.
+// http://www.yaml.org/spec/1.2/spec.html#id2802346
+
+
+'use strict';
+
+
+var Schema = require('../schema');
+
+
+module.exports = new Schema({
+  explicit: [
+    require('../type/str'),
+    require('../type/seq'),
+    require('../type/map')
+  ]
+});
+
+},{"../schema":7,"../type/map":21,"../type/seq":26,"../type/str":28}],12:[function(require,module,exports){
+// Standard YAML's JSON schema.
+// http://www.yaml.org/spec/1.2/spec.html#id2803231
+//
+// NOTE: JS-YAML does not support schema-specific tag resolution restrictions.
+// So, this schema is not such strict as defined in the YAML specification.
+// It allows numbers in binary notaion, use `Null` and `NULL` as `null`, etc.
+
+
+'use strict';
+
+
+var Schema = require('../schema');
+
+
+module.exports = new Schema({
+  include: [
+    require('./failsafe')
+  ],
+  implicit: [
+    require('../type/null'),
+    require('../type/bool'),
+    require('../type/int'),
+    require('../type/float')
+  ]
+});
+
+},{"../schema":7,"../type/bool":15,"../type/float":16,"../type/int":17,"../type/null":23,"./failsafe":11}],13:[function(require,module,exports){
+'use strict';
+
+var YAMLException = require('./exception');
+
+var TYPE_CONSTRUCTOR_OPTIONS = [
+  'kind',
+  'resolve',
+  'construct',
+  'instanceOf',
+  'predicate',
+  'represent',
+  'defaultStyle',
+  'styleAliases'
+];
+
+var YAML_NODE_KINDS = [
+  'scalar',
+  'sequence',
+  'mapping'
+];
+
+function compileStyleAliases(map) {
+  var result = {};
+
+  if (map !== null) {
+    Object.keys(map).forEach(function (style) {
+      map[style].forEach(function (alias) {
+        result[String(alias)] = style;
+      });
+    });
+  }
+
+  return result;
+}
+
+function Type(tag, options) {
+  options = options || {};
+
+  Object.keys(options).forEach(function (name) {
+    if (TYPE_CONSTRUCTOR_OPTIONS.indexOf(name) === -1) {
+      throw new YAMLException('Unknown option "' + name + '" is met in definition of "' + tag + '" YAML type.');
+    }
+  });
+
+  // TODO: Add tag format check.
+  this.tag          = tag;
+  this.kind         = options['kind']         || null;
+  this.resolve      = options['resolve']      || function () { return true; };
+  this.construct    = options['construct']    || function (data) { return data; };
+  this.instanceOf   = options['instanceOf']   || null;
+  this.predicate    = options['predicate']    || null;
+  this.represent    = options['represent']    || null;
+  this.defaultStyle = options['defaultStyle'] || null;
+  this.styleAliases = compileStyleAliases(options['styleAliases'] || null);
+
+  if (YAML_NODE_KINDS.indexOf(this.kind) === -1) {
+    throw new YAMLException('Unknown kind "' + this.kind + '" is specified for "' + tag + '" YAML type.');
+  }
+}
+
+module.exports = Type;
+
+},{"./exception":4}],14:[function(require,module,exports){
+'use strict';
+
+/*eslint-disable no-bitwise*/
+
+var NodeBuffer;
+
+try {
+  // A trick for browserified version, to not include `Buffer` shim
+  var _require = require;
+  NodeBuffer = _require('buffer').Buffer;
+} catch (__) {}
+
+var Type       = require('../type');
+
+
+// [ 64, 65, 66 ] -> [ padding, CR, LF ]
+var BASE64_MAP = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=\n\r';
+
+
+function resolveYamlBinary(data) {
+  if (data === null) return false;
+
+  var code, idx, bitlen = 0, max = data.length, map = BASE64_MAP;
+
+  // Convert one by one.
+  for (idx = 0; idx < max; idx++) {
+    code = map.indexOf(data.charAt(idx));
+
+    // Skip CR/LF
+    if (code > 64) continue;
+
+    // Fail on illegal characters
+    if (code < 0) return false;
+
+    bitlen += 6;
+  }
+
+  // If there are any bits left, source was corrupted
+  return (bitlen % 8) === 0;
+}
+
+function constructYamlBinary(data) {
+  var idx, tailbits,
+      input = data.replace(/[\r\n=]/g, ''), // remove CR/LF & padding to simplify scan
+      max = input.length,
+      map = BASE64_MAP,
+      bits = 0,
+      result = [];
+
+  // Collect by 6*4 bits (3 bytes)
+
+  for (idx = 0; idx < max; idx++) {
+    if ((idx % 4 === 0) && idx) {
+      result.push((bits >> 16) & 0xFF);
+      result.push((bits >> 8) & 0xFF);
+      result.push(bits & 0xFF);
+    }
+
+    bits = (bits << 6) | map.indexOf(input.charAt(idx));
+  }
+
+  // Dump tail
+
+  tailbits = (max % 4) * 6;
+
+  if (tailbits === 0) {
+    result.push((bits >> 16) & 0xFF);
+    result.push((bits >> 8) & 0xFF);
+    result.push(bits & 0xFF);
+  } else if (tailbits === 18) {
+    result.push((bits >> 10) & 0xFF);
+    result.push((bits >> 2) & 0xFF);
+  } else if (tailbits === 12) {
+    result.push((bits >> 4) & 0xFF);
+  }
+
+  // Wrap into Buffer for NodeJS and leave Array for browser
+  if (NodeBuffer) {
+    // Support node 6.+ Buffer API when available
+    return NodeBuffer.from ? NodeBuffer.from(result) : new NodeBuffer(result);
+  }
+
+  return result;
+}
+
+function representYamlBinary(object /*, style*/) {
+  var result = '', bits = 0, idx, tail,
+      max = object.length,
+      map = BASE64_MAP;
+
+  // Convert every three bytes to 4 ASCII characters.
+
+  for (idx = 0; idx < max; idx++) {
+    if ((idx % 3 === 0) && idx) {
+      result += map[(bits >> 18) & 0x3F];
+      result += map[(bits >> 12) & 0x3F];
+      result += map[(bits >> 6) & 0x3F];
+      result += map[bits & 0x3F];
+    }
+
+    bits = (bits << 8) + object[idx];
+  }
+
+  // Dump tail
+
+  tail = max % 3;
+
+  if (tail === 0) {
+    result += map[(bits >> 18) & 0x3F];
+    result += map[(bits >> 12) & 0x3F];
+    result += map[(bits >> 6) & 0x3F];
+    result += map[bits & 0x3F];
+  } else if (tail === 2) {
+    result += map[(bits >> 10) & 0x3F];
+    result += map[(bits >> 4) & 0x3F];
+    result += map[(bits << 2) & 0x3F];
+    result += map[64];
+  } else if (tail === 1) {
+    result += map[(bits >> 2) & 0x3F];
+    result += map[(bits << 4) & 0x3F];
+    result += map[64];
+    result += map[64];
+  }
+
+  return result;
+}
+
+function isBinary(object) {
+  return NodeBuffer && NodeBuffer.isBuffer(object);
+}
+
+module.exports = new Type('tag:yaml.org,2002:binary', {
+  kind: 'scalar',
+  resolve: resolveYamlBinary,
+  construct: constructYamlBinary,
+  predicate: isBinary,
+  represent: representYamlBinary
+});
+
+},{"../type":13}],15:[function(require,module,exports){
+'use strict';
+
+var Type = require('../type');
+
+function resolveYamlBoolean(data) {
+  if (data === null) return false;
+
+  var max = data.length;
+
+  return (max === 4 && (data === 'true' || data === 'True' || data === 'TRUE')) ||
+         (max === 5 && (data === 'false' || data === 'False' || data === 'FALSE'));
+}
+
+function constructYamlBoolean(data) {
+  return data === 'true' ||
+         data === 'True' ||
+         data === 'TRUE';
+}
+
+function isBoolean(object) {
+  return Object.prototype.toString.call(object) === '[object Boolean]';
+}
+
+module.exports = new Type('tag:yaml.org,2002:bool', {
+  kind: 'scalar',
+  resolve: resolveYamlBoolean,
+  construct: constructYamlBoolean,
+  predicate: isBoolean,
+  represent: {
+    lowercase: function (object) { return object ? 'true' : 'false'; },
+    uppercase: function (object) { return object ? 'TRUE' : 'FALSE'; },
+    camelcase: function (object) { return object ? 'True' : 'False'; }
+  },
+  defaultStyle: 'lowercase'
+});
+
+},{"../type":13}],16:[function(require,module,exports){
+'use strict';
+
+var common = require('../common');
+var Type   = require('../type');
+
+var YAML_FLOAT_PATTERN = new RegExp(
+  // 2.5e4, 2.5 and integers
+  '^(?:[-+]?(?:0|[1-9][0-9_]*)(?:\\.[0-9_]*)?(?:[eE][-+]?[0-9]+)?' +
+  // .2e4, .2
+  // special case, seems not from spec
+  '|\\.[0-9_]+(?:[eE][-+]?[0-9]+)?' +
+  // 20:59
+  '|[-+]?[0-9][0-9_]*(?::[0-5]?[0-9])+\\.[0-9_]*' +
+  // .inf
+  '|[-+]?\\.(?:inf|Inf|INF)' +
+  // .nan
+  '|\\.(?:nan|NaN|NAN))$');
+
+function resolveYamlFloat(data) {
+  if (data === null) return false;
+
+  if (!YAML_FLOAT_PATTERN.test(data) ||
+      // Quick hack to not allow integers end with `_`
+      // Probably should update regexp & check speed
+      data[data.length - 1] === '_') {
+    return false;
+  }
+
+  return true;
+}
+
+function constructYamlFloat(data) {
+  var value, sign, base, digits;
+
+  value  = data.replace(/_/g, '').toLowerCase();
+  sign   = value[0] === '-' ? -1 : 1;
+  digits = [];
+
+  if ('+-'.indexOf(value[0]) >= 0) {
+    value = value.slice(1);
+  }
+
+  if (value === '.inf') {
+    return (sign === 1) ? Number.POSITIVE_INFINITY : Number.NEGATIVE_INFINITY;
+
+  } else if (value === '.nan') {
+    return NaN;
+
+  } else if (value.indexOf(':') >= 0) {
+    value.split(':').forEach(function (v) {
+      digits.unshift(parseFloat(v, 10));
+    });
+
+    value = 0.0;
+    base = 1;
+
+    digits.forEach(function (d) {
+      value += d * base;
+      base *= 60;
+    });
+
+    return sign * value;
+
+  }
+  return sign * parseFloat(value, 10);
+}
+
+
+var SCIENTIFIC_WITHOUT_DOT = /^[-+]?[0-9]+e/;
+
+function representYamlFloat(object, style) {
+  var res;
+
+  if (isNaN(object)) {
+    switch (style) {
+      case 'lowercase': return '.nan';
+      case 'uppercase': return '.NAN';
+      case 'camelcase': return '.NaN';
+    }
+  } else if (Number.POSITIVE_INFINITY === object) {
+    switch (style) {
+      case 'lowercase': return '.inf';
+      case 'uppercase': return '.INF';
+      case 'camelcase': return '.Inf';
+    }
+  } else if (Number.NEGATIVE_INFINITY === object) {
+    switch (style) {
+      case 'lowercase': return '-.inf';
+      case 'uppercase': return '-.INF';
+      case 'camelcase': return '-.Inf';
+    }
+  } else if (common.isNegativeZero(object)) {
+    return '-0.0';
+  }
+
+  res = object.toString(10);
+
+  // JS stringifier can build scientific format without dots: 5e-100,
+  // while YAML requres dot: 5.e-100. Fix it with simple hack
+
+  return SCIENTIFIC_WITHOUT_DOT.test(res) ? res.replace('e', '.e') : res;
+}
+
+function isFloat(object) {
+  return (Object.prototype.toString.call(object) === '[object Number]') &&
+         (object % 1 !== 0 || common.isNegativeZero(object));
+}
+
+module.exports = new Type('tag:yaml.org,2002:float', {
+  kind: 'scalar',
+  resolve: resolveYamlFloat,
+  construct: constructYamlFloat,
+  predicate: isFloat,
+  represent: representYamlFloat,
+  defaultStyle: 'lowercase'
+});
+
+},{"../common":2,"../type":13}],17:[function(require,module,exports){
+'use strict';
+
+var common = require('../common');
+var Type   = require('../type');
+
+function isHexCode(c) {
+  return ((0x30/* 0 */ <= c) && (c <= 0x39/* 9 */)) ||
+         ((0x41/* A */ <= c) && (c <= 0x46/* F */)) ||
+         ((0x61/* a */ <= c) && (c <= 0x66/* f */));
+}
+
+function isOctCode(c) {
+  return ((0x30/* 0 */ <= c) && (c <= 0x37/* 7 */));
+}
+
+function isDecCode(c) {
+  return ((0x30/* 0 */ <= c) && (c <= 0x39/* 9 */));
+}
+
+function resolveYamlInteger(data) {
+  if (data === null) return false;
+
+  var max = data.length,
+      index = 0,
+      hasDigits = false,
+      ch;
+
+  if (!max) return false;
+
+  ch = data[index];
+
+  // sign
+  if (ch === '-' || ch === '+') {
+    ch = data[++index];
+  }
+
+  if (ch === '0') {
+    // 0
+    if (index + 1 === max) return true;
+    ch = data[++index];
+
+    // base 2, base 8, base 16
+
+    if (ch === 'b') {
+      // base 2
+      index++;
+
+      for (; index < max; index++) {
+        ch = data[index];
+        if (ch === '_') continue;
+        if (ch !== '0' && ch !== '1') return false;
+        hasDigits = true;
+      }
+      return hasDigits && ch !== '_';
+    }
+
+
+    if (ch === 'x') {
+      // base 16
+      index++;
+
+      for (; index < max; index++) {
+        ch = data[index];
+        if (ch === '_') continue;
+        if (!isHexCode(data.charCodeAt(index))) return false;
+        hasDigits = true;
+      }
+      return hasDigits && ch !== '_';
+    }
+
+    // base 8
+    for (; index < max; index++) {
+      ch = data[index];
+      if (ch === '_') continue;
+      if (!isOctCode(data.charCodeAt(index))) return false;
+      hasDigits = true;
+    }
+    return hasDigits && ch !== '_';
+  }
+
+  // base 10 (except 0) or base 60
+
+  // value should not start with `_`;
+  if (ch === '_') return false;
+
+  for (; index < max; index++) {
+    ch = data[index];
+    if (ch === '_') continue;
+    if (ch === ':') break;
+    if (!isDecCode(data.charCodeAt(index))) {
+      return false;
+    }
+    hasDigits = true;
+  }
+
+  // Should have digits and should not end with `_`
+  if (!hasDigits || ch === '_') return false;
+
+  // if !base60 - done;
+  if (ch !== ':') return true;
+
+  // base60 almost not used, no needs to optimize
+  return /^(:[0-5]?[0-9])+$/.test(data.slice(index));
+}
+
+function constructYamlInteger(data) {
+  var value = data, sign = 1, ch, base, digits = [];
+
+  if (value.indexOf('_') !== -1) {
+    value = value.replace(/_/g, '');
+  }
+
+  ch = value[0];
+
+  if (ch === '-' || ch === '+') {
+    if (ch === '-') sign = -1;
+    value = value.slice(1);
+    ch = value[0];
+  }
+
+  if (value === '0') return 0;
+
+  if (ch === '0') {
+    if (value[1] === 'b') return sign * parseInt(value.slice(2), 2);
+    if (value[1] === 'x') return sign * parseInt(value, 16);
+    return sign * parseInt(value, 8);
+  }
+
+  if (value.indexOf(':') !== -1) {
+    value.split(':').forEach(function (v) {
+      digits.unshift(parseInt(v, 10));
+    });
+
+    value = 0;
+    base = 1;
+
+    digits.forEach(function (d) {
+      value += (d * base);
+      base *= 60;
+    });
+
+    return sign * value;
+
+  }
+
+  return sign * parseInt(value, 10);
+}
+
+function isInteger(object) {
+  return (Object.prototype.toString.call(object)) === '[object Number]' &&
+         (object % 1 === 0 && !common.isNegativeZero(object));
+}
+
+module.exports = new Type('tag:yaml.org,2002:int', {
+  kind: 'scalar',
+  resolve: resolveYamlInteger,
+  construct: constructYamlInteger,
+  predicate: isInteger,
+  represent: {
+    binary:      function (obj) { return obj >= 0 ? '0b' + obj.toString(2) : '-0b' + obj.toString(2).slice(1); },
+    octal:       function (obj) { return obj >= 0 ? '0'  + obj.toString(8) : '-0'  + obj.toString(8).slice(1); },
+    decimal:     function (obj) { return obj.toString(10); },
+    /* eslint-disable max-len */
+    hexadecimal: function (obj) { return obj >= 0 ? '0x' + obj.toString(16).toUpperCase() :  '-0x' + obj.toString(16).toUpperCase().slice(1); }
+  },
+  defaultStyle: 'decimal',
+  styleAliases: {
+    binary:      [ 2,  'bin' ],
+    octal:       [ 8,  'oct' ],
+    decimal:     [ 10, 'dec' ],
+    hexadecimal: [ 16, 'hex' ]
+  }
+});
+
+},{"../common":2,"../type":13}],18:[function(require,module,exports){
+'use strict';
+
+var esprima;
+
+// Browserified version does not have esprima
+//
+// 1. For node.js just require module as deps
+// 2. For browser try to require mudule via external AMD system.
+//    If not found - try to fallback to window.esprima. If not
+//    found too - then fail to parse.
+//
+try {
+  // workaround to exclude package from browserify list.
+  var _require = require;
+  esprima = _require('esprima');
+} catch (_) {
+  /*global window */
+  if (typeof window !== 'undefined') esprima = window.esprima;
+}
+
+var Type = require('../../type');
+
+function resolveJavascriptFunction(data) {
+  if (data === null) return false;
+
+  try {
+    var source = '(' + data + ')',
+        ast    = esprima.parse(source, { range: true });
+
+    if (ast.type                    !== 'Program'             ||
+        ast.body.length             !== 1                     ||
+        ast.body[0].type            !== 'ExpressionStatement' ||
+        (ast.body[0].expression.type !== 'ArrowFunctionExpression' &&
+          ast.body[0].expression.type !== 'FunctionExpression')) {
+      return false;
+    }
+
+    return true;
+  } catch (err) {
+    return false;
+  }
+}
+
+function constructJavascriptFunction(data) {
+  /*jslint evil:true*/
+
+  var source = '(' + data + ')',
+      ast    = esprima.parse(source, { range: true }),
+      params = [],
+      body;
+
+  if (ast.type                    !== 'Program'             ||
+      ast.body.length             !== 1                     ||
+      ast.body[0].type            !== 'ExpressionStatement' ||
+      (ast.body[0].expression.type !== 'ArrowFunctionExpression' &&
+        ast.body[0].expression.type !== 'FunctionExpression')) {
+    throw new Error('Failed to resolve function');
+  }
+
+  ast.body[0].expression.params.forEach(function (param) {
+    params.push(param.name);
+  });
+
+  body = ast.body[0].expression.body.range;
+
+  // Esprima's ranges include the first '{' and the last '}' characters on
+  // function expressions. So cut them out.
+  /*eslint-disable no-new-func*/
+  return new Function(params, source.slice(body[0] + 1, body[1] - 1));
+}
+
+function representJavascriptFunction(object /*, style*/) {
+  return object.toString();
+}
+
+function isFunction(object) {
+  return Object.prototype.toString.call(object) === '[object Function]';
+}
+
+module.exports = new Type('tag:yaml.org,2002:js/function', {
+  kind: 'scalar',
+  resolve: resolveJavascriptFunction,
+  construct: constructJavascriptFunction,
+  predicate: isFunction,
+  represent: representJavascriptFunction
+});
+
+},{"../../type":13}],19:[function(require,module,exports){
+'use strict';
+
+var Type = require('../../type');
+
+function resolveJavascriptRegExp(data) {
+  if (data === null) return false;
+  if (data.length === 0) return false;
+
+  var regexp = data,
+      tail   = /\/([gim]*)$/.exec(data),
+      modifiers = '';
+
+  // if regexp starts with '/' it can have modifiers and must be properly closed
+  // `/foo/gim` - modifiers tail can be maximum 3 chars
+  if (regexp[0] === '/') {
+    if (tail) modifiers = tail[1];
+
+    if (modifiers.length > 3) return false;
+    // if expression starts with /, is should be properly terminated
+    if (regexp[regexp.length - modifiers.length - 1] !== '/') return false;
+  }
+
+  return true;
+}
+
+function constructJavascriptRegExp(data) {
+  var regexp = data,
+      tail   = /\/([gim]*)$/.exec(data),
+      modifiers = '';
+
+  // `/foo/gim` - tail can be maximum 4 chars
+  if (regexp[0] === '/') {
+    if (tail) modifiers = tail[1];
+    regexp = regexp.slice(1, regexp.length - modifiers.length - 1);
+  }
+
+  return new RegExp(regexp, modifiers);
+}
+
+function representJavascriptRegExp(object /*, style*/) {
+  var result = '/' + object.source + '/';
+
+  if (object.global) result += 'g';
+  if (object.multiline) result += 'm';
+  if (object.ignoreCase) result += 'i';
+
+  return result;
+}
+
+function isRegExp(object) {
+  return Object.prototype.toString.call(object) === '[object RegExp]';
+}
+
+module.exports = new Type('tag:yaml.org,2002:js/regexp', {
+  kind: 'scalar',
+  resolve: resolveJavascriptRegExp,
+  construct: constructJavascriptRegExp,
+  predicate: isRegExp,
+  represent: representJavascriptRegExp
+});
+
+},{"../../type":13}],20:[function(require,module,exports){
+'use strict';
+
+var Type = require('../../type');
+
+function resolveJavascriptUndefined() {
+  return true;
+}
+
+function constructJavascriptUndefined() {
+  /*eslint-disable no-undefined*/
+  return undefined;
+}
+
+function representJavascriptUndefined() {
+  return '';
+}
+
+function isUndefined(object) {
+  return typeof object === 'undefined';
+}
+
+module.exports = new Type('tag:yaml.org,2002:js/undefined', {
+  kind: 'scalar',
+  resolve: resolveJavascriptUndefined,
+  construct: constructJavascriptUndefined,
+  predicate: isUndefined,
+  represent: representJavascriptUndefined
+});
+
+},{"../../type":13}],21:[function(require,module,exports){
+'use strict';
+
+var Type = require('../type');
+
+module.exports = new Type('tag:yaml.org,2002:map', {
+  kind: 'mapping',
+  construct: function (data) { return data !== null ? data : {}; }
+});
+
+},{"../type":13}],22:[function(require,module,exports){
+'use strict';
+
+var Type = require('../type');
+
+function resolveYamlMerge(data) {
+  return data === '<<' || data === null;
+}
+
+module.exports = new Type('tag:yaml.org,2002:merge', {
+  kind: 'scalar',
+  resolve: resolveYamlMerge
+});
+
+},{"../type":13}],23:[function(require,module,exports){
+'use strict';
+
+var Type = require('../type');
+
+function resolveYamlNull(data) {
+  if (data === null) return true;
+
+  var max = data.length;
+
+  return (max === 1 && data === '~') ||
+         (max === 4 && (data === 'null' || data === 'Null' || data === 'NULL'));
+}
+
+function constructYamlNull() {
+  return null;
+}
+
+function isNull(object) {
+  return object === null;
+}
+
+module.exports = new Type('tag:yaml.org,2002:null', {
+  kind: 'scalar',
+  resolve: resolveYamlNull,
+  construct: constructYamlNull,
+  predicate: isNull,
+  represent: {
+    canonical: function () { return '~';    },
+    lowercase: function () { return 'null'; },
+    uppercase: function () { return 'NULL'; },
+    camelcase: function () { return 'Null'; }
+  },
+  defaultStyle: 'lowercase'
+});
+
+},{"../type":13}],24:[function(require,module,exports){
+'use strict';
+
+var Type = require('../type');
+
+var _hasOwnProperty = Object.prototype.hasOwnProperty;
+var _toString       = Object.prototype.toString;
+
+function resolveYamlOmap(data) {
+  if (data === null) return true;
+
+  var objectKeys = [], index, length, pair, pairKey, pairHasKey,
+      object = data;
+
+  for (index = 0, length = object.length; index < length; index += 1) {
+    pair = object[index];
+    pairHasKey = false;
+
+    if (_toString.call(pair) !== '[object Object]') return false;
+
+    for (pairKey in pair) {
+      if (_hasOwnProperty.call(pair, pairKey)) {
+        if (!pairHasKey) pairHasKey = true;
+        else return false;
+      }
+    }
+
+    if (!pairHasKey) return false;
+
+    if (objectKeys.indexOf(pairKey) === -1) objectKeys.push(pairKey);
+    else return false;
+  }
+
+  return true;
+}
+
+function constructYamlOmap(data) {
+  return data !== null ? data : [];
+}
+
+module.exports = new Type('tag:yaml.org,2002:omap', {
+  kind: 'sequence',
+  resolve: resolveYamlOmap,
+  construct: constructYamlOmap
+});
+
+},{"../type":13}],25:[function(require,module,exports){
+'use strict';
+
+var Type = require('../type');
+
+var _toString = Object.prototype.toString;
+
+function resolveYamlPairs(data) {
+  if (data === null) return true;
+
+  var index, length, pair, keys, result,
+      object = data;
+
+  result = new Array(object.length);
+
+  for (index = 0, length = object.length; index < length; index += 1) {
+    pair = object[index];
+
+    if (_toString.call(pair) !== '[object Object]') return false;
+
+    keys = Object.keys(pair);
+
+    if (keys.length !== 1) return false;
+
+    result[index] = [ keys[0], pair[keys[0]] ];
+  }
+
+  return true;
+}
+
+function constructYamlPairs(data) {
+  if (data === null) return [];
+
+  var index, length, pair, keys, result,
+      object = data;
+
+  result = new Array(object.length);
+
+  for (index = 0, length = object.length; index < length; index += 1) {
+    pair = object[index];
+
+    keys = Object.keys(pair);
+
+    result[index] = [ keys[0], pair[keys[0]] ];
+  }
+
+  return result;
+}
+
+module.exports = new Type('tag:yaml.org,2002:pairs', {
+  kind: 'sequence',
+  resolve: resolveYamlPairs,
+  construct: constructYamlPairs
+});
+
+},{"../type":13}],26:[function(require,module,exports){
+'use strict';
+
+var Type = require('../type');
+
+module.exports = new Type('tag:yaml.org,2002:seq', {
+  kind: 'sequence',
+  construct: function (data) { return data !== null ? data : []; }
+});
+
+},{"../type":13}],27:[function(require,module,exports){
+'use strict';
+
+var Type = require('../type');
+
+var _hasOwnProperty = Object.prototype.hasOwnProperty;
+
+function resolveYamlSet(data) {
+  if (data === null) return true;
+
+  var key, object = data;
+
+  for (key in object) {
+    if (_hasOwnProperty.call(object, key)) {
+      if (object[key] !== null) return false;
+    }
+  }
+
+  return true;
+}
+
+function constructYamlSet(data) {
+  return data !== null ? data : {};
+}
+
+module.exports = new Type('tag:yaml.org,2002:set', {
+  kind: 'mapping',
+  resolve: resolveYamlSet,
+  construct: constructYamlSet
+});
+
+},{"../type":13}],28:[function(require,module,exports){
+'use strict';
+
+var Type = require('../type');
+
+module.exports = new Type('tag:yaml.org,2002:str', {
+  kind: 'scalar',
+  construct: function (data) { return data !== null ? data : ''; }
+});
+
+},{"../type":13}],29:[function(require,module,exports){
+'use strict';
+
+var Type = require('../type');
+
+var YAML_DATE_REGEXP = new RegExp(
+  '^([0-9][0-9][0-9][0-9])'          + // [1] year
+  '-([0-9][0-9])'                    + // [2] month
+  '-([0-9][0-9])$');                   // [3] day
+
+var YAML_TIMESTAMP_REGEXP = new RegExp(
+  '^([0-9][0-9][0-9][0-9])'          + // [1] year
+  '-([0-9][0-9]?)'                   + // [2] month
+  '-([0-9][0-9]?)'                   + // [3] day
+  '(?:[Tt]|[ \\t]+)'                 + // ...
+  '([0-9][0-9]?)'                    + // [4] hour
+  ':([0-9][0-9])'                    + // [5] minute
+  ':([0-9][0-9])'                    + // [6] second
+  '(?:\\.([0-9]*))?'                 + // [7] fraction
+  '(?:[ \\t]*(Z|([-+])([0-9][0-9]?)' + // [8] tz [9] tz_sign [10] tz_hour
+  '(?::([0-9][0-9]))?))?$');           // [11] tz_minute
+
+function resolveYamlTimestamp(data) {
+  if (data === null) return false;
+  if (YAML_DATE_REGEXP.exec(data) !== null) return true;
+  if (YAML_TIMESTAMP_REGEXP.exec(data) !== null) return true;
+  return false;
+}
+
+function constructYamlTimestamp(data) {
+  var match, year, month, day, hour, minute, second, fraction = 0,
+      delta = null, tz_hour, tz_minute, date;
+
+  match = YAML_DATE_REGEXP.exec(data);
+  if (match === null) match = YAML_TIMESTAMP_REGEXP.exec(data);
+
+  if (match === null) throw new Error('Date resolve error');
+
+  // match: [1] year [2] month [3] day
+
+  year = +(match[1]);
+  month = +(match[2]) - 1; // JS month starts with 0
+  day = +(match[3]);
+
+  if (!match[4]) { // no hour
+    return new Date(Date.UTC(year, month, day));
+  }
+
+  // match: [4] hour [5] minute [6] second [7] fraction
+
+  hour = +(match[4]);
+  minute = +(match[5]);
+  second = +(match[6]);
+
+  if (match[7]) {
+    fraction = match[7].slice(0, 3);
+    while (fraction.length < 3) { // milli-seconds
+      fraction += '0';
+    }
+    fraction = +fraction;
+  }
+
+  // match: [8] tz [9] tz_sign [10] tz_hour [11] tz_minute
+
+  if (match[9]) {
+    tz_hour = +(match[10]);
+    tz_minute = +(match[11] || 0);
+    delta = (tz_hour * 60 + tz_minute) * 60000; // delta in mili-seconds
+    if (match[9] === '-') delta = -delta;
+  }
+
+  date = new Date(Date.UTC(year, month, day, hour, minute, second, fraction));
+
+  if (delta) date.setTime(date.getTime() - delta);
+
+  return date;
+}
+
+function representYamlTimestamp(object /*, style*/) {
+  return object.toISOString();
+}
+
+module.exports = new Type('tag:yaml.org,2002:timestamp', {
+  kind: 'scalar',
+  resolve: resolveYamlTimestamp,
+  construct: constructYamlTimestamp,
+  instanceOf: Date,
+  represent: representYamlTimestamp
+});
+
+},{"../type":13}],"/":[function(require,module,exports){
+'use strict';
+
+
+var yaml = require('./lib/js-yaml.js');
+
+
+module.exports = yaml;
+
+},{"./lib/js-yaml.js":1}]},{},[])("/")
+});

--- a/docker/nginx-gateway.conf
+++ b/docker/nginx-gateway.conf
@@ -50,6 +50,7 @@ server {
         proxy_http_version            1.1;
         proxy_set_header Upgrade      $http_upgrade;
         proxy_set_header Connection   $connection_upgrade;
+        proxy_socket_keepalive        on;
     }
 
     # Jolokia agent reverse proxying

--- a/docker/nginx-gateway.conf
+++ b/docker/nginx-gateway.conf
@@ -76,7 +76,6 @@ server {
         proxy_cache                   rbac;
         proxy_cache_methods           POST;
         proxy_cache_key               $uri$is_args$args|$http_authorization;
-        proxy_cache_lock              on;
         proxy_cache_valid             201 10s;
         proxy_ignore_headers          Cache-Control;
     }
@@ -96,7 +95,6 @@ server {
         proxy_cache                   rbac2;
         proxy_cache_methods           POST;
         proxy_cache_key               $uri$is_args$args|$http_authorization;
-        proxy_cache_lock              on;
         proxy_cache_valid             201 10s;
         proxy_ignore_headers          Cache-Control;
     }
@@ -112,7 +110,6 @@ server {
         proxy_ssl_trusted_certificate /var/run/secrets/kubernetes.io/serviceaccount/ca.crt;
         proxy_ssl_session_reuse       on;
         proxy_cache                   pods;
-        proxy_cache_lock              on;
         proxy_cache_valid             200 1m;
         proxy_ignore_headers          Cache-Control;
     }

--- a/docker/nginx-gateway.conf
+++ b/docker/nginx-gateway.conf
@@ -50,7 +50,6 @@ server {
         proxy_http_version            1.1;
         proxy_set_header Upgrade      $http_upgrade;
         proxy_set_header Connection   $connection_upgrade;
-        proxy_socket_keepalive        on;
     }
 
     # Jolokia agent reverse proxying

--- a/docker/nginx-gateway.conf
+++ b/docker/nginx-gateway.conf
@@ -22,6 +22,11 @@ server {
     gzip                on;
     root                /usr/share/nginx/html/;
 
+    # Performance tuning
+    subrequest_output_buffer_size 10m;
+    client_body_buffer_size       256k;
+    proxy_buffers                 16 128k;
+
     if ($new) {
         rewrite ^ $new redirect;
     }
@@ -51,10 +56,6 @@ server {
         proxy_set_header Upgrade      $http_upgrade;
         proxy_set_header Connection   $connection_upgrade;
     }
-
-    # Jolokia agent reverse proxying
-    subrequest_output_buffer_size 10m;
-    client_body_buffer_size       256k;
 
     location /management {
         js_content gateway.proxyJolokiaAgent;

--- a/docker/nginx-gateway.conf
+++ b/docker/nginx-gateway.conf
@@ -1,4 +1,4 @@
-js_include conf.d/nginx.js;
+js_import gateway from conf.d/nginx.js;
 
 proxy_cache_path /var/cache/nginx/pods levels=1:2 keys_zone=pods:1m max_size=2m inactive=60m use_temp_path=off;
 proxy_cache_path /var/cache/nginx/rbac levels=1:2 keys_zone=rbac:100k max_size=1m inactive=60m use_temp_path=off;
@@ -58,7 +58,7 @@ server {
     client_body_buffer_size       256k;
 
     location /management {
-        js_content proxyJolokiaAgent;
+        js_content gateway.proxyJolokiaAgent;
     }
 
     # Self-LocalSubjectSccessReview requests cache

--- a/docker/nginx-gateway.conf
+++ b/docker/nginx-gateway.conf
@@ -2,6 +2,7 @@ js_include conf.d/nginx.js;
 
 proxy_cache_path /var/cache/nginx/pods levels=1:2 keys_zone=pods:1m max_size=2m inactive=60m use_temp_path=off;
 proxy_cache_path /var/cache/nginx/rbac levels=1:2 keys_zone=rbac:100k max_size=1m inactive=60m use_temp_path=off;
+proxy_cache_path /var/cache/nginx/rbac2 levels=1:2 keys_zone=rbac2:100k max_size=1m inactive=60m use_temp_path=off;
 
 map $uri $new {
     / /online/;
@@ -73,7 +74,27 @@ server {
         proxy_ssl_session_reuse       on;
         proxy_cache                   rbac;
         proxy_cache_methods           POST;
-        proxy_cache_key               $http_authorization;
+        proxy_cache_key               $uri$is_args$args|$http_authorization;
+        proxy_cache_lock              on;
+        proxy_cache_valid             201 10s;
+        proxy_ignore_headers          Cache-Control;
+    }
+    # Duplicated location, as it seems caching does not handle multiple sub-requests calling the same location
+    # leading to different hash keys :(
+    location /authorization2 {
+        internal;
+        proxy_pass                    https://kubernetes.default/;
+        rewrite                       /authorization2/(.*) /apis/authorization.openshift.io/v1/$1 break;
+        proxy_set_header              Content-Type application/json;
+        proxy_pass_request_headers    on;
+        proxy_pass_request_body       on;
+        proxy_redirect                off;
+        proxy_ssl_verify              on;
+        proxy_ssl_trusted_certificate /var/run/secrets/kubernetes.io/serviceaccount/ca.crt;
+        proxy_ssl_session_reuse       on;
+        proxy_cache                   rbac2;
+        proxy_cache_methods           POST;
+        proxy_cache_key               $uri$is_args$args|$http_authorization;
         proxy_cache_lock              on;
         proxy_cache_valid             201 10s;
         proxy_ignore_headers          Cache-Control;

--- a/docker/nginx.js
+++ b/docker/nginx.js
@@ -49,14 +49,16 @@ function proxyJolokiaAgent(req) {
 
   function checkAuthorization(role, request) {
     var mbean = request.mbean;
-    var i = mbean.indexOf(':');
-    var domain = i === -1 ? mbean : mbean.substring(0, i);
-    var properties = mbean.substring(i + 1);
-    var regexp = /([^,]+)=([^,]+)+/g;
-    var objectName = {};
-    var match;
-    while ((match = regexp.exec(properties)) !== null) {
-      objectName[match[1]] = match[2];
+    var domain, objectName = {};
+    if (mbean) {
+      var i = mbean.indexOf(':');
+      domain = i === -1 ? mbean : mbean.substring(0, i);
+      var properties = mbean.substring(i + 1);
+      var regexp = /([^,]+)=([^,]+)+/g;
+      var match;
+      while ((match = regexp.exec(properties)) !== null) {
+        objectName[match[1]] = match[2];
+      }
     }
     return rbac(role, {
       type: request.type,

--- a/docker/nginx.js
+++ b/docker/nginx.js
@@ -37,7 +37,8 @@ function proxyJolokiaAgent(req) {
   }
 
   function selfLocalSubjectAccessReview(verb) {
-    return req.subrequest(`/authorization/namespaces/${namespace}/localsubjectaccessreviews`, {
+    // Work-around same-location sub-requests caching issue
+    return req.subrequest(`/authorization${verb === 'get' ? '2' : ''}/namespaces/${namespace}/localsubjectaccessreviews`, {
       method: 'POST',
       body: JSON.stringify({
         kind: 'LocalSubjectAccessReview',

--- a/docker/nginx.js
+++ b/docker/nginx.js
@@ -2,7 +2,7 @@
 // https://github.com/nginx/njs
 // https://github.com/xeioex/njs-examples
 
-import RBAC from '/rbac.js';
+import RBAC from 'rbac.js';
 
 export default { proxyJolokiaAgent };
 

--- a/docker/nginx.js
+++ b/docker/nginx.js
@@ -22,11 +22,8 @@ function proxyJolokiaAgent(req) {
   var path = parts[5];
 
   function response(res) {
-    // Iterate over headersOut properties when it becomes enumerable
-    if (res.headersOut) {
-      req.headersOut['Content-Type'] = res.headersOut['Content-Type'];
-      req.headersOut['Content-Length'] = res.headersOut['Content-Length'];
-      req.headersOut['Cache-Control'] = res.headersOut['Cache-Control'];
+    for (var header in res.headersOut) {
+      req.headersOut[header] = res.headersOut[header];
     }
     req.return(res.status, res.responseBody);
   }

--- a/docker/nginx.js
+++ b/docker/nginx.js
@@ -50,7 +50,7 @@ function proxyJolokiaAgent(req) {
   function checkAuthorization(role, request) {
     var mbean = request.mbean;
     var i = mbean.indexOf(':');
-    var domain = mbean.substring(0, i);
+    var domain = i === -1 ? mbean : mbean.substring(0, i);
     var properties = mbean.substring(i + 1);
     var regexp = /([^,]+)=([^,]+)+/g;
     var objectName = {};

--- a/docker/nginx.js
+++ b/docker/nginx.js
@@ -30,6 +30,9 @@ function proxyJolokiaAgent(req) {
     return Promise.reject({
       status: status,
       responseBody: message,
+      headersOut: {
+        'Content-Type': 'application/json',
+      }
     });
   }
 
@@ -90,7 +93,7 @@ function proxyJolokiaAgent(req) {
             // map the 'get' verb to the 'viewer' role
             return 'viewer';
           }
-          return reject(403, sar.reason);
+          return reject(403, JSON.stringify(sar));
         })
     })
     .then(function (role) {

--- a/docker/nginx.js
+++ b/docker/nginx.js
@@ -147,12 +147,10 @@ function proxyJolokiaAgent(req) {
     })
     .then(response)
     .catch(function (error) {
-      if (error instanceof Error) {
-        req.return(502, error);
-      } else if (typeof error === 'object') {
+      if (error.status) {
         response(error);
       } else {
-        req.return(500, error);
+        req.return(502, error);
       }
     });
 }

--- a/docker/nginx.js
+++ b/docker/nginx.js
@@ -81,7 +81,7 @@ function proxyJolokiaAgent(req) {
     return req.subrequest(`/proxy/${protocol}:${podIP}:${port}/${path}`, { method: req.method, body: request });
   }
 
-  selfLocalSubjectAccessReview('update')
+  return selfLocalSubjectAccessReview('update')
     .then(function (res) {
       if (res.status !== 201) {
         return Promise.reject(res);

--- a/docker/nginx.js
+++ b/docker/nginx.js
@@ -4,6 +4,8 @@
 
 import RBAC from '/rbac.js';
 
+export default { proxyJolokiaAgent };
+
 // Only Jolokia requests using the POST method are currently supported,
 // as this is more comprehensive and it's what the front-end uses.
 // Still, we may want to support GET requests as well, by adapting the inputs.

--- a/docker/nginx.repo
+++ b/docker/nginx.repo
@@ -1,5 +1,5 @@
 [nginx]
 name=nginx repo
-baseurl=http://nginx.org/packages/mainline/rhel/7/$basearch/
+baseurl=http://nginx.org/packages/rhel/7/$basearch/
 gpgcheck=1
 enabled=1

--- a/docker/nginx.repo
+++ b/docker/nginx.repo
@@ -1,5 +1,5 @@
 [nginx]
 name=nginx repo
-baseurl=http://nginx.org/packages/rhel/7/$basearch/
+baseurl=http://nginx.org/packages/mainline/rhel/7/$basearch/
 gpgcheck=1
 enabled=1

--- a/docker/nginx.sh
+++ b/docker/nginx.sh
@@ -8,9 +8,14 @@ set -eu
 
 ./config.sh > config.js
 
-if [ "${HAWTIO_ONLINE_GATEWAY:-}" = "true" ]; then
+if [ -v HAWTIO_ONLINE_RBAC_ACL ]; then
+  echo Using RBAC NGINX configuration
+  ln -sf /nginx-gateway.conf /etc/nginx/conf.d/nginx.conf
+elif [ "${HAWTIO_ONLINE_GATEWAY:-}" = "true" ]; then
+  echo Using gateway NGINX configuration
   ln -sf /nginx-gateway.conf /etc/nginx/conf.d/nginx.conf
 else
+  echo Using legacy NGINX configuration
   ln -sf /nginx.conf /etc/nginx/conf.d/nginx.conf
 fi
 

--- a/docker/rbac.js
+++ b/docker/rbac.js
@@ -3,7 +3,7 @@ import jsyaml from '/js-yaml.js';
 var fs = require('fs');
 
 // TODO: ACL location should be parameterized
-var ACL = jsyaml.load(fs.readFileSync('ACL.yaml'));
+var ACL = jsyaml.safeLoad(fs.readFileSync('ACL.yaml'));
 
 var regex = /^\/.*\/$/;
 

--- a/docker/rbac.js
+++ b/docker/rbac.js
@@ -1,0 +1,85 @@
+import jsyaml from '/js-yaml.js';
+
+var fs = require('fs');
+
+// TODO: ACL location should be parameterized
+var ACL = jsyaml.load(fs.readFileSync('ACL.yaml'));
+
+var regex = /^\/.*\/$/;
+
+function checkACL(role, jolokia, name) {
+  var acl = ACL[name];
+  if (!acl) {
+    return null;
+  }
+  var member = jolokia.operation || jolokia.attribute;
+  if (Array.isArray(acl)) {
+    var entry = acl.map(a => Object.entries(a)[0])
+      .find(e => e[0] === member || regex.test(e[0]) && new RegExp(e[0].substring(1, e[0].length - 1)).test(member));
+    if (entry) {
+      return checkRoles(role, jolokia, name, entry[0], entry[1]);
+    }
+  } else if (typeof acl === 'object') {
+    // direct match?
+    if (acl[member]) {
+      return checkRoles(role, jolokia, name, member, acl[member]);
+    }
+    // test regex keys
+    var entry = Object.entries(acl).filter(e => regex.test(e[0])).find(e => new RegExp(e[0].substring(1, e[0].length - 1)).test(member));
+    if (entry) {
+      return checkRoles(role, jolokia, name, entry[0], entry[1]);
+    }
+  }
+  return null;
+}
+
+function checkRoles(role, jolokia, name, key, roles) {
+  var allowed = { allowed: true, reason: `Role '${role}' allowed by '${name}[${key}]: ${roles}'` };
+  var denied = { allowed: false, reason: `Role '${role}' denied by '${name}[${key}]: ${roles}'` };
+
+  if (Array.isArray(roles)) {
+    // direct match?
+    if (roles.includes(role)) {
+      return allowed;
+    }
+    // test regex roles
+    var match = roles.filter(r => regex.test(r)).find(r => new RegExp(r.substring(1, r.length - 1)).test(role));
+    if (match) {
+      return allowed;
+    }
+    return denied;
+
+  } else if (typeof roles === 'string') {
+    if (roles === role) {
+      return allowed;
+    }
+    if (regex.test(roles) && new RegExp(roles.substring(1, roles.length - 1)).test(role)) {
+      return allowed;
+    }
+    return denied;
+  }
+  throw Error(`Unsupported roles '${roles}' in '${name}[${key}]'`);
+}
+
+export default function check(role, jolokia) {
+  var rbac;
+  // lookup ACL by domain and type
+  if (jolokia.properties.type) {
+    rbac = checkACL(role, jolokia, `${jolokia.domain}.${jolokia.properties.type}`);
+    if (rbac) {
+      return rbac;
+    } 
+  }
+  // lookup ACL by domain
+  rbac = checkACL(role, jolokia, jolokia.domain);
+  if (rbac) {
+    return rbac;
+  }
+  // fallback to default ACL if any
+  rbac = checkACL(role, jolokia, 'default');
+  if (rbac) {
+    return rbac;
+  }
+  // unauthorize by default
+  return { allowed: false, reason: `No ACL matching request ${JSON.stringify(jolokia)}` };
+}

--- a/docker/rbac.js
+++ b/docker/rbac.js
@@ -2,8 +2,7 @@ import jsyaml from 'js-yaml.js';
 
 var fs = require('fs');
 
-// TODO: ACL location should be parameterized
-var ACL = jsyaml.safeLoad(fs.readFileSync('ACL.yaml'));
+var ACL = jsyaml.safeLoad(fs.readFileSync(process.env['HAWTIO_ONLINE_RBAC_ACL'] || 'ACL.yaml'));
 var regex = /^\/.*\/$/;
 var rbacMBean = 'hawtio:area=jmx,type=security';
 

--- a/docker/rbac.js
+++ b/docker/rbac.js
@@ -67,8 +67,10 @@ function checkACL(role, jolokia, name) {
     } else {
       member = jolokia.operation.slice(0, -2);
     }
-  } else {
+  } else if (jolokia.attribute) {
     member = jolokia.attribute;
+  } else {
+    member = jolokia.type;
   }
 
   if (Array.isArray(acl)) {

--- a/docker/rbac.js
+++ b/docker/rbac.js
@@ -156,7 +156,7 @@ function checkACL(role, jolokia, name) {
   } else if (jolokia.attribute) {
     member = jolokia.attribute;
   } else {
-    member = jolokia.type;
+    member = jolokia.type.toLowerCase();
   }
 
   if (Array.isArray(acl)) {

--- a/docker/rbac.js
+++ b/docker/rbac.js
@@ -1,19 +1,13 @@
-import jsyaml from '/js-yaml.js';
+import jsyaml from 'js-yaml.js';
 
 var fs = require('fs');
 
 // TODO: ACL location should be parameterized
 var ACL = jsyaml.safeLoad(fs.readFileSync('ACL.yaml'));
-
 var regex = /^\/.*\/$/;
-
-export default {
-  check: check,
-  intercept: intercept,
-  isCanInvokeRequest: isCanInvokeRequest,
-};
-
 var rbacMBean = 'hawtio:area=jmx,type=security';
+
+export default { check, intercept, isCanInvokeRequest };
 
 function isCanInvokeRequest(request) {
   return request.type === 'exec' && request.mbean === rbacMBean && request.operation === 'canInvoke(java.lang.String)';

--- a/docker/rbac.js
+++ b/docker/rbac.js
@@ -10,9 +10,14 @@ var regex = /^\/.*\/$/;
 export default {
   check: check,
   intercept: intercept,
+  isCanInvokeRequest: isCanInvokeRequest,
 };
 
 var rbacMBean = 'hawtio:area=jmx,type=security';
+
+function isCanInvokeRequest(request) {
+  return request.type === 'exec' && request.mbean === rbacMBean && request.operation === 'canInvoke(java.lang.String)';
+}
 
 function intercept(request, role, mbeans) {
   var response = value => ({
@@ -32,7 +37,7 @@ function intercept(request, role, mbeans) {
   }
 
   // Intercept client-side RBAC canInvoke(java.lang.String) request
-  if (request.type === 'exec' && request.mbean === rbacMBean && request.operation === 'canInvoke(java.lang.String)') {
+  if (isCanInvokeRequest(request)) {
     var mbean = request.arguments[0];
     var i = mbean.indexOf(':');
     var domain = i === -1 ? mbean : mbean.substring(0, i);

--- a/docker/rbac.js
+++ b/docker/rbac.js
@@ -64,16 +64,18 @@ function checkRoles(role, jolokia, name, key, roles) {
 export default function check(role, jolokia) {
   var rbac;
   // lookup ACL by domain and type
-  if (jolokia.properties.type) {
+  if (jolokia.properties && jolokia.properties.type) {
     rbac = checkACL(role, jolokia, `${jolokia.domain}.${jolokia.properties.type}`);
     if (rbac) {
       return rbac;
     } 
   }
   // lookup ACL by domain
-  rbac = checkACL(role, jolokia, jolokia.domain);
-  if (rbac) {
-    return rbac;
+  if (jolokia.domain) {
+    rbac = checkACL(role, jolokia, jolokia.domain);
+    if (rbac) {
+      return rbac;
+    }
   }
   // fallback to default ACL if any
   rbac = checkACL(role, jolokia, 'default');

--- a/docker/rbac.js
+++ b/docker/rbac.js
@@ -37,6 +37,10 @@ function checkRoles(role, jolokia, name, key, roles) {
   var allowed = { allowed: true, reason: `Role '${role}' allowed by '${name}[${key}]: ${roles}'` };
   var denied = { allowed: false, reason: `Role '${role}' denied by '${name}[${key}]: ${roles}'` };
 
+  if (typeof roles === 'string') {
+    roles = roles.split(',').map(r => r.trim()).filter(r => r);
+  }
+
   if (Array.isArray(roles)) {
     // direct match?
     if (roles.includes(role)) {
@@ -48,16 +52,8 @@ function checkRoles(role, jolokia, name, key, roles) {
       return allowed;
     }
     return denied;
-
-  } else if (typeof roles === 'string') {
-    if (roles === role) {
-      return allowed;
-    }
-    if (regex.test(roles) && new RegExp(roles.substring(1, roles.length - 1)).test(role)) {
-      return allowed;
-    }
-    return denied;
   }
+
   throw Error(`Unsupported roles '${roles}' in '${name}[${key}]'`);
 }
 

--- a/docker/rbac.js
+++ b/docker/rbac.js
@@ -7,7 +7,33 @@ var ACL = jsyaml.safeLoad(fs.readFileSync('ACL.yaml'));
 
 var regex = /^\/.*\/$/;
 
-export default function check(role, request) {
+export default {
+  check: check,
+  intercept: intercept,
+};
+
+function intercept(request) {
+  if (request.type === 'search' && request.mbean === '*:type=security,area=jmx,*') {
+    return {
+      intercepted: true,
+      request: request,
+      response: {
+        status: 200,
+        request: request,
+        value: [
+          'io.hawt:area=jmx,type=security',
+        ],
+        timestamp: new Date().getTime(),
+      }
+    };
+  }
+  return {
+    intercepted: false,
+    request: request,
+  };
+}
+
+function check(role, request) {
   var mbean = request.mbean;
   var domain, objectName = {};
   if (mbean) {

--- a/docker/test.js
+++ b/docker/test.js
@@ -144,12 +144,12 @@ function canInvokeSingleOperationTest() {
   return proxyJolokiaAgent({
     uri: '/management/namespaces/test/pods/https:pod:443/remaining',
     requestBody: JSON.stringify({
-      "type": "exec",
-      "mbean": "hawtio:area=jmx,type=security",
-      "operation": "canInvoke(java.lang.String)",
-      "arguments": [
-        // "java.lang:name=Compressed Class Space,type=MemoryPool",
-        "org.apache.camel:context=MyCamel,name=\"simple-route\",type=routes",
+      'type': 'exec',
+      'mbean': 'hawtio:area=jmx,type=security',
+      'operation': 'canInvoke(java.lang.String)',
+      'arguments': [
+        // 'java.lang:name=Compressed Class Space,type=MemoryPool',
+        'org.apache.camel:context=MyCamel,name="simple-route",type=routes',
       ]
     }),
     headersOut: {},
@@ -164,12 +164,43 @@ function canInvokeSingleAttributeTest() {
   return proxyJolokiaAgent({
     uri: '/management/namespaces/test/pods/https:pod:443/remaining',
     requestBody: JSON.stringify({
-      "type": "exec",
-      "mbean": "hawtio:area=jmx,type=security",
-      "operation": "canInvoke(java.lang.String)",
-      "arguments": [
-        // "java.lang:name=PS Scavenge,type=GarbageCollector",
-        "java.lang:name=PS Old Gen,type=MemoryPool",
+      'type': 'exec',
+      'mbean': 'hawtio:area=jmx,type=security',
+      'operation': 'canInvoke(java.lang.String)',
+      'arguments': [
+        // 'java.lang:name=PS Scavenge,type=GarbageCollector',
+        'java.lang:name=PS Old Gen,type=MemoryPool',
+      ]
+    }),
+    headersOut: {},
+    subrequest: doWithViewerRole,
+    return: (code, message) => {
+      console.log('code:', code, 'message:', message);
+    },
+  });
+}
+
+function canInvokeMapTest() {
+  return proxyJolokiaAgent({
+    uri: '/management/namespaces/test/pods/https:pod:443/remaining',
+    requestBody: JSON.stringify({
+      'type': 'exec',
+      'mbean': 'hawtio:area=jmx,type=security',
+      'operation': 'canInvoke(java.util.Map)',
+      'arguments': [
+        {
+          'java.lang:type=Memory': [
+            'gc()',
+          ],
+          'org.apache.camel:context=io.fabric8.quickstarts.karaf-camel-log-log-example-context,name="log-example-context",type=context': [
+            'addOrUpdateRoutesFromXml(java.lang.String)',
+            'addOrUpdateRoutesFromXml(java.lang.String,boolean)',
+            'dumpStatsAsXml(boolean)',
+            'getCamelId()',
+            'getRedeliveries()',
+            'sendStringBody(java.lang.String,java.lang.String)',
+          ],
+        },
       ]
     }),
     headersOut: {},
@@ -244,4 +275,5 @@ Promise.resolve()
   .then(bulkRequestWithInterceptionTest)
   .then(canInvokeSingleOperationTest)
   .then(canInvokeSingleAttributeTest)
+  .then(canInvokeMapTest)
   ;

--- a/docker/test.js
+++ b/docker/test.js
@@ -1,3 +1,8 @@
+// This test file can be run using the NJS CLI.
+// The test result depends on the HAWTIO_ONLINE_RBAC_ACL environment variable.
+// To test with RBAC enabled:
+// HAWTIO_ONLINE_RBAC_ACL= njs test.js
+
 import gateway from 'nginx.js';
 
 var fs = require('fs');

--- a/docker/test.js
+++ b/docker/test.js
@@ -7,7 +7,7 @@ function requestWithViewerRoleTest() {
     uri: '/management/namespaces/test/pods/https:pod:443/remaining',
     requestBody: JSON.stringify({
       mbean: 'org.apache.camel:type=context',
-      operation: 'dumpRoutesAsXml',
+      operation: 'dumpRoutesAsXml()',
     }),
     headersOut: {},
     subrequest: doWithViewerRole,
@@ -23,13 +23,50 @@ function bulkRequestWithViewerRoleTest() {
     requestBody: JSON.stringify([
       {
         mbean: 'org.apache.camel:type=context',
-        operation: 'dumpRoutesAsXml',
+        operation: 'dumpRoutesAsXml()',
       },
       {
         mbean: 'java.lang.Memory',
-        operation: 'gc',
+        operation: 'gc()',
       },
     ]),
+    headersOut: {},
+    subrequest: doWithViewerRole,
+    return: (code, message) => {
+      console.log('code:', code, 'message:', message);
+    },
+  });
+}
+
+function requestOperationWithArgumentsAndNoRoleTest() {
+  return proxyJolokiaAgent({
+    uri: '/management/namespaces/test/pods/https:pod:443/remaining',
+    requestBody: JSON.stringify({
+      mbean: 'org.apache.karaf:type=bundle',
+      operation: 'uninstall(java.lang.String)',
+      arguments: [
+        '0',
+      ],
+    }),
+    headersOut: {},
+    subrequest: doWithViewerRole,
+    return: (code, message) => {
+      console.log('code:', code, 'message:', message);
+    },
+  });
+}
+
+function requestOperationWithArgumentsAndViewerRoleTest() {
+  return proxyJolokiaAgent({
+    uri: '/management/namespaces/test/pods/https:pod:443/remaining',
+    requestBody: JSON.stringify({
+      mbean: 'org.apache.karaf:type=bundle',
+      operation: 'update(java.lang.String,java.lang.String)',
+      arguments: [
+        '50',
+        'value',
+      ],
+    }),
     headersOut: {},
     subrequest: doWithViewerRole,
     return: (code, message) => {
@@ -87,4 +124,6 @@ function doWithViewerRole(uri, options) {
 
 Promise.resolve()
   .then(requestWithViewerRoleTest)
-  .then(bulkRequestWithViewerRoleTest);
+  .then(bulkRequestWithViewerRoleTest)
+  .then(requestOperationWithArgumentsAndNoRoleTest)
+  .then(requestOperationWithArgumentsAndViewerRoleTest);

--- a/docker/test.js
+++ b/docker/test.js
@@ -2,41 +2,69 @@
 // https://github.com/nginx/njs/issues/115
 import proxyJolokiaAgent from './nginx.js'
 
-proxyJolokiaAgent({
-  uri: '/management/namespaces/test/pods/https:pod:443/remaining',
-  requestBody: JSON.stringify({
-    mbean: 'org.apache.camel:type=context',
-    operation: 'dumpRoutesAsXml',
-  }),
-  headersOut: {},
-  subrequest: (uri, options, callback) => {
-    var body = JSON.parse(options.body || '{}');
-    var res;
-    if (uri.startsWith('/authorization') && body.verb === 'update') {
-      res = {
-        status: 201,
-        responseBody: JSON.stringify({
-          allowed: false,
-        }),
-      };
-    }
-    if (uri.startsWith('/authorization') && body.verb === 'get') {
-      res = {
-        status: 201,
-        responseBody: JSON.stringify({
-          allowed: true,
-        }),
-      };
-    }
-    if (!res) {
-      res = {
-        status: 404,
-        responseBody: `No stub for ${uri}`,
-      }
-    }
-    callback(Object.assign({ headersOut: {} }, res));
-  },
-  return: (code, message) => {
-    console.log('code:', code, 'message:', message);
-  },
-});
+function requestWithViewerRoleTest() {
+  proxyJolokiaAgent({
+    uri: '/management/namespaces/test/pods/https:pod:443/remaining',
+    requestBody: JSON.stringify({
+      mbean: 'org.apache.camel:type=context',
+      operation: 'dumpRoutesAsXml',
+    }),
+    headersOut: {},
+    subrequest: doWithViewerRole,
+    return: (code, message) => {
+      console.log('code:', code, 'message:', message);
+    },
+  });
+}
+
+function batchRequestWithViewerRoleTest() {
+  proxyJolokiaAgent({
+    uri: '/management/namespaces/test/pods/https:pod:443/remaining',
+    requestBody: JSON.stringify([
+      {
+        mbean: 'org.apache.camel:type=context',
+        operation: 'dumpRoutesAsXml',
+      },
+      {
+        mbean: 'java.lang.Memory',
+        operation: 'gc',
+      },
+    ]),
+    headersOut: {},
+    subrequest: doWithViewerRole,
+    return: (code, message) => {
+      console.log('code:', code, 'message:', message);
+    },
+  });
+}
+
+function doWithViewerRole(uri, options) {
+  var body = JSON.parse(options.body || '{}');
+  var res;
+  if (uri.startsWith('/authorization') && body.verb === 'update') {
+    res = {
+      status: 201,
+      responseBody: JSON.stringify({
+        allowed: false,
+      }),
+    };
+  }
+  if (uri.startsWith('/authorization') && body.verb === 'get') {
+    res = {
+      status: 201,
+      responseBody: JSON.stringify({
+        allowed: true,
+      }),
+    };
+  }
+  if (!res) {
+    return Promise.reject(Error(`No stub for ${uri}`));
+  }
+  Object.assign(res, {
+    headersOut: {},
+  });
+  return Promise.resolve(res);
+}
+
+requestWithViewerRoleTest();
+batchRequestWithViewerRoleTest();

--- a/docker/test.js
+++ b/docker/test.js
@@ -17,7 +17,7 @@ function requestWithViewerRoleTest() {
   });
 }
 
-function batchRequestWithViewerRoleTest() {
+function bulkRequestWithViewerRoleTest() {
   proxyJolokiaAgent({
     uri: '/management/namespaces/test/pods/https:pod:443/remaining',
     requestBody: JSON.stringify([
@@ -57,6 +57,25 @@ function doWithViewerRole(uri, options) {
       }),
     };
   }
+  if (uri.startsWith('/podIP')) {
+    res = {
+      status: 200,
+      responseBody: JSON.stringify({
+        status: {
+          podIP: '0.0.0.0',
+        },
+      }),
+    };
+  }
+  if (uri.startsWith('/proxy')) {
+    res = {
+      status: 200,
+      responseBody: JSON.stringify(Array.isArray(body)
+        ? body.map(b => ({ request: b, status: 200, value: 'VALUE' }))
+        : { request: body, status: 200, value: 'VALUE' },
+      ),
+    };
+  }
   if (!res) {
     return Promise.reject(Error(`No stub for ${uri}`));
   }
@@ -67,4 +86,4 @@ function doWithViewerRole(uri, options) {
 }
 
 requestWithViewerRoleTest();
-batchRequestWithViewerRoleTest();
+bulkRequestWithViewerRoleTest();

--- a/docker/test.js
+++ b/docker/test.js
@@ -3,7 +3,7 @@
 import proxyJolokiaAgent from './nginx.js'
 
 function requestWithViewerRoleTest() {
-  proxyJolokiaAgent({
+  return proxyJolokiaAgent({
     uri: '/management/namespaces/test/pods/https:pod:443/remaining',
     requestBody: JSON.stringify({
       mbean: 'org.apache.camel:type=context',
@@ -18,7 +18,7 @@ function requestWithViewerRoleTest() {
 }
 
 function bulkRequestWithViewerRoleTest() {
-  proxyJolokiaAgent({
+  return proxyJolokiaAgent({
     uri: '/management/namespaces/test/pods/https:pod:443/remaining',
     requestBody: JSON.stringify([
       {
@@ -85,5 +85,6 @@ function doWithViewerRole(uri, options) {
   return Promise.resolve(res);
 }
 
-requestWithViewerRoleTest();
-bulkRequestWithViewerRoleTest();
+Promise.resolve()
+  .then(requestWithViewerRoleTest)
+  .then(bulkRequestWithViewerRoleTest);

--- a/docker/test.js
+++ b/docker/test.js
@@ -140,7 +140,7 @@ function bulkRequestWithInterceptionTest() {
   });
 }
 
-function singleCanInvokeOperationTest() {
+function canInvokeSingleOperationTest() {
   return proxyJolokiaAgent({
     uri: '/management/namespaces/test/pods/https:pod:443/remaining',
     requestBody: JSON.stringify({
@@ -150,6 +150,26 @@ function singleCanInvokeOperationTest() {
       "arguments": [
         // "java.lang:name=Compressed Class Space,type=MemoryPool",
         "org.apache.camel:context=MyCamel,name=\"simple-route\",type=routes",
+      ]
+    }),
+    headersOut: {},
+    subrequest: doWithViewerRole,
+    return: (code, message) => {
+      console.log('code:', code, 'message:', message);
+    },
+  });
+}
+
+function canInvokeSingleAttributeTest() {
+  return proxyJolokiaAgent({
+    uri: '/management/namespaces/test/pods/https:pod:443/remaining',
+    requestBody: JSON.stringify({
+      "type": "exec",
+      "mbean": "hawtio:area=jmx,type=security",
+      "operation": "canInvoke(java.lang.String)",
+      "arguments": [
+        // "java.lang:name=PS Scavenge,type=GarbageCollector",
+        "java.lang:name=PS Old Gen,type=MemoryPool",
       ]
     }),
     headersOut: {},
@@ -222,5 +242,6 @@ Promise.resolve()
   .then(searchCamelRoutesTest)
   .then(searchRbacMBeanTest)
   .then(bulkRequestWithInterceptionTest)
-  .then(singleCanInvokeOperationTest)
+  .then(canInvokeSingleOperationTest)
+  .then(canInvokeSingleAttributeTest)
   ;

--- a/docker/test.js
+++ b/docker/test.js
@@ -1,13 +1,11 @@
+import gateway from 'nginx.js';
+
 var fs = require('fs');
 
 var listMBeans = fs.readFileSync('test.listMBeans.json');
 
-//TODO: find a way to load main file
-// https://github.com/nginx/njs/issues/115
-import proxyJolokiaAgent from './nginx.js'
-
 function requestWithViewerRoleTest() {
-  return proxyJolokiaAgent({
+  return gateway.proxyJolokiaAgent({
     uri: '/management/namespaces/test/pods/https:pod:443/remaining',
     requestBody: JSON.stringify({
       type: 'exec',
@@ -23,7 +21,7 @@ function requestWithViewerRoleTest() {
 }
 
 function bulkRequestWithViewerRoleTest() {
-  return proxyJolokiaAgent({
+  return gateway.proxyJolokiaAgent({
     uri: '/management/namespaces/test/pods/https:pod:443/remaining',
     requestBody: JSON.stringify([
       {
@@ -46,7 +44,7 @@ function bulkRequestWithViewerRoleTest() {
 }
 
 function requestOperationWithArgumentsAndNoRoleTest() {
-  return proxyJolokiaAgent({
+  return gateway.proxyJolokiaAgent({
     uri: '/management/namespaces/test/pods/https:pod:443/remaining',
     requestBody: JSON.stringify({
       type: 'exec',
@@ -65,7 +63,7 @@ function requestOperationWithArgumentsAndNoRoleTest() {
 }
 
 function requestOperationWithArgumentsAndViewerRoleTest() {
-  return proxyJolokiaAgent({
+  return gateway.proxyJolokiaAgent({
     uri: '/management/namespaces/test/pods/https:pod:443/remaining',
     requestBody: JSON.stringify({
       type: 'exec',
@@ -85,7 +83,7 @@ function requestOperationWithArgumentsAndViewerRoleTest() {
 }
 
 function searchCamelRoutesTest() {
-  return proxyJolokiaAgent({
+  return gateway.proxyJolokiaAgent({
     uri: '/management/namespaces/test/pods/https:pod:443/remaining',
     requestBody: JSON.stringify({
       type: 'search',
@@ -100,7 +98,7 @@ function searchCamelRoutesTest() {
 }
 
 function searchRbacMBeanTest() {
-  return proxyJolokiaAgent({
+  return gateway.proxyJolokiaAgent({
     uri: '/management/namespaces/test/pods/https:pod:443/remaining',
     requestBody: JSON.stringify({
       type: 'search',
@@ -115,7 +113,7 @@ function searchRbacMBeanTest() {
 }
 
 function bulkRequestWithInterceptionTest() {
-  return proxyJolokiaAgent({
+  return gateway.proxyJolokiaAgent({
     uri: '/management/namespaces/test/pods/https:pod:443/remaining',
     requestBody: JSON.stringify([
       {
@@ -141,7 +139,7 @@ function bulkRequestWithInterceptionTest() {
 }
 
 function canInvokeSingleOperationTest() {
-  return proxyJolokiaAgent({
+  return gateway.proxyJolokiaAgent({
     uri: '/management/namespaces/test/pods/https:pod:443/remaining',
     requestBody: JSON.stringify({
       'type': 'exec',
@@ -161,7 +159,7 @@ function canInvokeSingleOperationTest() {
 }
 
 function canInvokeSingleAttributeTest() {
-  return proxyJolokiaAgent({
+  return gateway.proxyJolokiaAgent({
     uri: '/management/namespaces/test/pods/https:pod:443/remaining',
     requestBody: JSON.stringify({
       'type': 'exec',
@@ -181,7 +179,7 @@ function canInvokeSingleAttributeTest() {
 }
 
 function canInvokeMapTest() {
-  return proxyJolokiaAgent({
+  return gateway.proxyJolokiaAgent({
     uri: '/management/namespaces/test/pods/https:pod:443/remaining',
     requestBody: JSON.stringify({
       'type': 'exec',

--- a/docker/test.js
+++ b/docker/test.js
@@ -6,6 +6,7 @@ function requestWithViewerRoleTest() {
   return proxyJolokiaAgent({
     uri: '/management/namespaces/test/pods/https:pod:443/remaining',
     requestBody: JSON.stringify({
+      type: 'exec',
       mbean: 'org.apache.camel:type=context',
       operation: 'dumpRoutesAsXml()',
     }),
@@ -22,10 +23,12 @@ function bulkRequestWithViewerRoleTest() {
     uri: '/management/namespaces/test/pods/https:pod:443/remaining',
     requestBody: JSON.stringify([
       {
+        type: 'exec',
         mbean: 'org.apache.camel:type=context',
         operation: 'dumpRoutesAsXml()',
       },
       {
+        type: 'exec',
         mbean: 'java.lang.Memory',
         operation: 'gc()',
       },
@@ -42,6 +45,7 @@ function requestOperationWithArgumentsAndNoRoleTest() {
   return proxyJolokiaAgent({
     uri: '/management/namespaces/test/pods/https:pod:443/remaining',
     requestBody: JSON.stringify({
+      type: 'exec',
       mbean: 'org.apache.karaf:type=bundle',
       operation: 'uninstall(java.lang.String)',
       arguments: [
@@ -60,12 +64,43 @@ function requestOperationWithArgumentsAndViewerRoleTest() {
   return proxyJolokiaAgent({
     uri: '/management/namespaces/test/pods/https:pod:443/remaining',
     requestBody: JSON.stringify({
+      type: 'exec',
       mbean: 'org.apache.karaf:type=bundle',
       operation: 'update(java.lang.String,java.lang.String)',
       arguments: [
         '50',
         'value',
       ],
+    }),
+    headersOut: {},
+    subrequest: doWithViewerRole,
+    return: (code, message) => {
+      console.log('code:', code, 'message:', message);
+    },
+  });
+}
+
+function searchCamelRoutesTest() {
+  return proxyJolokiaAgent({
+    uri: '/management/namespaces/test/pods/https:pod:443/remaining',
+    requestBody: JSON.stringify({
+      type: 'search',
+      mbean: 'org.apache.camel:context=*,type=routes,*',
+    }),
+    headersOut: {},
+    subrequest: doWithViewerRole,
+    return: (code, message) => {
+      console.log('code:', code, 'message:', message);
+    },
+  });
+}
+
+function searchRbacMBeanTest() {
+  return proxyJolokiaAgent({
+    uri: '/management/namespaces/test/pods/https:pod:443/remaining',
+    requestBody: JSON.stringify({
+      type: 'search',
+      mbean: '*:type=security,area=jmx,*',
     }),
     headersOut: {},
     subrequest: doWithViewerRole,
@@ -126,4 +161,7 @@ Promise.resolve()
   .then(requestWithViewerRoleTest)
   .then(bulkRequestWithViewerRoleTest)
   .then(requestOperationWithArgumentsAndNoRoleTest)
-  .then(requestOperationWithArgumentsAndViewerRoleTest);
+  .then(requestOperationWithArgumentsAndViewerRoleTest)
+  .then(searchCamelRoutesTest)
+  .then(searchRbacMBeanTest)
+  ;

--- a/docker/test.js
+++ b/docker/test.js
@@ -1,0 +1,42 @@
+//TODO: find a way to load main file
+// https://github.com/nginx/njs/issues/115
+import proxyJolokiaAgent from './nginx.js'
+
+proxyJolokiaAgent({
+  uri: '/management/namespaces/test/pods/https:pod:443/remaining',
+  requestBody: JSON.stringify({
+    mbean: 'org.apache.camel:type=context',
+    operation: 'dumpRoutesAsXml',
+  }),
+  headersOut: {},
+  subrequest: (uri, options, callback) => {
+    var body = JSON.parse(options.body || '{}');
+    var res;
+    if (uri.startsWith('/authorization') && body.verb === 'update') {
+      res = {
+        status: 201,
+        responseBody: JSON.stringify({
+          allowed: false,
+        }),
+      };
+    }
+    if (uri.startsWith('/authorization') && body.verb === 'get') {
+      res = {
+        status: 201,
+        responseBody: JSON.stringify({
+          allowed: true,
+        }),
+      };
+    }
+    if (!res) {
+      res = {
+        status: 404,
+        responseBody: `No stub for ${uri}`,
+      }
+    }
+    callback(Object.assign({ headersOut: {} }, res));
+  },
+  return: (code, message) => {
+    console.log('code:', code, 'message:', message);
+  },
+});

--- a/docker/test.js
+++ b/docker/test.js
@@ -110,6 +110,32 @@ function searchRbacMBeanTest() {
   });
 }
 
+function bulkRequestWithInterceptionTest() {
+  return proxyJolokiaAgent({
+    uri: '/management/namespaces/test/pods/https:pod:443/remaining',
+    requestBody: JSON.stringify([
+      {
+        type: 'search',
+        mbean: '*:type=security,area=jmx,*',
+      },
+      {
+        type: 'exec',
+        mbean: 'java.lang.Memory',
+        operation: 'gc()',
+      },
+      {
+        type: 'search',
+        mbean: 'org.apache.camel:context=*,type=routes,*',
+      },
+    ]),
+    headersOut: {},
+    subrequest: doWithViewerRole,
+    return: (code, message) => {
+      console.log('code:', code, 'message:', message);
+    },
+  });
+}
+
 function doWithViewerRole(uri, options) {
   var body = JSON.parse(options.body || '{}');
   var res;
@@ -164,4 +190,5 @@ Promise.resolve()
   .then(requestOperationWithArgumentsAndViewerRoleTest)
   .then(searchCamelRoutesTest)
   .then(searchRbacMBeanTest)
+  .then(bulkRequestWithInterceptionTest)
   ;

--- a/docker/test.listMBeans.json
+++ b/docker/test.listMBeans.json
@@ -1,0 +1,8381 @@
+{
+  "request": {
+    "type": "list"
+  },
+  "value": {
+    "org.springframework.boot": {
+      "name=healthEndpoint,type=Endpoint": {
+        "op": {
+          "isSensitive": {
+            "args": [],
+            "ret": "boolean",
+            "desc": "Indicates whether the underlying endpoint exposes sensitive information"
+          },
+          "getEndpointClass": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "Returns the class of the underlying endpoint"
+          },
+          "getData": {
+            "args": [],
+            "ret": "java.lang.Object",
+            "desc": "Invoke the underlying endpoint"
+          }
+        },
+        "attr": {
+          "EndpointClass": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Returns the class of the underlying endpoint"
+          },
+          "Sensitive": {
+            "rw": false,
+            "type": "boolean",
+            "desc": "Indicates whether the underlying endpoint exposes sensitive information"
+          },
+          "Data": {
+            "rw": false,
+            "type": "java.lang.Object",
+            "desc": "Invoke the underlying endpoint"
+          }
+        },
+        "class": "org.springframework.boot.actuate.endpoint.jmx.DataEndpointMBean",
+        "desc": ""
+      }
+    },
+    "JMImplementation": {
+      "type=MBeanServerDelegate": {
+        "attr": {
+          "ImplementationName": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "The JMX implementation name (the name of this product)"
+          },
+          "MBeanServerId": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "The MBean server agent identification"
+          },
+          "ImplementationVersion": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "The JMX implementation version (the version of this product)."
+          },
+          "SpecificationVersion": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "The version of the JMX specification implemented by this product."
+          },
+          "SpecificationVendor": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "The vendor of the JMX specification implemented by this product."
+          },
+          "SpecificationName": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "The full name of the JMX specification implemented by this product."
+          },
+          "ImplementationVendor": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "the JMX implementation vendor (the vendor of this product)."
+          }
+        },
+        "class": "javax.management.MBeanServerDelegate",
+        "desc": "Represents  the MBean server from the management point of view."
+      }
+    },
+    "java.util.logging": {
+      "type=Logging": {
+        "op": {
+          "getLoggerLevel": {
+            "args": [
+              {
+                "name": "p0",
+                "type": "java.lang.String",
+                "desc": "p0"
+              }
+            ],
+            "ret": "java.lang.String",
+            "desc": "getLoggerLevel"
+          },
+          "getParentLoggerName": {
+            "args": [
+              {
+                "name": "p0",
+                "type": "java.lang.String",
+                "desc": "p0"
+              }
+            ],
+            "ret": "java.lang.String",
+            "desc": "getParentLoggerName"
+          },
+          "setLoggerLevel": {
+            "args": [
+              {
+                "name": "p0",
+                "type": "java.lang.String",
+                "desc": "p0"
+              },
+              {
+                "name": "p1",
+                "type": "java.lang.String",
+                "desc": "p1"
+              }
+            ],
+            "ret": "void",
+            "desc": "setLoggerLevel"
+          }
+        },
+        "attr": {
+          "LoggerNames": {
+            "rw": false,
+            "type": "[Ljava.lang.String;",
+            "desc": "LoggerNames"
+          },
+          "ObjectName": {
+            "rw": false,
+            "type": "javax.management.ObjectName",
+            "desc": "ObjectName"
+          }
+        },
+        "class": "sun.management.ManagementFactoryHelper$PlatformLoggingImpl",
+        "desc": "Information on the management interface of the MBean"
+      }
+    },
+    "java.lang": {
+      "name=PS Scavenge,type=GarbageCollector": {
+        "attr": {
+          "MemoryPoolNames": {
+            "rw": false,
+            "type": "[Ljava.lang.String;",
+            "desc": "MemoryPoolNames"
+          },
+          "LastGcInfo": {
+            "rw": false,
+            "type": "javax.management.openmbean.CompositeData",
+            "desc": "LastGcInfo"
+          },
+          "CollectionTime": {
+            "rw": false,
+            "type": "long",
+            "desc": "CollectionTime"
+          },
+          "Valid": {
+            "rw": false,
+            "type": "boolean",
+            "desc": "Valid"
+          },
+          "CollectionCount": {
+            "rw": false,
+            "type": "long",
+            "desc": "CollectionCount"
+          },
+          "Name": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Name"
+          },
+          "ObjectName": {
+            "rw": false,
+            "type": "javax.management.ObjectName",
+            "desc": "ObjectName"
+          }
+        },
+        "class": "sun.management.GarbageCollectorImpl",
+        "desc": "Information on the management interface of the MBean"
+      },
+      "type=Threading": {
+        "op": {
+          "getThreadCpuTime": [
+            {
+              "args": [
+                {
+                  "name": "p0",
+                  "type": "[J",
+                  "desc": "p0"
+                }
+              ],
+              "ret": "[J",
+              "desc": "getThreadCpuTime"
+            },
+            {
+              "args": [
+                {
+                  "name": "p0",
+                  "type": "long",
+                  "desc": "p0"
+                }
+              ],
+              "ret": "long",
+              "desc": "getThreadCpuTime"
+            }
+          ],
+          "getThreadInfo": [
+            {
+              "args": [
+                {
+                  "name": "p0",
+                  "type": "[J",
+                  "desc": "p0"
+                },
+                {
+                  "name": "p1",
+                  "type": "int",
+                  "desc": "p1"
+                }
+              ],
+              "ret": "[Ljavax.management.openmbean.CompositeData;",
+              "desc": "getThreadInfo"
+            },
+            {
+              "args": [
+                {
+                  "name": "p0",
+                  "type": "long",
+                  "desc": "p0"
+                }
+              ],
+              "ret": "javax.management.openmbean.CompositeData",
+              "desc": "getThreadInfo"
+            },
+            {
+              "args": [
+                {
+                  "name": "p0",
+                  "type": "[J",
+                  "desc": "p0"
+                }
+              ],
+              "ret": "[Ljavax.management.openmbean.CompositeData;",
+              "desc": "getThreadInfo"
+            },
+            {
+              "args": [
+                {
+                  "name": "p0",
+                  "type": "long",
+                  "desc": "p0"
+                },
+                {
+                  "name": "p1",
+                  "type": "int",
+                  "desc": "p1"
+                }
+              ],
+              "ret": "javax.management.openmbean.CompositeData",
+              "desc": "getThreadInfo"
+            },
+            {
+              "args": [
+                {
+                  "name": "p0",
+                  "type": "[J",
+                  "desc": "p0"
+                },
+                {
+                  "name": "p1",
+                  "type": "boolean",
+                  "desc": "p1"
+                },
+                {
+                  "name": "p2",
+                  "type": "boolean",
+                  "desc": "p2"
+                }
+              ],
+              "ret": "[Ljavax.management.openmbean.CompositeData;",
+              "desc": "getThreadInfo"
+            }
+          ],
+          "findDeadlockedThreads": {
+            "args": [],
+            "ret": "[J",
+            "desc": "findDeadlockedThreads"
+          },
+          "getThreadAllocatedBytes": [
+            {
+              "args": [
+                {
+                  "name": "p0",
+                  "type": "[J",
+                  "desc": "p0"
+                }
+              ],
+              "ret": "[J",
+              "desc": "getThreadAllocatedBytes"
+            },
+            {
+              "args": [
+                {
+                  "name": "p0",
+                  "type": "long",
+                  "desc": "p0"
+                }
+              ],
+              "ret": "long",
+              "desc": "getThreadAllocatedBytes"
+            }
+          ],
+          "getThreadUserTime": [
+            {
+              "args": [
+                {
+                  "name": "p0",
+                  "type": "[J",
+                  "desc": "p0"
+                }
+              ],
+              "ret": "[J",
+              "desc": "getThreadUserTime"
+            },
+            {
+              "args": [
+                {
+                  "name": "p0",
+                  "type": "long",
+                  "desc": "p0"
+                }
+              ],
+              "ret": "long",
+              "desc": "getThreadUserTime"
+            }
+          ],
+          "findMonitorDeadlockedThreads": {
+            "args": [],
+            "ret": "[J",
+            "desc": "findMonitorDeadlockedThreads"
+          },
+          "resetPeakThreadCount": {
+            "args": [],
+            "ret": "void",
+            "desc": "resetPeakThreadCount"
+          },
+          "dumpAllThreads": {
+            "args": [
+              {
+                "name": "p0",
+                "type": "boolean",
+                "desc": "p0"
+              },
+              {
+                "name": "p1",
+                "type": "boolean",
+                "desc": "p1"
+              }
+            ],
+            "ret": "[Ljavax.management.openmbean.CompositeData;",
+            "desc": "dumpAllThreads"
+          }
+        },
+        "attr": {
+          "ThreadAllocatedMemorySupported": {
+            "rw": false,
+            "type": "boolean",
+            "desc": "ThreadAllocatedMemorySupported"
+          },
+          "ThreadContentionMonitoringEnabled": {
+            "rw": true,
+            "type": "boolean",
+            "desc": "ThreadContentionMonitoringEnabled"
+          },
+          "TotalStartedThreadCount": {
+            "rw": false,
+            "type": "long",
+            "desc": "TotalStartedThreadCount"
+          },
+          "CurrentThreadCpuTimeSupported": {
+            "rw": false,
+            "type": "boolean",
+            "desc": "CurrentThreadCpuTimeSupported"
+          },
+          "CurrentThreadUserTime": {
+            "rw": false,
+            "type": "long",
+            "desc": "CurrentThreadUserTime"
+          },
+          "PeakThreadCount": {
+            "rw": false,
+            "type": "int",
+            "desc": "PeakThreadCount"
+          },
+          "AllThreadIds": {
+            "rw": false,
+            "type": "[J",
+            "desc": "AllThreadIds"
+          },
+          "ThreadAllocatedMemoryEnabled": {
+            "rw": true,
+            "type": "boolean",
+            "desc": "ThreadAllocatedMemoryEnabled"
+          },
+          "CurrentThreadCpuTime": {
+            "rw": false,
+            "type": "long",
+            "desc": "CurrentThreadCpuTime"
+          },
+          "ObjectName": {
+            "rw": false,
+            "type": "javax.management.ObjectName",
+            "desc": "ObjectName"
+          },
+          "ThreadContentionMonitoringSupported": {
+            "rw": false,
+            "type": "boolean",
+            "desc": "ThreadContentionMonitoringSupported"
+          },
+          "ThreadCpuTimeSupported": {
+            "rw": false,
+            "type": "boolean",
+            "desc": "ThreadCpuTimeSupported"
+          },
+          "ThreadCount": {
+            "rw": false,
+            "type": "int",
+            "desc": "ThreadCount"
+          },
+          "ThreadCpuTimeEnabled": {
+            "rw": true,
+            "type": "boolean",
+            "desc": "ThreadCpuTimeEnabled"
+          },
+          "ObjectMonitorUsageSupported": {
+            "rw": false,
+            "type": "boolean",
+            "desc": "ObjectMonitorUsageSupported"
+          },
+          "SynchronizerUsageSupported": {
+            "rw": false,
+            "type": "boolean",
+            "desc": "SynchronizerUsageSupported"
+          },
+          "DaemonThreadCount": {
+            "rw": false,
+            "type": "int",
+            "desc": "DaemonThreadCount"
+          }
+        },
+        "class": "sun.management.ThreadImpl",
+        "desc": "Information on the management interface of the MBean"
+      },
+      "name=PS Old Gen,type=MemoryPool": {
+        "op": {
+          "resetPeakUsage": {
+            "args": [],
+            "ret": "void",
+            "desc": "resetPeakUsage"
+          }
+        },
+        "attr": {
+          "Usage": {
+            "rw": false,
+            "type": "javax.management.openmbean.CompositeData",
+            "desc": "Usage"
+          },
+          "UsageThresholdCount": {
+            "rw": false,
+            "type": "long",
+            "desc": "UsageThresholdCount"
+          },
+          "MemoryManagerNames": {
+            "rw": false,
+            "type": "[Ljava.lang.String;",
+            "desc": "MemoryManagerNames"
+          },
+          "UsageThresholdSupported": {
+            "rw": false,
+            "type": "boolean",
+            "desc": "UsageThresholdSupported"
+          },
+          "UsageThreshold": {
+            "rw": true,
+            "type": "long",
+            "desc": "UsageThreshold"
+          },
+          "CollectionUsageThresholdCount": {
+            "rw": false,
+            "type": "long",
+            "desc": "CollectionUsageThresholdCount"
+          },
+          "PeakUsage": {
+            "rw": false,
+            "type": "javax.management.openmbean.CompositeData",
+            "desc": "PeakUsage"
+          },
+          "Name": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Name"
+          },
+          "UsageThresholdExceeded": {
+            "rw": false,
+            "type": "boolean",
+            "desc": "UsageThresholdExceeded"
+          },
+          "CollectionUsageThreshold": {
+            "rw": true,
+            "type": "long",
+            "desc": "CollectionUsageThreshold"
+          },
+          "ObjectName": {
+            "rw": false,
+            "type": "javax.management.ObjectName",
+            "desc": "ObjectName"
+          },
+          "Type": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Type"
+          },
+          "Valid": {
+            "rw": false,
+            "type": "boolean",
+            "desc": "Valid"
+          },
+          "CollectionUsageThresholdSupported": {
+            "rw": false,
+            "type": "boolean",
+            "desc": "CollectionUsageThresholdSupported"
+          },
+          "CollectionUsage": {
+            "rw": false,
+            "type": "javax.management.openmbean.CompositeData",
+            "desc": "CollectionUsage"
+          },
+          "CollectionUsageThresholdExceeded": {
+            "rw": false,
+            "type": "boolean",
+            "desc": "CollectionUsageThresholdExceeded"
+          }
+        },
+        "class": "sun.management.MemoryPoolImpl",
+        "desc": "Information on the management interface of the MBean"
+      },
+      "type=Memory": {
+        "op": {
+          "gc": {
+            "args": [],
+            "ret": "void",
+            "desc": "gc"
+          }
+        },
+        "attr": {
+          "ObjectPendingFinalizationCount": {
+            "rw": false,
+            "type": "int",
+            "desc": "ObjectPendingFinalizationCount"
+          },
+          "Verbose": {
+            "rw": true,
+            "type": "boolean",
+            "desc": "Verbose"
+          },
+          "HeapMemoryUsage": {
+            "rw": false,
+            "type": "javax.management.openmbean.CompositeData",
+            "desc": "HeapMemoryUsage"
+          },
+          "NonHeapMemoryUsage": {
+            "rw": false,
+            "type": "javax.management.openmbean.CompositeData",
+            "desc": "NonHeapMemoryUsage"
+          },
+          "ObjectName": {
+            "rw": false,
+            "type": "javax.management.ObjectName",
+            "desc": "ObjectName"
+          }
+        },
+        "class": "sun.management.MemoryImpl",
+        "desc": "Information on the management interface of the MBean"
+      },
+      "name=Metaspace,type=MemoryPool": {
+        "op": {
+          "resetPeakUsage": {
+            "args": [],
+            "ret": "void",
+            "desc": "resetPeakUsage"
+          }
+        },
+        "attr": {
+          "Usage": {
+            "rw": false,
+            "type": "javax.management.openmbean.CompositeData",
+            "desc": "Usage"
+          },
+          "UsageThresholdCount": {
+            "rw": false,
+            "type": "long",
+            "desc": "UsageThresholdCount"
+          },
+          "MemoryManagerNames": {
+            "rw": false,
+            "type": "[Ljava.lang.String;",
+            "desc": "MemoryManagerNames"
+          },
+          "UsageThresholdSupported": {
+            "rw": false,
+            "type": "boolean",
+            "desc": "UsageThresholdSupported"
+          },
+          "UsageThreshold": {
+            "rw": true,
+            "type": "long",
+            "desc": "UsageThreshold"
+          },
+          "CollectionUsageThresholdCount": {
+            "rw": false,
+            "type": "long",
+            "desc": "CollectionUsageThresholdCount"
+          },
+          "PeakUsage": {
+            "rw": false,
+            "type": "javax.management.openmbean.CompositeData",
+            "desc": "PeakUsage"
+          },
+          "Name": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Name"
+          },
+          "UsageThresholdExceeded": {
+            "rw": false,
+            "type": "boolean",
+            "desc": "UsageThresholdExceeded"
+          },
+          "CollectionUsageThreshold": {
+            "rw": true,
+            "type": "long",
+            "desc": "CollectionUsageThreshold"
+          },
+          "ObjectName": {
+            "rw": false,
+            "type": "javax.management.ObjectName",
+            "desc": "ObjectName"
+          },
+          "Type": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Type"
+          },
+          "Valid": {
+            "rw": false,
+            "type": "boolean",
+            "desc": "Valid"
+          },
+          "CollectionUsageThresholdSupported": {
+            "rw": false,
+            "type": "boolean",
+            "desc": "CollectionUsageThresholdSupported"
+          },
+          "CollectionUsage": {
+            "rw": false,
+            "type": "javax.management.openmbean.CompositeData",
+            "desc": "CollectionUsage"
+          },
+          "CollectionUsageThresholdExceeded": {
+            "rw": false,
+            "type": "boolean",
+            "desc": "CollectionUsageThresholdExceeded"
+          }
+        },
+        "class": "sun.management.MemoryPoolImpl",
+        "desc": "Information on the management interface of the MBean"
+      },
+      "name=PS Survivor Space,type=MemoryPool": {
+        "op": {
+          "resetPeakUsage": {
+            "args": [],
+            "ret": "void",
+            "desc": "resetPeakUsage"
+          }
+        },
+        "attr": {
+          "Usage": {
+            "rw": false,
+            "type": "javax.management.openmbean.CompositeData",
+            "desc": "Usage"
+          },
+          "UsageThresholdCount": {
+            "rw": false,
+            "type": "long",
+            "desc": "UsageThresholdCount"
+          },
+          "MemoryManagerNames": {
+            "rw": false,
+            "type": "[Ljava.lang.String;",
+            "desc": "MemoryManagerNames"
+          },
+          "UsageThresholdSupported": {
+            "rw": false,
+            "type": "boolean",
+            "desc": "UsageThresholdSupported"
+          },
+          "UsageThreshold": {
+            "rw": true,
+            "type": "long",
+            "desc": "UsageThreshold"
+          },
+          "CollectionUsageThresholdCount": {
+            "rw": false,
+            "type": "long",
+            "desc": "CollectionUsageThresholdCount"
+          },
+          "PeakUsage": {
+            "rw": false,
+            "type": "javax.management.openmbean.CompositeData",
+            "desc": "PeakUsage"
+          },
+          "Name": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Name"
+          },
+          "UsageThresholdExceeded": {
+            "rw": false,
+            "type": "boolean",
+            "desc": "UsageThresholdExceeded"
+          },
+          "CollectionUsageThreshold": {
+            "rw": true,
+            "type": "long",
+            "desc": "CollectionUsageThreshold"
+          },
+          "ObjectName": {
+            "rw": false,
+            "type": "javax.management.ObjectName",
+            "desc": "ObjectName"
+          },
+          "Type": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Type"
+          },
+          "Valid": {
+            "rw": false,
+            "type": "boolean",
+            "desc": "Valid"
+          },
+          "CollectionUsageThresholdSupported": {
+            "rw": false,
+            "type": "boolean",
+            "desc": "CollectionUsageThresholdSupported"
+          },
+          "CollectionUsage": {
+            "rw": false,
+            "type": "javax.management.openmbean.CompositeData",
+            "desc": "CollectionUsage"
+          },
+          "CollectionUsageThresholdExceeded": {
+            "rw": false,
+            "type": "boolean",
+            "desc": "CollectionUsageThresholdExceeded"
+          }
+        },
+        "class": "sun.management.MemoryPoolImpl",
+        "desc": "Information on the management interface of the MBean"
+      },
+      "type=OperatingSystem": {
+        "attr": {
+          "OpenFileDescriptorCount": {
+            "rw": false,
+            "type": "long",
+            "desc": "OpenFileDescriptorCount"
+          },
+          "CommittedVirtualMemorySize": {
+            "rw": false,
+            "type": "long",
+            "desc": "CommittedVirtualMemorySize"
+          },
+          "FreePhysicalMemorySize": {
+            "rw": false,
+            "type": "long",
+            "desc": "FreePhysicalMemorySize"
+          },
+          "SystemLoadAverage": {
+            "rw": false,
+            "type": "double",
+            "desc": "SystemLoadAverage"
+          },
+          "Arch": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Arch"
+          },
+          "ProcessCpuLoad": {
+            "rw": false,
+            "type": "double",
+            "desc": "ProcessCpuLoad"
+          },
+          "FreeSwapSpaceSize": {
+            "rw": false,
+            "type": "long",
+            "desc": "FreeSwapSpaceSize"
+          },
+          "TotalPhysicalMemorySize": {
+            "rw": false,
+            "type": "long",
+            "desc": "TotalPhysicalMemorySize"
+          },
+          "Name": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Name"
+          },
+          "ObjectName": {
+            "rw": false,
+            "type": "javax.management.ObjectName",
+            "desc": "ObjectName"
+          },
+          "TotalSwapSpaceSize": {
+            "rw": false,
+            "type": "long",
+            "desc": "TotalSwapSpaceSize"
+          },
+          "ProcessCpuTime": {
+            "rw": false,
+            "type": "long",
+            "desc": "ProcessCpuTime"
+          },
+          "MaxFileDescriptorCount": {
+            "rw": false,
+            "type": "long",
+            "desc": "MaxFileDescriptorCount"
+          },
+          "SystemCpuLoad": {
+            "rw": false,
+            "type": "double",
+            "desc": "SystemCpuLoad"
+          },
+          "Version": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Version"
+          },
+          "AvailableProcessors": {
+            "rw": false,
+            "type": "int",
+            "desc": "AvailableProcessors"
+          }
+        },
+        "class": "sun.management.OperatingSystemImpl",
+        "desc": "Information on the management interface of the MBean"
+      },
+      "name=PS Eden Space,type=MemoryPool": {
+        "op": {
+          "resetPeakUsage": {
+            "args": [],
+            "ret": "void",
+            "desc": "resetPeakUsage"
+          }
+        },
+        "attr": {
+          "Usage": {
+            "rw": false,
+            "type": "javax.management.openmbean.CompositeData",
+            "desc": "Usage"
+          },
+          "UsageThresholdCount": {
+            "rw": false,
+            "type": "long",
+            "desc": "UsageThresholdCount"
+          },
+          "MemoryManagerNames": {
+            "rw": false,
+            "type": "[Ljava.lang.String;",
+            "desc": "MemoryManagerNames"
+          },
+          "UsageThresholdSupported": {
+            "rw": false,
+            "type": "boolean",
+            "desc": "UsageThresholdSupported"
+          },
+          "UsageThreshold": {
+            "rw": true,
+            "type": "long",
+            "desc": "UsageThreshold"
+          },
+          "CollectionUsageThresholdCount": {
+            "rw": false,
+            "type": "long",
+            "desc": "CollectionUsageThresholdCount"
+          },
+          "PeakUsage": {
+            "rw": false,
+            "type": "javax.management.openmbean.CompositeData",
+            "desc": "PeakUsage"
+          },
+          "Name": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Name"
+          },
+          "UsageThresholdExceeded": {
+            "rw": false,
+            "type": "boolean",
+            "desc": "UsageThresholdExceeded"
+          },
+          "CollectionUsageThreshold": {
+            "rw": true,
+            "type": "long",
+            "desc": "CollectionUsageThreshold"
+          },
+          "ObjectName": {
+            "rw": false,
+            "type": "javax.management.ObjectName",
+            "desc": "ObjectName"
+          },
+          "Type": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Type"
+          },
+          "Valid": {
+            "rw": false,
+            "type": "boolean",
+            "desc": "Valid"
+          },
+          "CollectionUsageThresholdSupported": {
+            "rw": false,
+            "type": "boolean",
+            "desc": "CollectionUsageThresholdSupported"
+          },
+          "CollectionUsage": {
+            "rw": false,
+            "type": "javax.management.openmbean.CompositeData",
+            "desc": "CollectionUsage"
+          },
+          "CollectionUsageThresholdExceeded": {
+            "rw": false,
+            "type": "boolean",
+            "desc": "CollectionUsageThresholdExceeded"
+          }
+        },
+        "class": "sun.management.MemoryPoolImpl",
+        "desc": "Information on the management interface of the MBean"
+      },
+      "name=CodeCacheManager,type=MemoryManager": {
+        "attr": {
+          "MemoryPoolNames": {
+            "rw": false,
+            "type": "[Ljava.lang.String;",
+            "desc": "MemoryPoolNames"
+          },
+          "Valid": {
+            "rw": false,
+            "type": "boolean",
+            "desc": "Valid"
+          },
+          "Name": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Name"
+          },
+          "ObjectName": {
+            "rw": false,
+            "type": "javax.management.ObjectName",
+            "desc": "ObjectName"
+          }
+        },
+        "class": "sun.management.MemoryManagerImpl",
+        "desc": "Information on the management interface of the MBean"
+      },
+      "name=Code Cache,type=MemoryPool": {
+        "op": {
+          "resetPeakUsage": {
+            "args": [],
+            "ret": "void",
+            "desc": "resetPeakUsage"
+          }
+        },
+        "attr": {
+          "Usage": {
+            "rw": false,
+            "type": "javax.management.openmbean.CompositeData",
+            "desc": "Usage"
+          },
+          "UsageThresholdCount": {
+            "rw": false,
+            "type": "long",
+            "desc": "UsageThresholdCount"
+          },
+          "MemoryManagerNames": {
+            "rw": false,
+            "type": "[Ljava.lang.String;",
+            "desc": "MemoryManagerNames"
+          },
+          "UsageThresholdSupported": {
+            "rw": false,
+            "type": "boolean",
+            "desc": "UsageThresholdSupported"
+          },
+          "UsageThreshold": {
+            "rw": true,
+            "type": "long",
+            "desc": "UsageThreshold"
+          },
+          "CollectionUsageThresholdCount": {
+            "rw": false,
+            "type": "long",
+            "desc": "CollectionUsageThresholdCount"
+          },
+          "PeakUsage": {
+            "rw": false,
+            "type": "javax.management.openmbean.CompositeData",
+            "desc": "PeakUsage"
+          },
+          "Name": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Name"
+          },
+          "UsageThresholdExceeded": {
+            "rw": false,
+            "type": "boolean",
+            "desc": "UsageThresholdExceeded"
+          },
+          "CollectionUsageThreshold": {
+            "rw": true,
+            "type": "long",
+            "desc": "CollectionUsageThreshold"
+          },
+          "ObjectName": {
+            "rw": false,
+            "type": "javax.management.ObjectName",
+            "desc": "ObjectName"
+          },
+          "Type": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Type"
+          },
+          "Valid": {
+            "rw": false,
+            "type": "boolean",
+            "desc": "Valid"
+          },
+          "CollectionUsageThresholdSupported": {
+            "rw": false,
+            "type": "boolean",
+            "desc": "CollectionUsageThresholdSupported"
+          },
+          "CollectionUsage": {
+            "rw": false,
+            "type": "javax.management.openmbean.CompositeData",
+            "desc": "CollectionUsage"
+          },
+          "CollectionUsageThresholdExceeded": {
+            "rw": false,
+            "type": "boolean",
+            "desc": "CollectionUsageThresholdExceeded"
+          }
+        },
+        "class": "sun.management.MemoryPoolImpl",
+        "desc": "Information on the management interface of the MBean"
+      },
+      "name=Compressed Class Space,type=MemoryPool": {
+        "op": {
+          "resetPeakUsage": {
+            "args": [],
+            "ret": "void",
+            "desc": "resetPeakUsage"
+          }
+        },
+        "attr": {
+          "Usage": {
+            "rw": false,
+            "type": "javax.management.openmbean.CompositeData",
+            "desc": "Usage"
+          },
+          "UsageThresholdCount": {
+            "rw": false,
+            "type": "long",
+            "desc": "UsageThresholdCount"
+          },
+          "MemoryManagerNames": {
+            "rw": false,
+            "type": "[Ljava.lang.String;",
+            "desc": "MemoryManagerNames"
+          },
+          "UsageThresholdSupported": {
+            "rw": false,
+            "type": "boolean",
+            "desc": "UsageThresholdSupported"
+          },
+          "UsageThreshold": {
+            "rw": true,
+            "type": "long",
+            "desc": "UsageThreshold"
+          },
+          "CollectionUsageThresholdCount": {
+            "rw": false,
+            "type": "long",
+            "desc": "CollectionUsageThresholdCount"
+          },
+          "PeakUsage": {
+            "rw": false,
+            "type": "javax.management.openmbean.CompositeData",
+            "desc": "PeakUsage"
+          },
+          "Name": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Name"
+          },
+          "UsageThresholdExceeded": {
+            "rw": false,
+            "type": "boolean",
+            "desc": "UsageThresholdExceeded"
+          },
+          "CollectionUsageThreshold": {
+            "rw": true,
+            "type": "long",
+            "desc": "CollectionUsageThreshold"
+          },
+          "ObjectName": {
+            "rw": false,
+            "type": "javax.management.ObjectName",
+            "desc": "ObjectName"
+          },
+          "Type": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Type"
+          },
+          "Valid": {
+            "rw": false,
+            "type": "boolean",
+            "desc": "Valid"
+          },
+          "CollectionUsageThresholdSupported": {
+            "rw": false,
+            "type": "boolean",
+            "desc": "CollectionUsageThresholdSupported"
+          },
+          "CollectionUsage": {
+            "rw": false,
+            "type": "javax.management.openmbean.CompositeData",
+            "desc": "CollectionUsage"
+          },
+          "CollectionUsageThresholdExceeded": {
+            "rw": false,
+            "type": "boolean",
+            "desc": "CollectionUsageThresholdExceeded"
+          }
+        },
+        "class": "sun.management.MemoryPoolImpl",
+        "desc": "Information on the management interface of the MBean"
+      },
+      "type=ClassLoading": {
+        "attr": {
+          "LoadedClassCount": {
+            "rw": false,
+            "type": "int",
+            "desc": "LoadedClassCount"
+          },
+          "UnloadedClassCount": {
+            "rw": false,
+            "type": "long",
+            "desc": "UnloadedClassCount"
+          },
+          "Verbose": {
+            "rw": true,
+            "type": "boolean",
+            "desc": "Verbose"
+          },
+          "TotalLoadedClassCount": {
+            "rw": false,
+            "type": "long",
+            "desc": "TotalLoadedClassCount"
+          },
+          "ObjectName": {
+            "rw": false,
+            "type": "javax.management.ObjectName",
+            "desc": "ObjectName"
+          }
+        },
+        "class": "sun.management.ClassLoadingImpl",
+        "desc": "Information on the management interface of the MBean"
+      },
+      "type=Compilation": {
+        "attr": {
+          "CompilationTimeMonitoringSupported": {
+            "rw": false,
+            "type": "boolean",
+            "desc": "CompilationTimeMonitoringSupported"
+          },
+          "TotalCompilationTime": {
+            "rw": false,
+            "type": "long",
+            "desc": "TotalCompilationTime"
+          },
+          "Name": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Name"
+          },
+          "ObjectName": {
+            "rw": false,
+            "type": "javax.management.ObjectName",
+            "desc": "ObjectName"
+          }
+        },
+        "class": "sun.management.CompilationImpl",
+        "desc": "Information on the management interface of the MBean"
+      },
+      "name=PS MarkSweep,type=GarbageCollector": {
+        "attr": {
+          "MemoryPoolNames": {
+            "rw": false,
+            "type": "[Ljava.lang.String;",
+            "desc": "MemoryPoolNames"
+          },
+          "LastGcInfo": {
+            "rw": false,
+            "type": "javax.management.openmbean.CompositeData",
+            "desc": "LastGcInfo"
+          },
+          "CollectionTime": {
+            "rw": false,
+            "type": "long",
+            "desc": "CollectionTime"
+          },
+          "Valid": {
+            "rw": false,
+            "type": "boolean",
+            "desc": "Valid"
+          },
+          "CollectionCount": {
+            "rw": false,
+            "type": "long",
+            "desc": "CollectionCount"
+          },
+          "Name": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Name"
+          },
+          "ObjectName": {
+            "rw": false,
+            "type": "javax.management.ObjectName",
+            "desc": "ObjectName"
+          }
+        },
+        "class": "sun.management.GarbageCollectorImpl",
+        "desc": "Information on the management interface of the MBean"
+      },
+      "name=Metaspace Manager,type=MemoryManager": {
+        "attr": {
+          "MemoryPoolNames": {
+            "rw": false,
+            "type": "[Ljava.lang.String;",
+            "desc": "MemoryPoolNames"
+          },
+          "Valid": {
+            "rw": false,
+            "type": "boolean",
+            "desc": "Valid"
+          },
+          "Name": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Name"
+          },
+          "ObjectName": {
+            "rw": false,
+            "type": "javax.management.ObjectName",
+            "desc": "ObjectName"
+          }
+        },
+        "class": "sun.management.MemoryManagerImpl",
+        "desc": "Information on the management interface of the MBean"
+      },
+      "type=Runtime": {
+        "attr": {
+          "SpecVendor": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "SpecVendor"
+          },
+          "ClassPath": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "ClassPath"
+          },
+          "InputArguments": {
+            "rw": false,
+            "type": "[Ljava.lang.String;",
+            "desc": "InputArguments"
+          },
+          "Uptime": {
+            "rw": false,
+            "type": "long",
+            "desc": "Uptime"
+          },
+          "VmName": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "VmName"
+          },
+          "StartTime": {
+            "rw": false,
+            "type": "long",
+            "desc": "StartTime"
+          },
+          "VmVersion": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "VmVersion"
+          },
+          "SpecName": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "SpecName"
+          },
+          "ManagementSpecVersion": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "ManagementSpecVersion"
+          },
+          "Name": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Name"
+          },
+          "ObjectName": {
+            "rw": false,
+            "type": "javax.management.ObjectName",
+            "desc": "ObjectName"
+          },
+          "VmVendor": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "VmVendor"
+          },
+          "LibraryPath": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "LibraryPath"
+          },
+          "BootClassPath": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "BootClassPath"
+          },
+          "SpecVersion": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "SpecVersion"
+          },
+          "SystemProperties": {
+            "rw": false,
+            "type": "javax.management.openmbean.TabularData",
+            "desc": "SystemProperties"
+          },
+          "BootClassPathSupported": {
+            "rw": false,
+            "type": "boolean",
+            "desc": "BootClassPathSupported"
+          }
+        },
+        "class": "sun.management.RuntimeImpl",
+        "desc": "Information on the management interface of the MBean"
+      }
+    },
+    "org.apache.camel": {
+      "context=MyCamel,name=\"MyCamel\",type=health": {
+        "op": {
+          "getIsHealthy": {
+            "args": [],
+            "ret": "boolean",
+            "desc": "IsHealthy"
+          },
+          "details": {
+            "args": [],
+            "ret": "javax.management.openmbean.TabularData",
+            "desc": "Registered Health Checks Details"
+          },
+          "invoke": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "java.lang.String",
+                "desc": ""
+              }
+            ],
+            "ret": "java.lang.String",
+            "desc": "Invoke an Health Check by ID"
+          },
+          "getHealthChecksIDs": {
+            "args": [],
+            "ret": "java.util.Collection",
+            "desc": "HealthChecksIDs"
+          }
+        },
+        "attr": {
+          "HealthChecksIDs": {
+            "rw": false,
+            "type": "java.util.Collection",
+            "desc": "Registered Health Checks IDs"
+          },
+          "IsHealthy": {
+            "rw": false,
+            "type": "boolean",
+            "desc": "Application Health"
+          }
+        },
+        "class": "org.apache.camel.management.mbean.ManagedCamelHealth",
+        "desc": ""
+      },
+      "context=MyCamel,name=DefaultEndpointRegistry,type=services": {
+        "op": {
+          "getDynamicSize": {
+            "args": [],
+            "ret": "java.lang.Integer",
+            "desc": "DynamicSize"
+          },
+          "suspend": {
+            "args": [],
+            "ret": "void",
+            "desc": "Suspend Service"
+          },
+          "resume": {
+            "args": [],
+            "ret": "void",
+            "desc": "Resume Service"
+          },
+          "isSuspended": {
+            "args": [],
+            "ret": "boolean",
+            "desc": "Suspended"
+          },
+          "start": {
+            "args": [],
+            "ret": "void",
+            "desc": "Start Service"
+          },
+          "getStaticSize": {
+            "args": [],
+            "ret": "java.lang.Integer",
+            "desc": "StaticSize"
+          },
+          "getRouteId": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "RouteId"
+          },
+          "purge": {
+            "args": [],
+            "ret": "void",
+            "desc": "Purges the cache"
+          },
+          "getCamelManagementName": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "CamelManagementName"
+          },
+          "getCamelId": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "CamelId"
+          },
+          "isSupportSuspension": {
+            "args": [],
+            "ret": "boolean",
+            "desc": "SupportSuspension"
+          },
+          "getSize": {
+            "args": [],
+            "ret": "java.lang.Integer",
+            "desc": "Size"
+          },
+          "getState": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "State"
+          },
+          "stop": {
+            "args": [],
+            "ret": "void",
+            "desc": "Stop Service"
+          },
+          "getMaximumCacheSize": {
+            "args": [],
+            "ret": "java.lang.Integer",
+            "desc": "MaximumCacheSize"
+          },
+          "listEndpoints": {
+            "args": [],
+            "ret": "javax.management.openmbean.TabularData",
+            "desc": "Lists all the endpoints in the registry (url)"
+          },
+          "isStaticService": {
+            "args": [],
+            "ret": "boolean",
+            "desc": "StaticService"
+          },
+          "getSource": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "Source"
+          },
+          "getServiceType": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "ServiceType"
+          }
+        },
+        "attr": {
+          "CamelManagementName": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Camel ManagementName"
+          },
+          "CamelId": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Camel ID"
+          },
+          "Size": {
+            "rw": false,
+            "type": "java.lang.Integer",
+            "desc": "Number of total endpoints cached"
+          },
+          "SupportSuspension": {
+            "rw": false,
+            "type": "boolean",
+            "desc": "Whether this service supports suspension"
+          },
+          "RouteId": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Route ID"
+          },
+          "StaticService": {
+            "rw": false,
+            "type": "boolean",
+            "desc": "Whether this service is static"
+          },
+          "Source": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Source"
+          },
+          "StaticSize": {
+            "rw": false,
+            "type": "java.lang.Integer",
+            "desc": "Number of static endpoints cached"
+          },
+          "State": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Service State"
+          },
+          "ServiceType": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Service Type"
+          },
+          "MaximumCacheSize": {
+            "rw": false,
+            "type": "java.lang.Integer",
+            "desc": "Maximum cache size (capacity)"
+          },
+          "Suspended": {
+            "rw": false,
+            "type": "boolean",
+            "desc": "Whether this service is suspended"
+          },
+          "DynamicSize": {
+            "rw": false,
+            "type": "java.lang.Integer",
+            "desc": "Number of dynamic endpoints cached"
+          }
+        },
+        "class": "org.apache.camel.management.mbean.ManagedEndpointRegistry",
+        "desc": "Managed EndpointRegistry"
+      },
+      "context=MyCamel,name=\"simple-route\",type=routes": {
+        "op": {
+          "getLastProcessingTime": {
+            "args": [],
+            "ret": "long",
+            "desc": "LastProcessingTime"
+          },
+          "getExchangesCompleted": {
+            "args": [],
+            "ret": "long",
+            "desc": "ExchangesCompleted"
+          },
+          "getDeltaProcessingTime": {
+            "args": [],
+            "ret": "long",
+            "desc": "DeltaProcessingTime"
+          },
+          "getStartTimestamp": {
+            "args": [],
+            "ret": "java.util.Date",
+            "desc": "StartTimestamp"
+          },
+          "getOldestInflightExchangeId": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "OldestInflightExchangeId"
+          },
+          "dumpStatsAsXml": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "boolean",
+                "desc": ""
+              }
+            ],
+            "ret": "java.lang.String",
+            "desc": "Dumps the statistics as XML"
+          },
+          "getLastExchangeFailureTimestamp": {
+            "args": [],
+            "ret": "java.util.Date",
+            "desc": "LastExchangeFailureTimestamp"
+          },
+          "dumpRouteAsXml": [
+            {
+              "args": [
+                {
+                  "name": "p1",
+                  "type": "boolean",
+                  "desc": ""
+                }
+              ],
+              "ret": "java.lang.String",
+              "desc": "Dumps the route as XML"
+            },
+            {
+              "args": [],
+              "ret": "java.lang.String",
+              "desc": "Dumps the route as XML"
+            }
+          ],
+          "setTracing": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "java.lang.Boolean",
+                "desc": ""
+              }
+            ],
+            "ret": "void",
+            "desc": "Tracing"
+          },
+          "suspend": [
+            {
+              "args": [],
+              "ret": "void",
+              "desc": "Suspend route"
+            },
+            {
+              "args": [
+                {
+                  "name": "p1",
+                  "type": "long",
+                  "desc": ""
+                }
+              ],
+              "ret": "void",
+              "desc": "Suspend route (using timeout in seconds)"
+            }
+          ],
+          "getTracing": {
+            "args": [],
+            "ret": "java.lang.Boolean",
+            "desc": "Tracing"
+          },
+          "getLastError": {
+            "args": [],
+            "ret": "org.apache.camel.spi.RouteError",
+            "desc": "LastError"
+          },
+          "getHasRouteController": {
+            "args": [],
+            "ret": "java.lang.Boolean",
+            "desc": "HasRouteController"
+          },
+          "getMinProcessingTime": {
+            "args": [],
+            "ret": "long",
+            "desc": "MinProcessingTime"
+          },
+          "getLoad15": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "Load15"
+          },
+          "getCamelManagementName": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "CamelManagementName"
+          },
+          "getExchangesTotal": {
+            "args": [],
+            "ret": "long",
+            "desc": "ExchangesTotal"
+          },
+          "getCamelId": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "CamelId"
+          },
+          "stop": [
+            {
+              "args": [
+                {
+                  "name": "p1",
+                  "type": "java.lang.Long",
+                  "desc": ""
+                },
+                {
+                  "name": "p2",
+                  "type": "java.lang.Boolean",
+                  "desc": ""
+                }
+              ],
+              "ret": "boolean",
+              "desc": "Stop route, abort stop after timeout (in seconds)"
+            },
+            {
+              "args": [
+                {
+                  "name": "p1",
+                  "type": "long",
+                  "desc": ""
+                }
+              ],
+              "ret": "void",
+              "desc": "Stop route (using timeout in seconds)"
+            },
+            {
+              "args": [],
+              "ret": "void",
+              "desc": "Stop route"
+            }
+          ],
+          "reset": [
+            {
+              "args": [],
+              "ret": "void",
+              "desc": "Reset counters"
+            },
+            {
+              "args": [
+                {
+                  "name": "p1",
+                  "type": "boolean",
+                  "desc": ""
+                }
+              ],
+              "ret": "void",
+              "desc": "Reset counters"
+            }
+          ],
+          "getFirstExchangeCompletedExchangeId": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "FirstExchangeCompletedExchangeId"
+          },
+          "getLastExchangeCompletedTimestamp": {
+            "args": [],
+            "ret": "java.util.Date",
+            "desc": "LastExchangeCompletedTimestamp"
+          },
+          "getOldestInflightDuration": {
+            "args": [],
+            "ret": "java.lang.Long",
+            "desc": "OldestInflightDuration"
+          },
+          "shutdown": [
+            {
+              "args": [
+                {
+                  "name": "p1",
+                  "type": "long",
+                  "desc": ""
+                }
+              ],
+              "ret": "void",
+              "desc": "Shutdown route (using timeout in seconds)"
+            },
+            {
+              "args": [],
+              "ret": "void",
+              "desc": "Shutdown route"
+            }
+          ],
+          "getUptime": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "Uptime"
+          },
+          "getEndpointUri": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "EndpointUri"
+          },
+          "getRoutePolicyList": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "RoutePolicyList"
+          },
+          "getTotalProcessingTime": {
+            "args": [],
+            "ret": "long",
+            "desc": "TotalProcessingTime"
+          },
+          "getDescription": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "Description"
+          },
+          "getLoad05": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "Load05"
+          },
+          "remove": {
+            "args": [],
+            "ret": "boolean",
+            "desc": "Remove route (must be stopped)"
+          },
+          "dumpRouteStatsAsXml": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "boolean",
+                "desc": ""
+              },
+              {
+                "name": "p2",
+                "type": "boolean",
+                "desc": ""
+              }
+            ],
+            "ret": "java.lang.String",
+            "desc": "Dumps the routes stats as XML"
+          },
+          "getFirstExchangeCompletedTimestamp": {
+            "args": [],
+            "ret": "java.util.Date",
+            "desc": "FirstExchangeCompletedTimestamp"
+          },
+          "getLastExchangeFailureExchangeId": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "LastExchangeFailureExchangeId"
+          },
+          "getMaxProcessingTime": {
+            "args": [],
+            "ret": "long",
+            "desc": "MaxProcessingTime"
+          },
+          "getLastExchangeCompletedExchangeId": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "LastExchangeCompletedExchangeId"
+          },
+          "getInflightExchanges": {
+            "args": [],
+            "ret": "java.lang.Integer",
+            "desc": "InflightExchanges"
+          },
+          "setStatisticsEnabled": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "boolean",
+                "desc": ""
+              }
+            ],
+            "ret": "void",
+            "desc": "StatisticsEnabled"
+          },
+          "getUptimeMillis": {
+            "args": [],
+            "ret": "long",
+            "desc": "UptimeMillis"
+          },
+          "resume": {
+            "args": [],
+            "ret": "void",
+            "desc": "Resume Route"
+          },
+          "getMeanProcessingTime": {
+            "args": [],
+            "ret": "long",
+            "desc": "MeanProcessingTime"
+          },
+          "restart": [
+            {
+              "args": [
+                {
+                  "name": "p1",
+                  "type": "long",
+                  "desc": ""
+                }
+              ],
+              "ret": "void",
+              "desc": "Restarts route (using delay in seconds before starting)"
+            },
+            {
+              "args": [],
+              "ret": "void",
+              "desc": "Restarts route (1 second delay before starting)"
+            }
+          ],
+          "getExternalRedeliveries": {
+            "args": [],
+            "ret": "long",
+            "desc": "ExternalRedeliveries"
+          },
+          "start": {
+            "args": [],
+            "ret": "void",
+            "desc": "Start route"
+          },
+          "createRouteStaticEndpointJson": [
+            {
+              "args": [
+                {
+                  "name": "p1",
+                  "type": "boolean",
+                  "desc": ""
+                }
+              ],
+              "ret": "java.lang.String",
+              "desc": "Returns the JSON representation of all the static endpoints (and possible dynamic) defined in this route"
+            },
+            {
+              "args": [],
+              "ret": "java.lang.String",
+              "desc": "Returns the JSON representation of all the static and dynamic endpoints defined in this route"
+            }
+          ],
+          "getFirstExchangeFailureExchangeId": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "FirstExchangeFailureExchangeId"
+          },
+          "getResetTimestamp": {
+            "args": [],
+            "ret": "java.util.Date",
+            "desc": "ResetTimestamp"
+          },
+          "getExchangesFailed": {
+            "args": [],
+            "ret": "long",
+            "desc": "ExchangesFailed"
+          },
+          "getRouteId": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "RouteId"
+          },
+          "getMessageHistory": {
+            "args": [],
+            "ret": "java.lang.Boolean",
+            "desc": "MessageHistory"
+          },
+          "getLoad01": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "Load01"
+          },
+          "getState": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "State"
+          },
+          "getFailuresHandled": {
+            "args": [],
+            "ret": "long",
+            "desc": "FailuresHandled"
+          },
+          "getExchangesInflight": {
+            "args": [],
+            "ret": "long",
+            "desc": "ExchangesInflight"
+          },
+          "getRedeliveries": {
+            "args": [],
+            "ret": "long",
+            "desc": "Redeliveries"
+          },
+          "isStatisticsEnabled": {
+            "args": [],
+            "ret": "boolean",
+            "desc": "StatisticsEnabled"
+          },
+          "getFirstExchangeFailureTimestamp": {
+            "args": [],
+            "ret": "java.util.Date",
+            "desc": "FirstExchangeFailureTimestamp"
+          },
+          "updateRouteFromXml": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "java.lang.String",
+                "desc": ""
+              }
+            ],
+            "ret": "void",
+            "desc": "Updates the route from XML"
+          }
+        },
+        "attr": {
+          "StatisticsEnabled": {
+            "rw": true,
+            "type": "boolean",
+            "desc": "Statistics enabled"
+          },
+          "EndpointUri": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Route Endpoint URI"
+          },
+          "CamelManagementName": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Camel ManagementName"
+          },
+          "LastProcessingTime": {
+            "rw": false,
+            "type": "long",
+            "desc": "Last Processing Time [milliseconds]"
+          },
+          "ExchangesCompleted": {
+            "rw": false,
+            "type": "long",
+            "desc": "Number of completed exchanges"
+          },
+          "ExchangesFailed": {
+            "rw": false,
+            "type": "long",
+            "desc": "Number of failed exchanges"
+          },
+          "Description": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Route Description"
+          },
+          "FirstExchangeCompletedExchangeId": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "First Exchange Completed ExchangeId"
+          },
+          "StartTimestamp": {
+            "rw": false,
+            "type": "java.util.Date",
+            "desc": "Timestamp when the stats was initially started"
+          },
+          "FirstExchangeCompletedTimestamp": {
+            "rw": false,
+            "type": "java.util.Date",
+            "desc": "First Exchange Completed Timestamp"
+          },
+          "LastExchangeFailureTimestamp": {
+            "rw": false,
+            "type": "java.util.Date",
+            "desc": "Last Exchange Failed Timestamp"
+          },
+          "MaxProcessingTime": {
+            "rw": false,
+            "type": "long",
+            "desc": "Max Processing Time [milliseconds]"
+          },
+          "LastExchangeCompletedTimestamp": {
+            "rw": false,
+            "type": "java.util.Date",
+            "desc": "Last Exchange Completed Timestamp"
+          },
+          "Load15": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Average load over the last fifteen minutes"
+          },
+          "DeltaProcessingTime": {
+            "rw": false,
+            "type": "long",
+            "desc": "Delta Processing Time [milliseconds]"
+          },
+          "OldestInflightDuration": {
+            "rw": false,
+            "type": "java.lang.Long",
+            "desc": "Oldest inflight exchange duration"
+          },
+          "ExternalRedeliveries": {
+            "rw": false,
+            "type": "long",
+            "desc": "Number of external initiated redeliveries (such as from JMS broker)"
+          },
+          "UptimeMillis": {
+            "rw": false,
+            "type": "long",
+            "desc": "Route Uptime [milliseconds]"
+          },
+          "ExchangesTotal": {
+            "rw": false,
+            "type": "long",
+            "desc": "Total number of exchanges"
+          },
+          "ResetTimestamp": {
+            "rw": false,
+            "type": "java.util.Date",
+            "desc": "Timestamp when the stats was last reset or initially started"
+          },
+          "ExchangesInflight": {
+            "rw": false,
+            "type": "long",
+            "desc": "Number of inflight exchanges"
+          },
+          "MeanProcessingTime": {
+            "rw": false,
+            "type": "long",
+            "desc": "Mean Processing Time [milliseconds]"
+          },
+          "HasRouteController": {
+            "rw": false,
+            "type": "java.lang.Boolean",
+            "desc": "Route controller"
+          },
+          "LastExchangeFailureExchangeId": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Last Exchange Failed ExchangeId"
+          },
+          "FirstExchangeFailureExchangeId": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "First Exchange Failed ExchangeId"
+          },
+          "Uptime": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Route Uptime [human readable text]"
+          },
+          "CamelId": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Camel ID"
+          },
+          "FirstExchangeFailureTimestamp": {
+            "rw": false,
+            "type": "java.util.Date",
+            "desc": "First Exchange Failed Timestamp"
+          },
+          "TotalProcessingTime": {
+            "rw": false,
+            "type": "long",
+            "desc": "Total Processing Time [milliseconds]"
+          },
+          "RouteId": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Route ID"
+          },
+          "RoutePolicyList": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Route Policy List"
+          },
+          "FailuresHandled": {
+            "rw": false,
+            "type": "long",
+            "desc": "Number of failures handled"
+          },
+          "MessageHistory": {
+            "rw": false,
+            "type": "java.lang.Boolean",
+            "desc": "Message History"
+          },
+          "LastError": {
+            "rw": false,
+            "type": "org.apache.camel.spi.RouteError",
+            "desc": "Last error"
+          },
+          "Load05": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Average load over the last five minutes"
+          },
+          "OldestInflightExchangeId": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Oldest inflight exchange id"
+          },
+          "State": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Route State"
+          },
+          "InflightExchanges": {
+            "rw": false,
+            "type": "java.lang.Integer",
+            "desc": "Current number of inflight Exchanges"
+          },
+          "Redeliveries": {
+            "rw": false,
+            "type": "long",
+            "desc": "Number of redeliveries (internal only)"
+          },
+          "MinProcessingTime": {
+            "rw": false,
+            "type": "long",
+            "desc": "Min Processing Time [milliseconds]"
+          },
+          "LastExchangeCompletedExchangeId": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Last Exchange Completed ExchangeId"
+          },
+          "Tracing": {
+            "rw": true,
+            "type": "java.lang.Boolean",
+            "desc": "Tracing"
+          },
+          "Load01": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Average load over the last minute"
+          }
+        },
+        "class": "org.apache.camel.management.mbean.ManagedSuspendableRoute",
+        "desc": "Managed Suspendable Route"
+      },
+      "context=MyCamel,name=TimerConsumer(0x1e225820),type=consumers": {
+        "op": {
+          "suspend": {
+            "args": [],
+            "ret": "void",
+            "desc": "Suspend Service"
+          },
+          "resume": {
+            "args": [],
+            "ret": "void",
+            "desc": "Resume Service"
+          },
+          "getEndpointUri": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "EndpointUri"
+          },
+          "isSuspended": {
+            "args": [],
+            "ret": "boolean",
+            "desc": "Suspended"
+          },
+          "start": {
+            "args": [],
+            "ret": "void",
+            "desc": "Start Service"
+          },
+          "getRouteId": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "RouteId"
+          },
+          "getCamelManagementName": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "CamelManagementName"
+          },
+          "getCamelId": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "CamelId"
+          },
+          "isSupportSuspension": {
+            "args": [],
+            "ret": "boolean",
+            "desc": "SupportSuspension"
+          },
+          "getState": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "State"
+          },
+          "stop": {
+            "args": [],
+            "ret": "void",
+            "desc": "Stop Service"
+          },
+          "isStaticService": {
+            "args": [],
+            "ret": "boolean",
+            "desc": "StaticService"
+          },
+          "getInflightExchanges": {
+            "args": [],
+            "ret": "java.lang.Integer",
+            "desc": "InflightExchanges"
+          },
+          "getServiceType": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "ServiceType"
+          }
+        },
+        "attr": {
+          "CamelManagementName": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Camel ManagementName"
+          },
+          "EndpointUri": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Endpoint URI"
+          },
+          "State": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Service State"
+          },
+          "CamelId": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Camel ID"
+          },
+          "ServiceType": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Service Type"
+          },
+          "InflightExchanges": {
+            "rw": false,
+            "type": "java.lang.Integer",
+            "desc": "Current number of inflight Exchanges"
+          },
+          "SupportSuspension": {
+            "rw": false,
+            "type": "boolean",
+            "desc": "Whether this service supports suspension"
+          },
+          "RouteId": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Route ID"
+          },
+          "Suspended": {
+            "rw": false,
+            "type": "boolean",
+            "desc": "Whether this service is suspended"
+          },
+          "StaticService": {
+            "rw": false,
+            "type": "boolean",
+            "desc": "Whether this service is static"
+          }
+        },
+        "class": "org.apache.camel.management.mbean.ManagedConsumer",
+        "desc": "Managed Consumer"
+      },
+      "context=MyCamel,name=\"route-log\",type=processors": {
+        "op": {
+          "getLastProcessingTime": {
+            "args": [],
+            "ret": "long",
+            "desc": "LastProcessingTime"
+          },
+          "getExchangesCompleted": {
+            "args": [],
+            "ret": "long",
+            "desc": "ExchangesCompleted"
+          },
+          "explain": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "boolean",
+                "desc": ""
+              }
+            ],
+            "ret": "javax.management.openmbean.TabularData",
+            "desc": "Explain how this processor is configured"
+          },
+          "getDeltaProcessingTime": {
+            "args": [],
+            "ret": "long",
+            "desc": "DeltaProcessingTime"
+          },
+          "getIndex": {
+            "args": [],
+            "ret": "java.lang.Integer",
+            "desc": "Index"
+          },
+          "getTotalProcessingTime": {
+            "args": [],
+            "ret": "long",
+            "desc": "TotalProcessingTime"
+          },
+          "getStartTimestamp": {
+            "args": [],
+            "ret": "java.util.Date",
+            "desc": "StartTimestamp"
+          },
+          "dumpStatsAsXml": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "boolean",
+                "desc": ""
+              }
+            ],
+            "ret": "java.lang.String",
+            "desc": "Dumps the statistics as XML"
+          },
+          "getLastExchangeFailureTimestamp": {
+            "args": [],
+            "ret": "java.util.Date",
+            "desc": "LastExchangeFailureTimestamp"
+          },
+          "getLogName": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "LogName"
+          },
+          "getFirstExchangeCompletedTimestamp": {
+            "args": [],
+            "ret": "java.util.Date",
+            "desc": "FirstExchangeCompletedTimestamp"
+          },
+          "getLastExchangeFailureExchangeId": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "LastExchangeFailureExchangeId"
+          },
+          "getMarker": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "Marker"
+          },
+          "getMaxProcessingTime": {
+            "args": [],
+            "ret": "long",
+            "desc": "MaxProcessingTime"
+          },
+          "getLoggingLevel": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "LoggingLevel"
+          },
+          "getLastExchangeCompletedExchangeId": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "LastExchangeCompletedExchangeId"
+          },
+          "informationJson": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "Processor information as JSon"
+          },
+          "setStatisticsEnabled": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "boolean",
+                "desc": ""
+              }
+            ],
+            "ret": "void",
+            "desc": "StatisticsEnabled"
+          },
+          "getSupportExtendedInformation": {
+            "args": [],
+            "ret": "java.lang.Boolean",
+            "desc": "SupportExtendedInformation"
+          },
+          "getProcessorId": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "ProcessorId"
+          },
+          "getMinProcessingTime": {
+            "args": [],
+            "ret": "long",
+            "desc": "MinProcessingTime"
+          },
+          "getMeanProcessingTime": {
+            "args": [],
+            "ret": "long",
+            "desc": "MeanProcessingTime"
+          },
+          "getExternalRedeliveries": {
+            "args": [],
+            "ret": "long",
+            "desc": "ExternalRedeliveries"
+          },
+          "start": {
+            "args": [],
+            "ret": "void",
+            "desc": "Start Processor"
+          },
+          "getFirstExchangeFailureExchangeId": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "FirstExchangeFailureExchangeId"
+          },
+          "getMessage": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "Message"
+          },
+          "getResetTimestamp": {
+            "args": [],
+            "ret": "java.util.Date",
+            "desc": "ResetTimestamp"
+          },
+          "getExchangesFailed": {
+            "args": [],
+            "ret": "long",
+            "desc": "ExchangesFailed"
+          },
+          "getRouteId": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "RouteId"
+          },
+          "getCamelManagementName": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "CamelManagementName"
+          },
+          "getExchangesTotal": {
+            "args": [],
+            "ret": "long",
+            "desc": "ExchangesTotal"
+          },
+          "getCamelId": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "CamelId"
+          },
+          "getState": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "State"
+          },
+          "stop": {
+            "args": [],
+            "ret": "void",
+            "desc": "Stop Processor"
+          },
+          "getFailuresHandled": {
+            "args": [],
+            "ret": "long",
+            "desc": "FailuresHandled"
+          },
+          "getExchangesInflight": {
+            "args": [],
+            "ret": "long",
+            "desc": "ExchangesInflight"
+          },
+          "reset": {
+            "args": [],
+            "ret": "void",
+            "desc": "Reset counters"
+          },
+          "dumpProcessorAsXml": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "Dumps the processor as XML"
+          },
+          "getRedeliveries": {
+            "args": [],
+            "ret": "long",
+            "desc": "Redeliveries"
+          },
+          "getFirstExchangeCompletedExchangeId": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "FirstExchangeCompletedExchangeId"
+          },
+          "isStatisticsEnabled": {
+            "args": [],
+            "ret": "boolean",
+            "desc": "StatisticsEnabled"
+          },
+          "getLastExchangeCompletedTimestamp": {
+            "args": [],
+            "ret": "java.util.Date",
+            "desc": "LastExchangeCompletedTimestamp"
+          },
+          "getFirstExchangeFailureTimestamp": {
+            "args": [],
+            "ret": "java.util.Date",
+            "desc": "FirstExchangeFailureTimestamp"
+          }
+        },
+        "attr": {
+          "StatisticsEnabled": {
+            "rw": true,
+            "type": "boolean",
+            "desc": "Statistics enabled"
+          },
+          "CamelManagementName": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Camel ManagementName"
+          },
+          "LastProcessingTime": {
+            "rw": false,
+            "type": "long",
+            "desc": "Last Processing Time [milliseconds]"
+          },
+          "ExchangesCompleted": {
+            "rw": false,
+            "type": "long",
+            "desc": "Number of completed exchanges"
+          },
+          "ExchangesFailed": {
+            "rw": false,
+            "type": "long",
+            "desc": "Number of failed exchanges"
+          },
+          "FirstExchangeCompletedExchangeId": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "First Exchange Completed ExchangeId"
+          },
+          "Message": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "The log message (uses simple language)"
+          },
+          "StartTimestamp": {
+            "rw": false,
+            "type": "java.util.Date",
+            "desc": "Timestamp when the stats was initially started"
+          },
+          "FirstExchangeCompletedTimestamp": {
+            "rw": false,
+            "type": "java.util.Date",
+            "desc": "First Exchange Completed Timestamp"
+          },
+          "LastExchangeFailureTimestamp": {
+            "rw": false,
+            "type": "java.util.Date",
+            "desc": "Last Exchange Failed Timestamp"
+          },
+          "Index": {
+            "rw": false,
+            "type": "java.lang.Integer",
+            "desc": "Processor Index"
+          },
+          "MaxProcessingTime": {
+            "rw": false,
+            "type": "long",
+            "desc": "Max Processing Time [milliseconds]"
+          },
+          "LastExchangeCompletedTimestamp": {
+            "rw": false,
+            "type": "java.util.Date",
+            "desc": "Last Exchange Completed Timestamp"
+          },
+          "DeltaProcessingTime": {
+            "rw": false,
+            "type": "long",
+            "desc": "Delta Processing Time [milliseconds]"
+          },
+          "ExternalRedeliveries": {
+            "rw": false,
+            "type": "long",
+            "desc": "Number of external initiated redeliveries (such as from JMS broker)"
+          },
+          "LogName": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "The name of the logger"
+          },
+          "ExchangesTotal": {
+            "rw": false,
+            "type": "long",
+            "desc": "Total number of exchanges"
+          },
+          "ResetTimestamp": {
+            "rw": false,
+            "type": "java.util.Date",
+            "desc": "Timestamp when the stats was last reset or initially started"
+          },
+          "ExchangesInflight": {
+            "rw": false,
+            "type": "long",
+            "desc": "Number of inflight exchanges"
+          },
+          "MeanProcessingTime": {
+            "rw": false,
+            "type": "long",
+            "desc": "Mean Processing Time [milliseconds]"
+          },
+          "LastExchangeFailureExchangeId": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Last Exchange Failed ExchangeId"
+          },
+          "LoggingLevel": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "The logging level"
+          },
+          "FirstExchangeFailureExchangeId": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "First Exchange Failed ExchangeId"
+          },
+          "ProcessorId": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Processor ID"
+          },
+          "CamelId": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Camel ID"
+          },
+          "FirstExchangeFailureTimestamp": {
+            "rw": false,
+            "type": "java.util.Date",
+            "desc": "First Exchange Failed Timestamp"
+          },
+          "TotalProcessingTime": {
+            "rw": false,
+            "type": "long",
+            "desc": "Total Processing Time [milliseconds]"
+          },
+          "SupportExtendedInformation": {
+            "rw": false,
+            "type": "java.lang.Boolean",
+            "desc": "Whether this processor supports extended JMX information"
+          },
+          "RouteId": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Route ID"
+          },
+          "Marker": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "To use slf4j marker"
+          },
+          "FailuresHandled": {
+            "rw": false,
+            "type": "long",
+            "desc": "Number of failures handled"
+          },
+          "State": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Processor State"
+          },
+          "Redeliveries": {
+            "rw": false,
+            "type": "long",
+            "desc": "Number of redeliveries (internal only)"
+          },
+          "MinProcessingTime": {
+            "rw": false,
+            "type": "long",
+            "desc": "Min Processing Time [milliseconds]"
+          },
+          "LastExchangeCompletedExchangeId": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Last Exchange Completed ExchangeId"
+          }
+        },
+        "class": "org.apache.camel.management.mbean.ManagedLog",
+        "desc": "Managed Log"
+      },
+      "context=MyCamel,name=DefaultRuntimeCamelCatalog,type=services": {
+        "op": {
+          "suspend": {
+            "args": [],
+            "ret": "void",
+            "desc": "Suspend Service"
+          },
+          "resume": {
+            "args": [],
+            "ret": "void",
+            "desc": "Resume Service"
+          },
+          "isSuspended": {
+            "args": [],
+            "ret": "boolean",
+            "desc": "Suspended"
+          },
+          "modelJSonSchema": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "java.lang.String",
+                "desc": ""
+              }
+            ],
+            "ret": "java.lang.String",
+            "desc": "Returns the model information as JSon format"
+          },
+          "componentJSonSchema": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "java.lang.String",
+                "desc": ""
+              }
+            ],
+            "ret": "java.lang.String",
+            "desc": "Returns the component information as JSon format"
+          },
+          "start": {
+            "args": [],
+            "ret": "void",
+            "desc": "Start Service"
+          },
+          "dataFormatJSonSchema": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "java.lang.String",
+                "desc": ""
+              }
+            ],
+            "ret": "java.lang.String",
+            "desc": "Returns the data format information as JSon format."
+          },
+          "getRouteId": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "RouteId"
+          },
+          "getCamelManagementName": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "CamelManagementName"
+          },
+          "getCamelId": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "CamelId"
+          },
+          "isSupportSuspension": {
+            "args": [],
+            "ret": "boolean",
+            "desc": "SupportSuspension"
+          },
+          "getState": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "State"
+          },
+          "stop": {
+            "args": [],
+            "ret": "void",
+            "desc": "Stop Service"
+          },
+          "languageJSonSchema": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "java.lang.String",
+                "desc": ""
+              }
+            ],
+            "ret": "java.lang.String",
+            "desc": "Returns the language information as JSon format"
+          },
+          "isStaticService": {
+            "args": [],
+            "ret": "boolean",
+            "desc": "StaticService"
+          },
+          "getServiceType": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "ServiceType"
+          }
+        },
+        "attr": {
+          "CamelManagementName": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Camel ManagementName"
+          },
+          "State": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Service State"
+          },
+          "CamelId": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Camel ID"
+          },
+          "ServiceType": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Service Type"
+          },
+          "SupportSuspension": {
+            "rw": false,
+            "type": "boolean",
+            "desc": "Whether this service supports suspension"
+          },
+          "RouteId": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Route ID"
+          },
+          "Suspended": {
+            "rw": false,
+            "type": "boolean",
+            "desc": "Whether this service is suspended"
+          },
+          "StaticService": {
+            "rw": false,
+            "type": "boolean",
+            "desc": "Whether this service is static"
+          }
+        },
+        "class": "org.apache.camel.management.mbean.ManagedRuntimeCamelCatalog",
+        "desc": "Managed RuntimeCamelCatalog"
+      },
+      "context=MyCamel,name=\"spring-event\",type=components": {
+        "op": {
+          "getCamelId": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "CamelId"
+          },
+          "explain": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "boolean",
+                "desc": ""
+              }
+            ],
+            "ret": "javax.management.openmbean.TabularData",
+            "desc": "Explain how this component is configured"
+          },
+          "getComponentName": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "ComponentName"
+          },
+          "getState": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "State"
+          },
+          "isVerifySupported": {
+            "args": [],
+            "ret": "boolean",
+            "desc": "VerifySupported"
+          },
+          "informationJson": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "Component information as JSon"
+          },
+          "verify": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "java.lang.String",
+                "desc": ""
+              },
+              {
+                "name": "p2",
+                "type": "java.util.Map",
+                "desc": ""
+              }
+            ],
+            "ret": "org.apache.camel.component.extension.ComponentVerifierExtension$Result",
+            "desc": "Verify options against a given scope"
+          },
+          "getCamelManagementName": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "CamelManagementName"
+          }
+        },
+        "attr": {
+          "VerifySupported": {
+            "rw": false,
+            "type": "boolean",
+            "desc": "Whether this component support verification (parameters or connectivity)"
+          },
+          "CamelManagementName": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Camel ManagementName"
+          },
+          "State": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Component State"
+          },
+          "CamelId": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Camel ID"
+          },
+          "ComponentName": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Component Name"
+          }
+        },
+        "class": "org.apache.camel.management.mbean.ManagedComponent",
+        "desc": "Managed Component"
+      },
+      "context=MyCamel,name=DefaultValidatorRegistry,type=services": {
+        "op": {
+          "getDynamicSize": {
+            "args": [],
+            "ret": "java.lang.Integer",
+            "desc": "DynamicSize"
+          },
+          "suspend": {
+            "args": [],
+            "ret": "void",
+            "desc": "Suspend Service"
+          },
+          "resume": {
+            "args": [],
+            "ret": "void",
+            "desc": "Resume Service"
+          },
+          "isSuspended": {
+            "args": [],
+            "ret": "boolean",
+            "desc": "Suspended"
+          },
+          "start": {
+            "args": [],
+            "ret": "void",
+            "desc": "Start Service"
+          },
+          "getStaticSize": {
+            "args": [],
+            "ret": "java.lang.Integer",
+            "desc": "StaticSize"
+          },
+          "listValidators": {
+            "args": [],
+            "ret": "javax.management.openmbean.TabularData",
+            "desc": "Lists all the validators in the registry"
+          },
+          "getRouteId": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "RouteId"
+          },
+          "purge": {
+            "args": [],
+            "ret": "void",
+            "desc": "Purges the cache"
+          },
+          "getCamelManagementName": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "CamelManagementName"
+          },
+          "getCamelId": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "CamelId"
+          },
+          "isSupportSuspension": {
+            "args": [],
+            "ret": "boolean",
+            "desc": "SupportSuspension"
+          },
+          "getSize": {
+            "args": [],
+            "ret": "java.lang.Integer",
+            "desc": "Size"
+          },
+          "getState": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "State"
+          },
+          "stop": {
+            "args": [],
+            "ret": "void",
+            "desc": "Stop Service"
+          },
+          "getMaximumCacheSize": {
+            "args": [],
+            "ret": "java.lang.Integer",
+            "desc": "MaximumCacheSize"
+          },
+          "isStaticService": {
+            "args": [],
+            "ret": "boolean",
+            "desc": "StaticService"
+          },
+          "getSource": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "Source"
+          },
+          "getServiceType": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "ServiceType"
+          }
+        },
+        "attr": {
+          "CamelManagementName": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Camel ManagementName"
+          },
+          "CamelId": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Camel ID"
+          },
+          "Size": {
+            "rw": false,
+            "type": "java.lang.Integer",
+            "desc": "Number of total validators cached"
+          },
+          "SupportSuspension": {
+            "rw": false,
+            "type": "boolean",
+            "desc": "Whether this service supports suspension"
+          },
+          "RouteId": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Route ID"
+          },
+          "StaticService": {
+            "rw": false,
+            "type": "boolean",
+            "desc": "Whether this service is static"
+          },
+          "Source": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Source"
+          },
+          "StaticSize": {
+            "rw": false,
+            "type": "java.lang.Integer",
+            "desc": "Number of static validators cached"
+          },
+          "State": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Service State"
+          },
+          "ServiceType": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Service Type"
+          },
+          "MaximumCacheSize": {
+            "rw": false,
+            "type": "java.lang.Integer",
+            "desc": "Maximum cache size (capacity)"
+          },
+          "Suspended": {
+            "rw": false,
+            "type": "boolean",
+            "desc": "Whether this service is suspended"
+          },
+          "DynamicSize": {
+            "rw": false,
+            "type": "java.lang.Integer",
+            "desc": "Number of dynamic validators cached"
+          }
+        },
+        "class": "org.apache.camel.management.mbean.ManagedValidatorRegistry",
+        "desc": "Managed ValidatorRegistry"
+      },
+      "context=MyCamel,name=BacklogDebugger,type=tracer": {
+        "op": {
+          "getSuspendedBreakpointNodeIds": {
+            "args": [],
+            "ret": "java.util.Set",
+            "desc": "Return the node ids which is currently suspended"
+          },
+          "getDebugCounter": {
+            "args": [],
+            "ret": "long",
+            "desc": "DebugCounter"
+          },
+          "resetDebugCounter": {
+            "args": [],
+            "ret": "void",
+            "desc": "Resets the debug counter"
+          },
+          "setMessageBodyOnBreakpoint": [
+            {
+              "args": [
+                {
+                  "name": "p1",
+                  "type": "java.lang.String",
+                  "desc": ""
+                },
+                {
+                  "name": "p2",
+                  "type": "java.lang.Object",
+                  "desc": ""
+                },
+                {
+                  "name": "p3",
+                  "type": "java.lang.String",
+                  "desc": ""
+                }
+              ],
+              "ret": "void",
+              "desc": "Updates the message body (with a new type) on the suspended breakpoint at the given node id"
+            },
+            {
+              "args": [
+                {
+                  "name": "p1",
+                  "type": "java.lang.String",
+                  "desc": ""
+                },
+                {
+                  "name": "p2",
+                  "type": "java.lang.Object",
+                  "desc": ""
+                }
+              ],
+              "ret": "void",
+              "desc": "Updates the message body (uses same type as old body) on the suspended breakpoint at the given node id"
+            }
+          ],
+          "removeBreakpoint": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "java.lang.String",
+                "desc": ""
+              }
+            ],
+            "ret": "void",
+            "desc": "Remote the breakpoint from the given node id (will resume suspend breakpoint first)"
+          },
+          "getFallbackTimeout": {
+            "args": [],
+            "ret": "long",
+            "desc": "FallbackTimeout"
+          },
+          "stepBreakpoint": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "java.lang.String",
+                "desc": ""
+              }
+            ],
+            "ret": "void",
+            "desc": "Starts single step debugging from the suspended breakpoint at the given node id"
+          },
+          "validateConditionalBreakpoint": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "java.lang.String",
+                "desc": ""
+              },
+              {
+                "name": "p2",
+                "type": "java.lang.String",
+                "desc": ""
+              }
+            ],
+            "ret": "java.lang.String",
+            "desc": "Used for validating if a given predicate is valid or not"
+          },
+          "disableDebugger": {
+            "args": [],
+            "ret": "void",
+            "desc": "Disable the debugger"
+          },
+          "setBodyIncludeStreams": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "boolean",
+                "desc": ""
+              }
+            ],
+            "ret": "void",
+            "desc": "BodyIncludeStreams"
+          },
+          "setMessageHeaderOnBreakpoint": [
+            {
+              "args": [
+                {
+                  "name": "p1",
+                  "type": "java.lang.String",
+                  "desc": ""
+                },
+                {
+                  "name": "p2",
+                  "type": "java.lang.String",
+                  "desc": ""
+                },
+                {
+                  "name": "p3",
+                  "type": "java.lang.Object",
+                  "desc": ""
+                }
+              ],
+              "ret": "void",
+              "desc": "Updates\/adds the message header (uses same type as old header value) on the suspended breakpoint at the given node id"
+            },
+            {
+              "args": [
+                {
+                  "name": "p1",
+                  "type": "java.lang.String",
+                  "desc": ""
+                },
+                {
+                  "name": "p2",
+                  "type": "java.lang.String",
+                  "desc": ""
+                },
+                {
+                  "name": "p3",
+                  "type": "java.lang.Object",
+                  "desc": ""
+                },
+                {
+                  "name": "p4",
+                  "type": "java.lang.String",
+                  "desc": ""
+                }
+              ],
+              "ret": "void",
+              "desc": "Updates\/adds the message header (with a new type) on the suspended breakpoint at the given node id"
+            }
+          ],
+          "setBodyMaxChars": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "int",
+                "desc": ""
+              }
+            ],
+            "ret": "void",
+            "desc": "BodyMaxChars"
+          },
+          "getBodyMaxChars": {
+            "args": [],
+            "ret": "int",
+            "desc": "BodyMaxChars"
+          },
+          "getLoggingLevel": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "LoggingLevel"
+          },
+          "removeMessageHeaderOnBreakpoint": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "java.lang.String",
+                "desc": ""
+              },
+              {
+                "name": "p2",
+                "type": "java.lang.String",
+                "desc": ""
+              }
+            ],
+            "ret": "void",
+            "desc": "Removes the message header on the suspended breakpoint at the given node id"
+          },
+          "isSingleStepMode": {
+            "args": [],
+            "ret": "boolean",
+            "desc": "SingleStepMode"
+          },
+          "setFallbackTimeout": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "long",
+                "desc": ""
+              }
+            ],
+            "ret": "void",
+            "desc": "FallbackTimeout"
+          },
+          "isBodyIncludeFiles": {
+            "args": [],
+            "ret": "boolean",
+            "desc": "BodyIncludeFiles"
+          },
+          "addBreakpoint": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "java.lang.String",
+                "desc": ""
+              }
+            ],
+            "ret": "void",
+            "desc": "Add a breakpoint at the given node id"
+          },
+          "enableDebugger": {
+            "args": [],
+            "ret": "void",
+            "desc": "Enable the debugger"
+          },
+          "removeAllBreakpoints": {
+            "args": [],
+            "ret": "void",
+            "desc": "Remote all breakpoints (will resume all suspend breakpoints first and exists single step mode)"
+          },
+          "setBodyIncludeFiles": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "boolean",
+                "desc": ""
+              }
+            ],
+            "ret": "void",
+            "desc": "BodyIncludeFiles"
+          },
+          "resumeAll": {
+            "args": [],
+            "ret": "void",
+            "desc": "Resume running any suspended breakpoints, and exits step mode"
+          },
+          "addConditionalBreakpoint": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "java.lang.String",
+                "desc": ""
+              },
+              {
+                "name": "p2",
+                "type": "java.lang.String",
+                "desc": ""
+              },
+              {
+                "name": "p3",
+                "type": "java.lang.String",
+                "desc": ""
+              }
+            ],
+            "ret": "void",
+            "desc": "Add a conditional breakpoint at the given node id"
+          },
+          "dumpTracedMessagesAsXml": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "java.lang.String",
+                "desc": ""
+              }
+            ],
+            "ret": "java.lang.String",
+            "desc": "Dumps the messages in xml format from the suspended breakpoint at the given node"
+          },
+          "resumeBreakpoint": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "java.lang.String",
+                "desc": ""
+              }
+            ],
+            "ret": "void",
+            "desc": "Resume running from the suspended breakpoint at the given node id"
+          },
+          "removeMessageBodyOnBreakpoint": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "java.lang.String",
+                "desc": ""
+              }
+            ],
+            "ret": "void",
+            "desc": "Removes the message body on the suspended breakpoint at the given node id"
+          },
+          "getCamelManagementName": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "CamelManagementName"
+          },
+          "getCamelId": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "CamelId"
+          },
+          "isBodyIncludeStreams": {
+            "args": [],
+            "ret": "boolean",
+            "desc": "BodyIncludeStreams"
+          },
+          "setLoggingLevel": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "java.lang.String",
+                "desc": ""
+              }
+            ],
+            "ret": "void",
+            "desc": "LoggingLevel"
+          },
+          "enableBreakpoint": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "java.lang.String",
+                "desc": ""
+              }
+            ],
+            "ret": "void",
+            "desc": "Enables a breakpoint which has been disabled"
+          },
+          "isEnabled": {
+            "args": [],
+            "ret": "boolean",
+            "desc": "Enabled"
+          },
+          "disableBreakpoint": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "java.lang.String",
+                "desc": ""
+              }
+            ],
+            "ret": "void",
+            "desc": "Disables a breakpoint"
+          },
+          "step": {
+            "args": [],
+            "ret": "void",
+            "desc": "Steps to next node in step mode"
+          },
+          "getBreakpoints": {
+            "args": [],
+            "ret": "java.util.Set",
+            "desc": "Return the node ids which has breakpoints"
+          }
+        },
+        "attr": {
+          "BodyIncludeStreams": {
+            "rw": true,
+            "type": "boolean",
+            "desc": "Whether to include stream based message body in the trace message."
+          },
+          "SingleStepMode": {
+            "rw": false,
+            "type": "boolean",
+            "desc": "Whether currently in step mode"
+          },
+          "CamelManagementName": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Camel ManagementName"
+          },
+          "FallbackTimeout": {
+            "rw": true,
+            "type": "long",
+            "desc": "Fallback Timeout in seconds when block the message processing in Camel."
+          },
+          "LoggingLevel": {
+            "rw": true,
+            "type": "java.lang.String",
+            "desc": "Logging Level"
+          },
+          "CamelId": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Camel ID"
+          },
+          "BodyMaxChars": {
+            "rw": true,
+            "type": "int",
+            "desc": "Number of maximum chars in the message body in the trace message. Use zero or negative value to have unlimited size."
+          },
+          "Enabled": {
+            "rw": false,
+            "type": "boolean",
+            "desc": "Is debugger enabled"
+          },
+          "BodyIncludeFiles": {
+            "rw": true,
+            "type": "boolean",
+            "desc": "Whether to include file based message body in the trace message."
+          },
+          "DebugCounter": {
+            "rw": false,
+            "type": "long",
+            "desc": "Number of total debugged messages"
+          }
+        },
+        "class": "org.apache.camel.management.mbean.ManagedBacklogDebugger",
+        "desc": "Managed BacklogDebugger"
+      },
+      "context=MyCamel,name=DefaultRestRegistry,type=services": {
+        "op": {
+          "suspend": {
+            "args": [],
+            "ret": "void",
+            "desc": "Suspend Service"
+          },
+          "resume": {
+            "args": [],
+            "ret": "void",
+            "desc": "Resume Service"
+          },
+          "apiDocAsJson": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "Outputs the Rest services API documentation in JSon (requires camel-swagger-java on classpath)"
+          },
+          "isSuspended": {
+            "args": [],
+            "ret": "boolean",
+            "desc": "Suspended"
+          },
+          "start": {
+            "args": [],
+            "ret": "void",
+            "desc": "Start Service"
+          },
+          "listRestServices": {
+            "args": [],
+            "ret": "javax.management.openmbean.TabularData",
+            "desc": "Lists all the Rest services in the registry (url, path, verb, consumes, produces)"
+          },
+          "getRouteId": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "RouteId"
+          },
+          "getCamelManagementName": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "CamelManagementName"
+          },
+          "getCamelId": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "CamelId"
+          },
+          "isSupportSuspension": {
+            "args": [],
+            "ret": "boolean",
+            "desc": "SupportSuspension"
+          },
+          "getState": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "State"
+          },
+          "stop": {
+            "args": [],
+            "ret": "void",
+            "desc": "Stop Service"
+          },
+          "isStaticService": {
+            "args": [],
+            "ret": "boolean",
+            "desc": "StaticService"
+          },
+          "getNumberOfRestServices": {
+            "args": [],
+            "ret": "int",
+            "desc": "NumberOfRestServices"
+          },
+          "getServiceType": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "ServiceType"
+          }
+        },
+        "attr": {
+          "CamelManagementName": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Camel ManagementName"
+          },
+          "State": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Service State"
+          },
+          "CamelId": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Camel ID"
+          },
+          "ServiceType": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Service Type"
+          },
+          "NumberOfRestServices": {
+            "rw": false,
+            "type": "int",
+            "desc": "Number of rest services in the registry"
+          },
+          "SupportSuspension": {
+            "rw": false,
+            "type": "boolean",
+            "desc": "Whether this service supports suspension"
+          },
+          "RouteId": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Route ID"
+          },
+          "Suspended": {
+            "rw": false,
+            "type": "boolean",
+            "desc": "Whether this service is suspended"
+          },
+          "StaticService": {
+            "rw": false,
+            "type": "boolean",
+            "desc": "Whether this service is static"
+          }
+        },
+        "class": "org.apache.camel.management.mbean.ManagedRestRegistry",
+        "desc": "Managed RestRegistry"
+      },
+      "context=MyCamel,name=\"MyCamel\",type=routecontrollers": {
+        "op": {
+          "getControlledRoutes": {
+            "args": [],
+            "ret": "java.util.Collection",
+            "desc": "ControlledRoutes"
+          }
+        },
+        "attr": {
+          "ControlledRoutes": {
+            "rw": false,
+            "type": "java.util.Collection",
+            "desc": "Controlled Routes"
+          }
+        },
+        "class": "org.apache.camel.management.mbean.ManagedRouteController",
+        "desc": ""
+      },
+      "context=MyCamel,name=DefaultAsyncProcessorAwaitManager,type=services": {
+        "op": {
+          "getMeanDuration": {
+            "args": [],
+            "ret": "long",
+            "desc": "MeanDuration"
+          },
+          "getMinDuration": {
+            "args": [],
+            "ret": "long",
+            "desc": "MinDuration"
+          },
+          "isSupportSuspension": {
+            "args": [],
+            "ret": "boolean",
+            "desc": "SupportSuspension"
+          },
+          "setInterruptThreadsWhileStopping": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "boolean",
+                "desc": ""
+              }
+            ],
+            "ret": "void",
+            "desc": "InterruptThreadsWhileStopping"
+          },
+          "interrupt": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "java.lang.String",
+                "desc": ""
+              }
+            ],
+            "ret": "void",
+            "desc": "To interrupt an exchange which may seem as stuck, to force the exchange to continue, allowing any blocking thread to be released."
+          },
+          "getThreadsInterrupted": {
+            "args": [],
+            "ret": "long",
+            "desc": "ThreadsInterrupted"
+          },
+          "setStatisticsEnabled": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "boolean",
+                "desc": ""
+              }
+            ],
+            "ret": "void",
+            "desc": "StatisticsEnabled"
+          },
+          "isInterruptThreadsWhileStopping": {
+            "args": [],
+            "ret": "boolean",
+            "desc": "InterruptThreadsWhileStopping"
+          },
+          "getMaxDuration": {
+            "args": [],
+            "ret": "long",
+            "desc": "MaxDuration"
+          },
+          "suspend": {
+            "args": [],
+            "ret": "void",
+            "desc": "Suspend Service"
+          },
+          "resume": {
+            "args": [],
+            "ret": "void",
+            "desc": "Resume Service"
+          },
+          "isSuspended": {
+            "args": [],
+            "ret": "boolean",
+            "desc": "Suspended"
+          },
+          "resetStatistics": {
+            "args": [],
+            "ret": "void",
+            "desc": "Resets the statistics"
+          },
+          "start": {
+            "args": [],
+            "ret": "void",
+            "desc": "Start Service"
+          },
+          "getRouteId": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "RouteId"
+          },
+          "getCamelManagementName": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "CamelManagementName"
+          },
+          "getCamelId": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "CamelId"
+          },
+          "getSize": {
+            "args": [],
+            "ret": "int",
+            "desc": "Size"
+          },
+          "getState": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "State"
+          },
+          "stop": {
+            "args": [],
+            "ret": "void",
+            "desc": "Stop Service"
+          },
+          "getTotalDuration": {
+            "args": [],
+            "ret": "long",
+            "desc": "TotalDuration"
+          },
+          "isStaticService": {
+            "args": [],
+            "ret": "boolean",
+            "desc": "StaticService"
+          },
+          "getThreadsBlocked": {
+            "args": [],
+            "ret": "long",
+            "desc": "ThreadsBlocked"
+          },
+          "getServiceType": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "ServiceType"
+          },
+          "isStatisticsEnabled": {
+            "args": [],
+            "ret": "boolean",
+            "desc": "StatisticsEnabled"
+          },
+          "browse": {
+            "args": [],
+            "ret": "javax.management.openmbean.TabularData",
+            "desc": "Lists all the exchanges which are currently inflight, having a blocked thread awaiting for other threads to trigger the callback when they are done"
+          }
+        },
+        "attr": {
+          "CamelManagementName": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Camel ManagementName"
+          },
+          "StatisticsEnabled": {
+            "rw": true,
+            "type": "boolean",
+            "desc": "Utilization statistics enabled"
+          },
+          "CamelId": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Camel ID"
+          },
+          "Size": {
+            "rw": false,
+            "type": "int",
+            "desc": "Number of threads that are blocked waiting for other threads to trigger the callback when they are done processing the exchange"
+          },
+          "ThreadsInterrupted": {
+            "rw": false,
+            "type": "long",
+            "desc": "Number of threads that has been interrupted"
+          },
+          "MaxDuration": {
+            "rw": false,
+            "type": "long",
+            "desc": "The maximum wait time in msec."
+          },
+          "SupportSuspension": {
+            "rw": false,
+            "type": "boolean",
+            "desc": "Whether this service supports suspension"
+          },
+          "MinDuration": {
+            "rw": false,
+            "type": "long",
+            "desc": "The minimum wait time in msec."
+          },
+          "RouteId": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Route ID"
+          },
+          "StaticService": {
+            "rw": false,
+            "type": "boolean",
+            "desc": "Whether this service is static"
+          },
+          "TotalDuration": {
+            "rw": false,
+            "type": "long",
+            "desc": "Total wait time in msec."
+          },
+          "State": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Service State"
+          },
+          "ServiceType": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Service Type"
+          },
+          "MeanDuration": {
+            "rw": false,
+            "type": "long",
+            "desc": "The average wait time in msec."
+          },
+          "InterruptThreadsWhileStopping": {
+            "rw": true,
+            "type": "boolean",
+            "desc": "Whether to interrupt any blocking threads during stopping."
+          },
+          "Suspended": {
+            "rw": false,
+            "type": "boolean",
+            "desc": "Whether this service is suspended"
+          },
+          "ThreadsBlocked": {
+            "rw": false,
+            "type": "long",
+            "desc": "Number of threads that has been blocked"
+          }
+        },
+        "class": "org.apache.camel.management.mbean.ManagedAsyncProcessorAwaitManager",
+        "desc": "Managed AsyncProcessorAwaitManager"
+      },
+      "context=MyCamel,name=DefaultShutdownStrategy,type=services": {
+        "op": {
+          "getCamelId": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "CamelId"
+          },
+          "suspend": {
+            "args": [],
+            "ret": "void",
+            "desc": "Suspend Service"
+          },
+          "resume": {
+            "args": [],
+            "ret": "void",
+            "desc": "Resume Service"
+          },
+          "isSupportSuspension": {
+            "args": [],
+            "ret": "boolean",
+            "desc": "SupportSuspension"
+          },
+          "getState": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "State"
+          },
+          "isSuspended": {
+            "args": [],
+            "ret": "boolean",
+            "desc": "Suspended"
+          },
+          "stop": {
+            "args": [],
+            "ret": "void",
+            "desc": "Stop Service"
+          },
+          "isStaticService": {
+            "args": [],
+            "ret": "boolean",
+            "desc": "StaticService"
+          },
+          "start": {
+            "args": [],
+            "ret": "void",
+            "desc": "Start Service"
+          },
+          "getRouteId": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "RouteId"
+          },
+          "getServiceType": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "ServiceType"
+          },
+          "getCamelManagementName": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "CamelManagementName"
+          }
+        },
+        "attr": {
+          "CamelManagementName": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Camel ManagementName"
+          },
+          "State": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Service State"
+          },
+          "CamelId": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Camel ID"
+          },
+          "ServiceType": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Service Type"
+          },
+          "SupportSuspension": {
+            "rw": false,
+            "type": "boolean",
+            "desc": "Whether this service supports suspension"
+          },
+          "RouteId": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Route ID"
+          },
+          "Suspended": {
+            "rw": false,
+            "type": "boolean",
+            "desc": "Whether this service is suspended"
+          },
+          "StaticService": {
+            "rw": false,
+            "type": "boolean",
+            "desc": "Whether this service is static"
+          }
+        },
+        "class": "org.apache.camel.management.mbean.ManagedService",
+        "desc": "Managed Service"
+      },
+      "context=MyCamel,name=\"properties\",type=components": {
+        "op": {
+          "getCamelId": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "CamelId"
+          },
+          "explain": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "boolean",
+                "desc": ""
+              }
+            ],
+            "ret": "javax.management.openmbean.TabularData",
+            "desc": "Explain how this component is configured"
+          },
+          "getComponentName": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "ComponentName"
+          },
+          "getState": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "State"
+          },
+          "isVerifySupported": {
+            "args": [],
+            "ret": "boolean",
+            "desc": "VerifySupported"
+          },
+          "informationJson": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "Component information as JSon"
+          },
+          "verify": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "java.lang.String",
+                "desc": ""
+              },
+              {
+                "name": "p2",
+                "type": "java.util.Map",
+                "desc": ""
+              }
+            ],
+            "ret": "org.apache.camel.component.extension.ComponentVerifierExtension$Result",
+            "desc": "Verify options against a given scope"
+          },
+          "getCamelManagementName": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "CamelManagementName"
+          }
+        },
+        "attr": {
+          "VerifySupported": {
+            "rw": false,
+            "type": "boolean",
+            "desc": "Whether this component support verification (parameters or connectivity)"
+          },
+          "CamelManagementName": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Camel ManagementName"
+          },
+          "State": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Component State"
+          },
+          "CamelId": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Camel ID"
+          },
+          "ComponentName": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Component Name"
+          }
+        },
+        "class": "org.apache.camel.management.mbean.ManagedComponent",
+        "desc": "Managed Component"
+      },
+      "context=MyCamel,name=\"DefaultErrorHandlerBuilder(ref:CamelDefaultErrorHandlerBuilder)\",type=errorhandlers": {
+        "op": {
+          "getLogStackTrace": {
+            "args": [],
+            "ret": "java.lang.Boolean",
+            "desc": "LogStackTrace"
+          },
+          "getRetriesExhaustedLogLevel": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "RetriesExhaustedLogLevel"
+          },
+          "setLogExhaustedMessageBody": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "java.lang.Boolean",
+                "desc": ""
+              }
+            ],
+            "ret": "void",
+            "desc": "LogExhaustedMessageBody"
+          },
+          "isDeadLetterHandleNewException": {
+            "args": [],
+            "ret": "boolean",
+            "desc": "DeadLetterHandleNewException"
+          },
+          "setUseCollisionAvoidance": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "java.lang.Boolean",
+                "desc": ""
+              }
+            ],
+            "ret": "void",
+            "desc": "UseCollisionAvoidance"
+          },
+          "setBackOffMultiplier": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "java.lang.Double",
+                "desc": ""
+              }
+            ],
+            "ret": "void",
+            "desc": "BackOffMultiplier"
+          },
+          "getMaximumRedeliveryDelay": {
+            "args": [],
+            "ret": "java.lang.Long",
+            "desc": "MaximumRedeliveryDelay"
+          },
+          "getDeadLetterChannelEndpointUri": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "DeadLetterChannelEndpointUri"
+          },
+          "getLogExhausted": {
+            "args": [],
+            "ret": "java.lang.Boolean",
+            "desc": "LogExhausted"
+          },
+          "isSupportRedelivery": {
+            "args": [],
+            "ret": "boolean",
+            "desc": "SupportRedelivery"
+          },
+          "setLogStackTrace": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "java.lang.Boolean",
+                "desc": ""
+              }
+            ],
+            "ret": "void",
+            "desc": "LogStackTrace"
+          },
+          "getRedeliveryDelay": {
+            "args": [],
+            "ret": "java.lang.Long",
+            "desc": "RedeliveryDelay"
+          },
+          "setAllowRedeliveryWhileStopping": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "java.lang.Boolean",
+                "desc": ""
+              }
+            ],
+            "ret": "void",
+            "desc": "AllowRedeliveryWhileStopping"
+          },
+          "setCollisionAvoidancePercent": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "java.lang.Double",
+                "desc": ""
+              }
+            ],
+            "ret": "void",
+            "desc": "CollisionAvoidancePercent"
+          },
+          "isDeadLetterChannel": {
+            "args": [],
+            "ret": "boolean",
+            "desc": "DeadLetterChannel"
+          },
+          "getLogNewException": {
+            "args": [],
+            "ret": "java.lang.Boolean",
+            "desc": "LogNewException"
+          },
+          "setCollisionAvoidanceFactor": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "java.lang.Double",
+                "desc": ""
+              }
+            ],
+            "ret": "void",
+            "desc": "CollisionAvoidanceFactor"
+          },
+          "setMaximumRedeliveries": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "java.lang.Integer",
+                "desc": ""
+              }
+            ],
+            "ret": "void",
+            "desc": "MaximumRedeliveries"
+          },
+          "getBackOffMultiplier": {
+            "args": [],
+            "ret": "java.lang.Double",
+            "desc": "BackOffMultiplier"
+          },
+          "getLogContinued": {
+            "args": [],
+            "ret": "java.lang.Boolean",
+            "desc": "LogContinued"
+          },
+          "getCamelManagementName": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "CamelManagementName"
+          },
+          "getCamelId": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "CamelId"
+          },
+          "getRetryAttemptedLogLevel": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "RetryAttemptedLogLevel"
+          },
+          "getPendingRedeliveryCount": {
+            "args": [],
+            "ret": "java.lang.Integer",
+            "desc": "PendingRedeliveryCount"
+          },
+          "setLogExhaustedMessageHistory": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "java.lang.Boolean",
+                "desc": ""
+              }
+            ],
+            "ret": "void",
+            "desc": "LogExhaustedMessageHistory"
+          },
+          "isSupportTransactions": {
+            "args": [],
+            "ret": "boolean",
+            "desc": "SupportTransactions"
+          },
+          "setRedeliveryDelay": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "java.lang.Long",
+                "desc": ""
+              }
+            ],
+            "ret": "void",
+            "desc": "RedeliveryDelay"
+          },
+          "getLogRetryStackTrace": {
+            "args": [],
+            "ret": "java.lang.Boolean",
+            "desc": "LogRetryStackTrace"
+          },
+          "getAllowRedeliveryWhileStopping": {
+            "args": [],
+            "ret": "java.lang.Boolean",
+            "desc": "AllowRedeliveryWhileStopping"
+          },
+          "setRetryAttemptedLogLevel": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "java.lang.String",
+                "desc": ""
+              }
+            ],
+            "ret": "void",
+            "desc": "RetryAttemptedLogLevel"
+          },
+          "getLogHandled": {
+            "args": [],
+            "ret": "java.lang.Boolean",
+            "desc": "LogHandled"
+          },
+          "setDelayPattern": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "java.lang.String",
+                "desc": ""
+              }
+            ],
+            "ret": "void",
+            "desc": "DelayPattern"
+          },
+          "getUseCollisionAvoidance": {
+            "args": [],
+            "ret": "java.lang.Boolean",
+            "desc": "UseCollisionAvoidance"
+          },
+          "getLogExhaustedMessageBody": {
+            "args": [],
+            "ret": "java.lang.Boolean",
+            "desc": "LogExhaustedMessageBody"
+          },
+          "getCollisionAvoidanceFactor": {
+            "args": [],
+            "ret": "java.lang.Double",
+            "desc": "CollisionAvoidanceFactor"
+          },
+          "setUseExponentialBackOff": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "java.lang.Boolean",
+                "desc": ""
+              }
+            ],
+            "ret": "void",
+            "desc": "UseExponentialBackOff"
+          },
+          "setMaximumRedeliveryDelay": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "java.lang.Long",
+                "desc": ""
+              }
+            ],
+            "ret": "void",
+            "desc": "MaximumRedeliveryDelay"
+          },
+          "getUseExponentialBackOff": {
+            "args": [],
+            "ret": "java.lang.Boolean",
+            "desc": "UseExponentialBackOff"
+          },
+          "setLogNewException": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "java.lang.Boolean",
+                "desc": ""
+              }
+            ],
+            "ret": "void",
+            "desc": "LogNewException"
+          },
+          "setLogRetryStackTrace": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "java.lang.Boolean",
+                "desc": ""
+              }
+            ],
+            "ret": "void",
+            "desc": "LogRetryStackTrace"
+          },
+          "getMaximumRedeliveries": {
+            "args": [],
+            "ret": "java.lang.Integer",
+            "desc": "MaximumRedeliveries"
+          },
+          "setLogExhausted": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "java.lang.Boolean",
+                "desc": ""
+              }
+            ],
+            "ret": "void",
+            "desc": "LogExhausted"
+          },
+          "setLogContinued": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "java.lang.Boolean",
+                "desc": ""
+              }
+            ],
+            "ret": "void",
+            "desc": "LogContinued"
+          },
+          "setLogHandled": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "java.lang.Boolean",
+                "desc": ""
+              }
+            ],
+            "ret": "void",
+            "desc": "LogHandled"
+          },
+          "setRetriesExhaustedLogLevel": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "java.lang.String",
+                "desc": ""
+              }
+            ],
+            "ret": "void",
+            "desc": "RetriesExhaustedLogLevel"
+          },
+          "getDelayPattern": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "DelayPattern"
+          },
+          "getLogExhaustedMessageHistory": {
+            "args": [],
+            "ret": "java.lang.Boolean",
+            "desc": "LogExhaustedMessageHistory"
+          },
+          "getCollisionAvoidancePercent": {
+            "args": [],
+            "ret": "java.lang.Double",
+            "desc": "CollisionAvoidancePercent"
+          },
+          "isDeadLetterUseOriginalMessage": {
+            "args": [],
+            "ret": "boolean",
+            "desc": "DeadLetterUseOriginalMessage"
+          }
+        },
+        "attr": {
+          "LogContinued": {
+            "rw": true,
+            "type": "java.lang.Boolean",
+            "desc": "RedeliveryPolicy for logging handled and continued exceptions"
+          },
+          "LogExhaustedMessageBody": {
+            "rw": true,
+            "type": "java.lang.Boolean",
+            "desc": "RedeliveryPolicy for logging exhausted with message body"
+          },
+          "CamelManagementName": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Camel ManagementName"
+          },
+          "CollisionAvoidanceFactor": {
+            "rw": true,
+            "type": "java.lang.Double",
+            "desc": "RedeliveryPolicy for collision avoidance factor"
+          },
+          "RedeliveryDelay": {
+            "rw": true,
+            "type": "java.lang.Long",
+            "desc": "RedeliveryPolicy for redelivery delay"
+          },
+          "DeadLetterChannel": {
+            "rw": false,
+            "type": "boolean",
+            "desc": "Is this error handler a dead letter channel"
+          },
+          "MaximumRedeliveries": {
+            "rw": true,
+            "type": "java.lang.Integer",
+            "desc": "RedeliveryPolicy for maximum redeliveries"
+          },
+          "DeadLetterUseOriginalMessage": {
+            "rw": false,
+            "type": "boolean",
+            "desc": "When a message is moved to dead letter channel is it the original message or recent message"
+          },
+          "UseCollisionAvoidance": {
+            "rw": true,
+            "type": "java.lang.Boolean",
+            "desc": "RedeliveryPolicy for using collision avoidance"
+          },
+          "RetriesExhaustedLogLevel": {
+            "rw": true,
+            "type": "java.lang.String",
+            "desc": "RedeliveryPolicy for logging level when retries exhausted"
+          },
+          "LogNewException": {
+            "rw": true,
+            "type": "java.lang.Boolean",
+            "desc": "RedeliveryPolicy for logging new exceptions"
+          },
+          "SupportRedelivery": {
+            "rw": false,
+            "type": "boolean",
+            "desc": "Does the error handler support redelivery"
+          },
+          "PendingRedeliveryCount": {
+            "rw": false,
+            "type": "java.lang.Integer",
+            "desc": "Number of Exchanges scheduled for redelivery (waiting to be redelivered in the future)"
+          },
+          "RetryAttemptedLogLevel": {
+            "rw": true,
+            "type": "java.lang.String",
+            "desc": "RedeliveryPolicy for logging level when attempting retry"
+          },
+          "LogExhausted": {
+            "rw": true,
+            "type": "java.lang.Boolean",
+            "desc": "RedeliveryPolicy for logging exhausted exceptions"
+          },
+          "BackOffMultiplier": {
+            "rw": true,
+            "type": "java.lang.Double",
+            "desc": "RedeliveryPolicy for backoff multiplier"
+          },
+          "CollisionAvoidancePercent": {
+            "rw": true,
+            "type": "java.lang.Double",
+            "desc": "RedeliveryPolicy for collision avoidance percent"
+          },
+          "AllowRedeliveryWhileStopping": {
+            "rw": true,
+            "type": "java.lang.Boolean",
+            "desc": "RedeliveryPolicy for allow redelivery while stopping"
+          },
+          "CamelId": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Camel ID"
+          },
+          "UseExponentialBackOff": {
+            "rw": true,
+            "type": "java.lang.Boolean",
+            "desc": "RedeliveryPolicy for using exponential backoff"
+          },
+          "LogStackTrace": {
+            "rw": true,
+            "type": "java.lang.Boolean",
+            "desc": "RedeliveryPolicy for logging stack traces"
+          },
+          "LogExhaustedMessageHistory": {
+            "rw": true,
+            "type": "java.lang.Boolean",
+            "desc": "RedeliveryPolicy for logging exhausted with message history"
+          },
+          "DeadLetterHandleNewException": {
+            "rw": false,
+            "type": "boolean",
+            "desc": "Does this error handler handle new exceptions which may occur during error handling"
+          },
+          "LogHandled": {
+            "rw": true,
+            "type": "java.lang.Boolean",
+            "desc": "RedeliveryPolicy for logging handled exceptions"
+          },
+          "SupportTransactions": {
+            "rw": false,
+            "type": "boolean",
+            "desc": "Does this error handler support transactions"
+          },
+          "DeadLetterChannelEndpointUri": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Endpoint Uri for the dead letter channel where dead message is move to"
+          },
+          "LogRetryStackTrace": {
+            "rw": true,
+            "type": "java.lang.Boolean",
+            "desc": "RedeliveryPolicy for logging redelivery stack traces"
+          },
+          "MaximumRedeliveryDelay": {
+            "rw": true,
+            "type": "java.lang.Long",
+            "desc": "RedeliveryPolicy for maximum redelivery delay"
+          },
+          "DelayPattern": {
+            "rw": true,
+            "type": "java.lang.String",
+            "desc": "RedeliveryPolicy for delay pattern"
+          }
+        },
+        "class": "org.apache.camel.management.mbean.ManagedErrorHandler",
+        "desc": "Managed ErrorHandler"
+      },
+      "context=MyCamel,name=DefaultExecutorServiceManager,type=services": {
+        "op": {
+          "getCamelId": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "CamelId"
+          },
+          "suspend": {
+            "args": [],
+            "ret": "void",
+            "desc": "Suspend Service"
+          },
+          "resume": {
+            "args": [],
+            "ret": "void",
+            "desc": "Resume Service"
+          },
+          "isSupportSuspension": {
+            "args": [],
+            "ret": "boolean",
+            "desc": "SupportSuspension"
+          },
+          "getState": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "State"
+          },
+          "isSuspended": {
+            "args": [],
+            "ret": "boolean",
+            "desc": "Suspended"
+          },
+          "stop": {
+            "args": [],
+            "ret": "void",
+            "desc": "Stop Service"
+          },
+          "isStaticService": {
+            "args": [],
+            "ret": "boolean",
+            "desc": "StaticService"
+          },
+          "start": {
+            "args": [],
+            "ret": "void",
+            "desc": "Start Service"
+          },
+          "getRouteId": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "RouteId"
+          },
+          "getServiceType": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "ServiceType"
+          },
+          "getCamelManagementName": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "CamelManagementName"
+          }
+        },
+        "attr": {
+          "CamelManagementName": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Camel ManagementName"
+          },
+          "State": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Service State"
+          },
+          "CamelId": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Camel ID"
+          },
+          "ServiceType": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Service Type"
+          },
+          "SupportSuspension": {
+            "rw": false,
+            "type": "boolean",
+            "desc": "Whether this service supports suspension"
+          },
+          "RouteId": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Route ID"
+          },
+          "Suspended": {
+            "rw": false,
+            "type": "boolean",
+            "desc": "Whether this service is suspended"
+          },
+          "StaticService": {
+            "rw": false,
+            "type": "boolean",
+            "desc": "Whether this service is static"
+          }
+        },
+        "class": "org.apache.camel.management.mbean.ManagedService",
+        "desc": "Managed Service"
+      },
+      "context=MyCamel,name=\"route-transform\",type=processors": {
+        "op": {
+          "getLastProcessingTime": {
+            "args": [],
+            "ret": "long",
+            "desc": "LastProcessingTime"
+          },
+          "getExchangesCompleted": {
+            "args": [],
+            "ret": "long",
+            "desc": "ExchangesCompleted"
+          },
+          "explain": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "boolean",
+                "desc": ""
+              }
+            ],
+            "ret": "javax.management.openmbean.TabularData",
+            "desc": "Explain how this processor is configured"
+          },
+          "getDeltaProcessingTime": {
+            "args": [],
+            "ret": "long",
+            "desc": "DeltaProcessingTime"
+          },
+          "getIndex": {
+            "args": [],
+            "ret": "java.lang.Integer",
+            "desc": "Index"
+          },
+          "getTotalProcessingTime": {
+            "args": [],
+            "ret": "long",
+            "desc": "TotalProcessingTime"
+          },
+          "getStartTimestamp": {
+            "args": [],
+            "ret": "java.util.Date",
+            "desc": "StartTimestamp"
+          },
+          "dumpStatsAsXml": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "boolean",
+                "desc": ""
+              }
+            ],
+            "ret": "java.lang.String",
+            "desc": "Dumps the statistics as XML"
+          },
+          "getLastExchangeFailureTimestamp": {
+            "args": [],
+            "ret": "java.util.Date",
+            "desc": "LastExchangeFailureTimestamp"
+          },
+          "getFirstExchangeCompletedTimestamp": {
+            "args": [],
+            "ret": "java.util.Date",
+            "desc": "FirstExchangeCompletedTimestamp"
+          },
+          "getLastExchangeFailureExchangeId": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "LastExchangeFailureExchangeId"
+          },
+          "getMaxProcessingTime": {
+            "args": [],
+            "ret": "long",
+            "desc": "MaxProcessingTime"
+          },
+          "getLastExchangeCompletedExchangeId": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "LastExchangeCompletedExchangeId"
+          },
+          "informationJson": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "Processor information as JSon"
+          },
+          "setStatisticsEnabled": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "boolean",
+                "desc": ""
+              }
+            ],
+            "ret": "void",
+            "desc": "StatisticsEnabled"
+          },
+          "getSupportExtendedInformation": {
+            "args": [],
+            "ret": "java.lang.Boolean",
+            "desc": "SupportExtendedInformation"
+          },
+          "getProcessorId": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "ProcessorId"
+          },
+          "getMinProcessingTime": {
+            "args": [],
+            "ret": "long",
+            "desc": "MinProcessingTime"
+          },
+          "getMeanProcessingTime": {
+            "args": [],
+            "ret": "long",
+            "desc": "MeanProcessingTime"
+          },
+          "getExternalRedeliveries": {
+            "args": [],
+            "ret": "long",
+            "desc": "ExternalRedeliveries"
+          },
+          "start": {
+            "args": [],
+            "ret": "void",
+            "desc": "Start Processor"
+          },
+          "getFirstExchangeFailureExchangeId": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "FirstExchangeFailureExchangeId"
+          },
+          "getResetTimestamp": {
+            "args": [],
+            "ret": "java.util.Date",
+            "desc": "ResetTimestamp"
+          },
+          "getExchangesFailed": {
+            "args": [],
+            "ret": "long",
+            "desc": "ExchangesFailed"
+          },
+          "getRouteId": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "RouteId"
+          },
+          "getCamelManagementName": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "CamelManagementName"
+          },
+          "getExchangesTotal": {
+            "args": [],
+            "ret": "long",
+            "desc": "ExchangesTotal"
+          },
+          "getCamelId": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "CamelId"
+          },
+          "getExpression": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "Expression"
+          },
+          "getExpressionLanguage": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "ExpressionLanguage"
+          },
+          "getState": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "State"
+          },
+          "stop": {
+            "args": [],
+            "ret": "void",
+            "desc": "Stop Processor"
+          },
+          "getFailuresHandled": {
+            "args": [],
+            "ret": "long",
+            "desc": "FailuresHandled"
+          },
+          "getExchangesInflight": {
+            "args": [],
+            "ret": "long",
+            "desc": "ExchangesInflight"
+          },
+          "reset": {
+            "args": [],
+            "ret": "void",
+            "desc": "Reset counters"
+          },
+          "dumpProcessorAsXml": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "Dumps the processor as XML"
+          },
+          "getRedeliveries": {
+            "args": [],
+            "ret": "long",
+            "desc": "Redeliveries"
+          },
+          "getFirstExchangeCompletedExchangeId": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "FirstExchangeCompletedExchangeId"
+          },
+          "isStatisticsEnabled": {
+            "args": [],
+            "ret": "boolean",
+            "desc": "StatisticsEnabled"
+          },
+          "getLastExchangeCompletedTimestamp": {
+            "args": [],
+            "ret": "java.util.Date",
+            "desc": "LastExchangeCompletedTimestamp"
+          },
+          "getFirstExchangeFailureTimestamp": {
+            "args": [],
+            "ret": "java.util.Date",
+            "desc": "FirstExchangeFailureTimestamp"
+          }
+        },
+        "attr": {
+          "StatisticsEnabled": {
+            "rw": true,
+            "type": "boolean",
+            "desc": "Statistics enabled"
+          },
+          "CamelManagementName": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Camel ManagementName"
+          },
+          "LastProcessingTime": {
+            "rw": false,
+            "type": "long",
+            "desc": "Last Processing Time [milliseconds]"
+          },
+          "ExchangesCompleted": {
+            "rw": false,
+            "type": "long",
+            "desc": "Number of completed exchanges"
+          },
+          "ExchangesFailed": {
+            "rw": false,
+            "type": "long",
+            "desc": "Number of failed exchanges"
+          },
+          "FirstExchangeCompletedExchangeId": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "First Exchange Completed ExchangeId"
+          },
+          "StartTimestamp": {
+            "rw": false,
+            "type": "java.util.Date",
+            "desc": "Timestamp when the stats was initially started"
+          },
+          "FirstExchangeCompletedTimestamp": {
+            "rw": false,
+            "type": "java.util.Date",
+            "desc": "First Exchange Completed Timestamp"
+          },
+          "LastExchangeFailureTimestamp": {
+            "rw": false,
+            "type": "java.util.Date",
+            "desc": "Last Exchange Failed Timestamp"
+          },
+          "Index": {
+            "rw": false,
+            "type": "java.lang.Integer",
+            "desc": "Processor Index"
+          },
+          "MaxProcessingTime": {
+            "rw": false,
+            "type": "long",
+            "desc": "Max Processing Time [milliseconds]"
+          },
+          "LastExchangeCompletedTimestamp": {
+            "rw": false,
+            "type": "java.util.Date",
+            "desc": "Last Exchange Completed Timestamp"
+          },
+          "DeltaProcessingTime": {
+            "rw": false,
+            "type": "long",
+            "desc": "Delta Processing Time [milliseconds]"
+          },
+          "ExternalRedeliveries": {
+            "rw": false,
+            "type": "long",
+            "desc": "Number of external initiated redeliveries (such as from JMS broker)"
+          },
+          "ExchangesTotal": {
+            "rw": false,
+            "type": "long",
+            "desc": "Total number of exchanges"
+          },
+          "ResetTimestamp": {
+            "rw": false,
+            "type": "java.util.Date",
+            "desc": "Timestamp when the stats was last reset or initially started"
+          },
+          "ExchangesInflight": {
+            "rw": false,
+            "type": "long",
+            "desc": "Number of inflight exchanges"
+          },
+          "MeanProcessingTime": {
+            "rw": false,
+            "type": "long",
+            "desc": "Mean Processing Time [milliseconds]"
+          },
+          "LastExchangeFailureExchangeId": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Last Exchange Failed ExchangeId"
+          },
+          "FirstExchangeFailureExchangeId": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "First Exchange Failed ExchangeId"
+          },
+          "ProcessorId": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Processor ID"
+          },
+          "CamelId": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Camel ID"
+          },
+          "FirstExchangeFailureTimestamp": {
+            "rw": false,
+            "type": "java.util.Date",
+            "desc": "First Exchange Failed Timestamp"
+          },
+          "TotalProcessingTime": {
+            "rw": false,
+            "type": "long",
+            "desc": "Total Processing Time [milliseconds]"
+          },
+          "SupportExtendedInformation": {
+            "rw": false,
+            "type": "java.lang.Boolean",
+            "desc": "Whether this processor supports extended JMX information"
+          },
+          "RouteId": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Route ID"
+          },
+          "ExpressionLanguage": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "The language for the expression"
+          },
+          "FailuresHandled": {
+            "rw": false,
+            "type": "long",
+            "desc": "Number of failures handled"
+          },
+          "Expression": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Expression to return the transformed message body (the new message body to use)"
+          },
+          "State": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Processor State"
+          },
+          "Redeliveries": {
+            "rw": false,
+            "type": "long",
+            "desc": "Number of redeliveries (internal only)"
+          },
+          "MinProcessingTime": {
+            "rw": false,
+            "type": "long",
+            "desc": "Min Processing Time [milliseconds]"
+          },
+          "LastExchangeCompletedExchangeId": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Last Exchange Completed ExchangeId"
+          }
+        },
+        "class": "org.apache.camel.management.mbean.ManagedTransformer",
+        "desc": "Managed Transformer"
+      },
+      "context=MyCamel,name=\"timer\",type=components": {
+        "op": {
+          "getCamelId": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "CamelId"
+          },
+          "explain": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "boolean",
+                "desc": ""
+              }
+            ],
+            "ret": "javax.management.openmbean.TabularData",
+            "desc": "Explain how this component is configured"
+          },
+          "getComponentName": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "ComponentName"
+          },
+          "getState": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "State"
+          },
+          "isVerifySupported": {
+            "args": [],
+            "ret": "boolean",
+            "desc": "VerifySupported"
+          },
+          "informationJson": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "Component information as JSon"
+          },
+          "verify": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "java.lang.String",
+                "desc": ""
+              },
+              {
+                "name": "p2",
+                "type": "java.util.Map",
+                "desc": ""
+              }
+            ],
+            "ret": "org.apache.camel.component.extension.ComponentVerifierExtension$Result",
+            "desc": "Verify options against a given scope"
+          },
+          "getCamelManagementName": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "CamelManagementName"
+          }
+        },
+        "attr": {
+          "VerifySupported": {
+            "rw": false,
+            "type": "boolean",
+            "desc": "Whether this component support verification (parameters or connectivity)"
+          },
+          "CamelManagementName": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Camel ManagementName"
+          },
+          "State": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Component State"
+          },
+          "CamelId": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Camel ID"
+          },
+          "ComponentName": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Component Name"
+          }
+        },
+        "class": "org.apache.camel.management.mbean.ManagedComponent",
+        "desc": "Managed Component"
+      },
+      "context=MyCamel,name=\"bean\",type=components": {
+        "op": {
+          "getCamelId": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "CamelId"
+          },
+          "explain": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "boolean",
+                "desc": ""
+              }
+            ],
+            "ret": "javax.management.openmbean.TabularData",
+            "desc": "Explain how this component is configured"
+          },
+          "getComponentName": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "ComponentName"
+          },
+          "getState": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "State"
+          },
+          "isVerifySupported": {
+            "args": [],
+            "ret": "boolean",
+            "desc": "VerifySupported"
+          },
+          "informationJson": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "Component information as JSon"
+          },
+          "verify": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "java.lang.String",
+                "desc": ""
+              },
+              {
+                "name": "p2",
+                "type": "java.util.Map",
+                "desc": ""
+              }
+            ],
+            "ret": "org.apache.camel.component.extension.ComponentVerifierExtension$Result",
+            "desc": "Verify options against a given scope"
+          },
+          "getCamelManagementName": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "CamelManagementName"
+          }
+        },
+        "attr": {
+          "VerifySupported": {
+            "rw": false,
+            "type": "boolean",
+            "desc": "Whether this component support verification (parameters or connectivity)"
+          },
+          "CamelManagementName": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Camel ManagementName"
+          },
+          "State": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Component State"
+          },
+          "CamelId": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Camel ID"
+          },
+          "ComponentName": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Component Name"
+          }
+        },
+        "class": "org.apache.camel.management.mbean.ManagedComponent",
+        "desc": "Managed Component"
+      },
+      "context=MyCamel,name=\"MyCamel\",type=context": {
+        "op": {
+          "getDeltaProcessingTime": {
+            "args": [],
+            "ret": "long",
+            "desc": "DeltaProcessingTime"
+          },
+          "getCamelVersion": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "CamelVersion"
+          },
+          "getStartTimestamp": {
+            "args": [],
+            "ret": "java.util.Date",
+            "desc": "StartTimestamp"
+          },
+          "getClassResolver": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "ClassResolver"
+          },
+          "isLogMask": {
+            "args": [],
+            "ret": "boolean",
+            "desc": "LogMask"
+          },
+          "isUseMDCLogging": {
+            "args": [],
+            "ret": "boolean",
+            "desc": "UseMDCLogging"
+          },
+          "getLastExchangeFailureTimestamp": {
+            "args": [],
+            "ret": "java.util.Date",
+            "desc": "LastExchangeFailureTimestamp"
+          },
+          "isUseBreadcrumb": {
+            "args": [],
+            "ret": "boolean",
+            "desc": "UseBreadcrumb"
+          },
+          "explainEipJson": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "java.lang.String",
+                "desc": ""
+              },
+              {
+                "name": "p2",
+                "type": "boolean",
+                "desc": ""
+              }
+            ],
+            "ret": "java.lang.String",
+            "desc": "Returns a JSON schema representation of the EIP parameters for the given EIP by its id"
+          },
+          "dataFormatParameterJsonSchema": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "java.lang.String",
+                "desc": ""
+              }
+            ],
+            "ret": "java.lang.String",
+            "desc": "Returns the JSON schema representation of the data format parameters for the given data format name"
+          },
+          "sendBody": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "java.lang.String",
+                "desc": ""
+              },
+              {
+                "name": "p2",
+                "type": "java.lang.Object",
+                "desc": ""
+              }
+            ],
+            "ret": "void",
+            "desc": "Send body (in only)"
+          },
+          "dumpRoutesAsXml": [
+            {
+              "args": [
+                {
+                  "name": "p1",
+                  "type": "boolean",
+                  "desc": ""
+                }
+              ],
+              "ret": "java.lang.String",
+              "desc": "Dumps the routes as XML"
+            },
+            {
+              "args": [],
+              "ret": "java.lang.String",
+              "desc": "Dumps the routes as XML"
+            }
+          ],
+          "componentParameterJsonSchema": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "java.lang.String",
+                "desc": ""
+              }
+            ],
+            "ret": "java.lang.String",
+            "desc": "Returns the JSON schema representation of the endpoint parameters for the given component name"
+          },
+          "canSendToEndpoint": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "java.lang.String",
+                "desc": ""
+              }
+            ],
+            "ret": "boolean",
+            "desc": "Whether its possible to send to the endpoint (eg the endpoint has a producer)"
+          },
+          "setShutdownNowOnTimeout": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "boolean",
+                "desc": ""
+              }
+            ],
+            "ret": "void",
+            "desc": "ShutdownNowOnTimeout"
+          },
+          "getMinProcessingTime": {
+            "args": [],
+            "ret": "long",
+            "desc": "MinProcessingTime"
+          },
+          "startAllRoutes": {
+            "args": [],
+            "ret": "void",
+            "desc": "Starts all the routes which currently is not started"
+          },
+          "getProperties": {
+            "args": [],
+            "ret": "java.util.Map",
+            "desc": "Properties"
+          },
+          "getLoad15": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "Load15"
+          },
+          "stop": {
+            "args": [],
+            "ret": "void",
+            "desc": "Stop Camel (shutdown)"
+          },
+          "setProperty": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "java.lang.String",
+                "desc": ""
+              },
+              {
+                "name": "p2",
+                "type": "java.lang.String",
+                "desc": ""
+              }
+            ],
+            "ret": "void",
+            "desc": "Sets the value of a Camel global option"
+          },
+          "getGlobalOptions": {
+            "args": [],
+            "ret": "java.util.Map",
+            "desc": "GlobalOptions"
+          },
+          "reset": [
+            {
+              "args": [],
+              "ret": "void",
+              "desc": "Reset counters"
+            },
+            {
+              "args": [
+                {
+                  "name": "p1",
+                  "type": "boolean",
+                  "desc": ""
+                }
+              ],
+              "ret": "void",
+              "desc": "Reset counters"
+            }
+          ],
+          "getLastExchangeCompletedTimestamp": {
+            "args": [],
+            "ret": "java.util.Date",
+            "desc": "LastExchangeCompletedTimestamp"
+          },
+          "addOrUpdateRoutesFromXml": [
+            {
+              "args": [
+                {
+                  "name": "p1",
+                  "type": "java.lang.String",
+                  "desc": ""
+                }
+              ],
+              "ret": "void",
+              "desc": "Adds or updates existing routes from XML"
+            },
+            {
+              "args": [
+                {
+                  "name": "p1",
+                  "type": "java.lang.String",
+                  "desc": ""
+                },
+                {
+                  "name": "p2",
+                  "type": "boolean",
+                  "desc": ""
+                }
+              ],
+              "ret": "void",
+              "desc": "Adds or updates existing routes from XML"
+            }
+          ],
+          "findComponents": {
+            "args": [],
+            "ret": "java.util.Map",
+            "desc": "Find all Camel components available in the classpath"
+          },
+          "getManagementName": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "ManagementName"
+          },
+          "explainEndpointJson": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "java.lang.String",
+                "desc": ""
+              },
+              {
+                "name": "p2",
+                "type": "boolean",
+                "desc": ""
+              }
+            ],
+            "ret": "java.lang.String",
+            "desc": " Returns a JSON schema representation of the endpoint parameters for the given endpoint uri"
+          },
+          "dumpRoutesStatsAsXml": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "boolean",
+                "desc": ""
+              },
+              {
+                "name": "p2",
+                "type": "boolean",
+                "desc": ""
+              }
+            ],
+            "ret": "java.lang.String",
+            "desc": "Dumps the CamelContext and routes stats as XML"
+          },
+          "listEips": {
+            "args": [],
+            "ret": "javax.management.openmbean.TabularData",
+            "desc": "List all Camel EIPs from camel-core"
+          },
+          "findComponentNames": {
+            "args": [],
+            "ret": "java.util.List",
+            "desc": "Find all Camel components names available in the classpath"
+          },
+          "getFirstExchangeCompletedTimestamp": {
+            "args": [],
+            "ret": "java.util.Date",
+            "desc": "FirstExchangeCompletedTimestamp"
+          },
+          "requestBody": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "java.lang.String",
+                "desc": ""
+              },
+              {
+                "name": "p2",
+                "type": "java.lang.Object",
+                "desc": ""
+              }
+            ],
+            "ret": "java.lang.Object",
+            "desc": "Request body (in out)"
+          },
+          "getPackageScanClassResolver": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "PackageScanClassResolver"
+          },
+          "isMessageHistory": {
+            "args": [],
+            "ret": "boolean",
+            "desc": "MessageHistory"
+          },
+          "getTimeout": {
+            "args": [],
+            "ret": "long",
+            "desc": "Timeout"
+          },
+          "getInflightExchanges": {
+            "args": [],
+            "ret": "java.lang.Integer",
+            "desc": "InflightExchanges"
+          },
+          "setStatisticsEnabled": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "boolean",
+                "desc": ""
+              }
+            ],
+            "ret": "void",
+            "desc": "StatisticsEnabled"
+          },
+          "getUptimeMillis": {
+            "args": [],
+            "ret": "long",
+            "desc": "UptimeMillis"
+          },
+          "resume": {
+            "args": [],
+            "ret": "void",
+            "desc": "Resume Camel"
+          },
+          "getMeanProcessingTime": {
+            "args": [],
+            "ret": "long",
+            "desc": "MeanProcessingTime"
+          },
+          "getApplicationContextClassName": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "ApplicationContextClassName"
+          },
+          "restart": {
+            "args": [],
+            "ret": "void",
+            "desc": "Restart Camel (stop and then start)"
+          },
+          "getExternalRedeliveries": {
+            "args": [],
+            "ret": "long",
+            "desc": "ExternalRedeliveries"
+          },
+          "getResetTimestamp": {
+            "args": [],
+            "ret": "java.util.Date",
+            "desc": "ResetTimestamp"
+          },
+          "getExchangesFailed": {
+            "args": [],
+            "ret": "long",
+            "desc": "ExchangesFailed"
+          },
+          "getStartedRoutes": {
+            "args": [],
+            "ret": "java.lang.Integer",
+            "desc": "StartedRoutes"
+          },
+          "getTimeUnit": {
+            "args": [],
+            "ret": "java.util.concurrent.TimeUnit",
+            "desc": "TimeUnit"
+          },
+          "setTimeout": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "long",
+                "desc": ""
+              }
+            ],
+            "ret": "void",
+            "desc": "Timeout"
+          },
+          "createEndpoint": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "java.lang.String",
+                "desc": ""
+              }
+            ],
+            "ret": "boolean",
+            "desc": "Creates the endpoint by the given URI"
+          },
+          "completeEndpointPath": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "java.lang.String",
+                "desc": ""
+              },
+              {
+                "name": "p2",
+                "type": "java.util.Map",
+                "desc": ""
+              },
+              {
+                "name": "p3",
+                "type": "java.lang.String",
+                "desc": ""
+              }
+            ],
+            "ret": "java.util.List",
+            "desc": "Returns the list of available endpoint paths for the given component name, endpoint properties and completion text"
+          },
+          "getExchangesInflight": {
+            "args": [],
+            "ret": "long",
+            "desc": "ExchangesInflight"
+          },
+          "getManagementStatisticsLevel": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "ManagementStatisticsLevel"
+          },
+          "getTotalRoutes": {
+            "args": [],
+            "ret": "java.lang.Integer",
+            "desc": "TotalRoutes"
+          },
+          "findEips": {
+            "args": [],
+            "ret": "java.util.Map",
+            "desc": "Find all Camel EIPs from camel-core"
+          },
+          "getFirstExchangeFailureTimestamp": {
+            "args": [],
+            "ret": "java.util.Date",
+            "desc": "FirstExchangeFailureTimestamp"
+          },
+          "getLastProcessingTime": {
+            "args": [],
+            "ret": "long",
+            "desc": "LastProcessingTime"
+          },
+          "getExchangesCompleted": {
+            "args": [],
+            "ret": "long",
+            "desc": "ExchangesCompleted"
+          },
+          "eipParameterJsonSchema": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "java.lang.String",
+                "desc": ""
+              }
+            ],
+            "ret": "java.lang.String",
+            "desc": "Returns the JSON schema representation of the EIP parameters for the given EIP name"
+          },
+          "dumpRestsAsXml": [
+            {
+              "args": [],
+              "ret": "java.lang.String",
+              "desc": "Dumps the rests as XML"
+            },
+            {
+              "args": [
+                {
+                  "name": "p1",
+                  "type": "boolean",
+                  "desc": ""
+                }
+              ],
+              "ret": "java.lang.String",
+              "desc": "Dumps the rests as XML"
+            }
+          ],
+          "requestBodyAndHeaders": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "java.lang.String",
+                "desc": ""
+              },
+              {
+                "name": "p2",
+                "type": "java.lang.Object",
+                "desc": ""
+              },
+              {
+                "name": "p3",
+                "type": "java.util.Map",
+                "desc": ""
+              }
+            ],
+            "ret": "java.lang.Object",
+            "desc": "Request body and headers (in out)"
+          },
+          "dumpStatsAsXml": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "boolean",
+                "desc": ""
+              }
+            ],
+            "ret": "java.lang.String",
+            "desc": "Dumps the statistics as XML"
+          },
+          "isShutdownNowOnTimeout": {
+            "args": [],
+            "ret": "boolean",
+            "desc": "ShutdownNowOnTimeout"
+          },
+          "sendBodyAndHeaders": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "java.lang.String",
+                "desc": ""
+              },
+              {
+                "name": "p2",
+                "type": "java.lang.Object",
+                "desc": ""
+              },
+              {
+                "name": "p3",
+                "type": "java.util.Map",
+                "desc": ""
+              }
+            ],
+            "ret": "void",
+            "desc": "Send body and headers (in only)"
+          },
+          "setTracing": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "java.lang.Boolean",
+                "desc": ""
+              }
+            ],
+            "ret": "void",
+            "desc": "Tracing"
+          },
+          "suspend": {
+            "args": [],
+            "ret": "void",
+            "desc": "Suspend Camel"
+          },
+          "getTracing": {
+            "args": [],
+            "ret": "java.lang.Boolean",
+            "desc": "Tracing"
+          },
+          "removeEndpoints": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "java.lang.String",
+                "desc": ""
+              }
+            ],
+            "ret": "int",
+            "desc": "Removes endpoints by the given pattern"
+          },
+          "findEipNames": {
+            "args": [],
+            "ret": "java.util.List",
+            "desc": "Find all Camel EIP names from camel-core"
+          },
+          "languageParameterJsonSchema": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "java.lang.String",
+                "desc": ""
+              }
+            ],
+            "ret": "java.lang.String",
+            "desc": "Returns the JSON schema representation of the language parameters for the given language name"
+          },
+          "setGlobalOption": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "java.lang.String",
+                "desc": ""
+              },
+              {
+                "name": "p2",
+                "type": "java.lang.String",
+                "desc": ""
+              }
+            ],
+            "ret": "void",
+            "desc": "Sets the value of a Camel global option"
+          },
+          "getComponentDocumentation": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "java.lang.String",
+                "desc": ""
+              }
+            ],
+            "ret": "java.lang.String",
+            "desc": "Returns the HTML documentation for the given camel component"
+          },
+          "getExchangesTotal": {
+            "args": [],
+            "ret": "long",
+            "desc": "ExchangesTotal"
+          },
+          "getCamelId": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "CamelId"
+          },
+          "setTimeUnit": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "java.util.concurrent.TimeUnit",
+                "desc": ""
+              }
+            ],
+            "ret": "void",
+            "desc": "TimeUnit"
+          },
+          "listComponents": {
+            "args": [],
+            "ret": "javax.management.openmbean.TabularData",
+            "desc": "List all Camel components available in the classpath"
+          },
+          "getFirstExchangeCompletedExchangeId": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "FirstExchangeCompletedExchangeId"
+          },
+          "getUptime": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "Uptime"
+          },
+          "getHeadersMapFactoryClassName": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "HeadersMapFactoryClassName"
+          },
+          "getTotalProcessingTime": {
+            "args": [],
+            "ret": "long",
+            "desc": "TotalProcessingTime"
+          },
+          "dumpRoutesCoverageAsXml": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "Dumps the routes coverage as XML"
+          },
+          "requestStringBody": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "java.lang.String",
+                "desc": ""
+              },
+              {
+                "name": "p2",
+                "type": "java.lang.String",
+                "desc": ""
+              }
+            ],
+            "ret": "java.lang.Object",
+            "desc": "Request body (String type) (in out)"
+          },
+          "getLoad05": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "Load05"
+          },
+          "getLastExchangeFailureExchangeId": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "LastExchangeFailureExchangeId"
+          },
+          "isUseDataType": {
+            "args": [],
+            "ret": "boolean",
+            "desc": "UseDataType"
+          },
+          "getMaxProcessingTime": {
+            "args": [],
+            "ret": "long",
+            "desc": "MaxProcessingTime"
+          },
+          "getLastExchangeCompletedExchangeId": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "LastExchangeCompletedExchangeId"
+          },
+          "isAllowUseOriginalMessage": {
+            "args": [],
+            "ret": "boolean",
+            "desc": "AllowUseOriginalMessage"
+          },
+          "explainComponentJson": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "java.lang.String",
+                "desc": ""
+              },
+              {
+                "name": "p2",
+                "type": "boolean",
+                "desc": ""
+              }
+            ],
+            "ret": "java.lang.String",
+            "desc": " Returns a JSON schema representation of the component parameters for the given component by its id"
+          },
+          "getProperty": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "java.lang.String",
+                "desc": ""
+              }
+            ],
+            "ret": "java.lang.String",
+            "desc": "Gets the value of a Camel global option"
+          },
+          "start": {
+            "args": [],
+            "ret": "void",
+            "desc": "Start Camel"
+          },
+          "createRouteStaticEndpointJson": [
+            {
+              "args": [],
+              "ret": "java.lang.String",
+              "desc": "Returns the JSON representation of all the static and dynamic endpoints defined in all the routes"
+            },
+            {
+              "args": [
+                {
+                  "name": "p1",
+                  "type": "boolean",
+                  "desc": ""
+                }
+              ],
+              "ret": "java.lang.String",
+              "desc": "Returns the JSON representation of all the static endpoints (and possible dynamic) defined in all the routes"
+            }
+          ],
+          "getFirstExchangeFailureExchangeId": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "FirstExchangeFailureExchangeId"
+          },
+          "getLoad01": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "Load01"
+          },
+          "getState": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "State"
+          },
+          "getFailuresHandled": {
+            "args": [],
+            "ret": "long",
+            "desc": "FailuresHandled"
+          },
+          "getGlobalOption": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "java.lang.String",
+                "desc": ""
+              }
+            ],
+            "ret": "java.lang.String",
+            "desc": "Gets the value of a Camel global option"
+          },
+          "getRedeliveries": {
+            "args": [],
+            "ret": "long",
+            "desc": "Redeliveries"
+          },
+          "isStatisticsEnabled": {
+            "args": [],
+            "ret": "boolean",
+            "desc": "StatisticsEnabled"
+          },
+          "sendStringBody": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "java.lang.String",
+                "desc": ""
+              },
+              {
+                "name": "p2",
+                "type": "java.lang.String",
+                "desc": ""
+              }
+            ],
+            "ret": "void",
+            "desc": "Send body (String type) (in only)"
+          }
+        },
+        "attr": {
+          "StatisticsEnabled": {
+            "rw": true,
+            "type": "boolean",
+            "desc": "Statistics enabled"
+          },
+          "UseMDCLogging": {
+            "rw": false,
+            "type": "boolean",
+            "desc": "Whether MDC logging is supported"
+          },
+          "ExchangesFailed": {
+            "rw": false,
+            "type": "long",
+            "desc": "Number of failed exchanges"
+          },
+          "FirstExchangeCompletedExchangeId": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "First Exchange Completed ExchangeId"
+          },
+          "StartTimestamp": {
+            "rw": false,
+            "type": "java.util.Date",
+            "desc": "Timestamp when the stats was initially started"
+          },
+          "FirstExchangeCompletedTimestamp": {
+            "rw": false,
+            "type": "java.util.Date",
+            "desc": "First Exchange Completed Timestamp"
+          },
+          "DeltaProcessingTime": {
+            "rw": false,
+            "type": "long",
+            "desc": "Delta Processing Time [milliseconds]"
+          },
+          "TotalRoutes": {
+            "rw": false,
+            "type": "java.lang.Integer",
+            "desc": "Total number of routes"
+          },
+          "ExternalRedeliveries": {
+            "rw": false,
+            "type": "long",
+            "desc": "Number of external initiated redeliveries (such as from JMS broker)"
+          },
+          "UseBreadcrumb": {
+            "rw": false,
+            "type": "boolean",
+            "desc": "Whether breadcrumbs is in use"
+          },
+          "UptimeMillis": {
+            "rw": false,
+            "type": "long",
+            "desc": "Uptime [milliseconds]"
+          },
+          "TimeUnit": {
+            "rw": true,
+            "type": "java.util.concurrent.TimeUnit",
+            "desc": "Shutdown timeout time unit"
+          },
+          "ExchangesTotal": {
+            "rw": false,
+            "type": "long",
+            "desc": "Total number of exchanges"
+          },
+          "ExchangesInflight": {
+            "rw": false,
+            "type": "long",
+            "desc": "Number of inflight exchanges"
+          },
+          "MeanProcessingTime": {
+            "rw": false,
+            "type": "long",
+            "desc": "Mean Processing Time [milliseconds]"
+          },
+          "LastExchangeFailureExchangeId": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Last Exchange Failed ExchangeId"
+          },
+          "LogMask": {
+            "rw": false,
+            "type": "boolean",
+            "desc": "Whether security mask for Logging is enabled"
+          },
+          "FirstExchangeFailureExchangeId": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "First Exchange Failed ExchangeId"
+          },
+          "Timeout": {
+            "rw": true,
+            "type": "long",
+            "desc": "Shutdown timeout"
+          },
+          "CamelId": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Camel ID"
+          },
+          "TotalProcessingTime": {
+            "rw": false,
+            "type": "long",
+            "desc": "Total Processing Time [milliseconds]"
+          },
+          "AllowUseOriginalMessage": {
+            "rw": false,
+            "type": "boolean",
+            "desc": "Whether allowing access to the original message during routing"
+          },
+          "FailuresHandled": {
+            "rw": false,
+            "type": "long",
+            "desc": "Number of failures handled"
+          },
+          "MessageHistory": {
+            "rw": false,
+            "type": "boolean",
+            "desc": "Whether message history is enabled"
+          },
+          "State": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Camel State"
+          },
+          "InflightExchanges": {
+            "rw": false,
+            "type": "java.lang.Integer",
+            "desc": "Current number of inflight Exchanges"
+          },
+          "Tracing": {
+            "rw": true,
+            "type": "java.lang.Boolean",
+            "desc": "Tracing"
+          },
+          "LastProcessingTime": {
+            "rw": false,
+            "type": "long",
+            "desc": "Last Processing Time [milliseconds]"
+          },
+          "ExchangesCompleted": {
+            "rw": false,
+            "type": "long",
+            "desc": "Number of completed exchanges"
+          },
+          "HeadersMapFactoryClassName": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "HeadersMapFactory class name"
+          },
+          "LastExchangeFailureTimestamp": {
+            "rw": false,
+            "type": "java.util.Date",
+            "desc": "Last Exchange Failed Timestamp"
+          },
+          "Properties": {
+            "rw": false,
+            "type": "java.util.Map",
+            "desc": "Camel Properties"
+          },
+          "MaxProcessingTime": {
+            "rw": false,
+            "type": "long",
+            "desc": "Max Processing Time [milliseconds]"
+          },
+          "LastExchangeCompletedTimestamp": {
+            "rw": false,
+            "type": "java.util.Date",
+            "desc": "Last Exchange Completed Timestamp"
+          },
+          "Load15": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Average load over the last fifteen minutes"
+          },
+          "ApplicationContextClassName": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "ApplicationContext class name"
+          },
+          "StartedRoutes": {
+            "rw": false,
+            "type": "java.lang.Integer",
+            "desc": "Current number of started routes"
+          },
+          "ManagementName": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Camel ManagementName"
+          },
+          "ClassResolver": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "ClassResolver class name"
+          },
+          "GlobalOptions": {
+            "rw": false,
+            "type": "java.util.Map",
+            "desc": "Camel Global Options"
+          },
+          "ResetTimestamp": {
+            "rw": false,
+            "type": "java.util.Date",
+            "desc": "Timestamp when the stats was last reset or initially started"
+          },
+          "UseDataType": {
+            "rw": false,
+            "type": "boolean",
+            "desc": "Whether Message DataType is enabled"
+          },
+          "Uptime": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Uptime [human readable text]"
+          },
+          "FirstExchangeFailureTimestamp": {
+            "rw": false,
+            "type": "java.util.Date",
+            "desc": "First Exchange Failed Timestamp"
+          },
+          "ShutdownNowOnTimeout": {
+            "rw": true,
+            "type": "boolean",
+            "desc": "Whether to force shutdown now when a timeout occurred"
+          },
+          "Load05": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Average load over the last five minutes"
+          },
+          "PackageScanClassResolver": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "PackageScanClassResolver class name"
+          },
+          "CamelVersion": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Camel Version"
+          },
+          "Redeliveries": {
+            "rw": false,
+            "type": "long",
+            "desc": "Number of redeliveries (internal only)"
+          },
+          "MinProcessingTime": {
+            "rw": false,
+            "type": "long",
+            "desc": "Min Processing Time [milliseconds]"
+          },
+          "LastExchangeCompletedExchangeId": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Last Exchange Completed ExchangeId"
+          },
+          "ManagementStatisticsLevel": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Camel Management StatisticsLevel"
+          },
+          "Load01": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Average load over the last minute"
+          }
+        },
+        "class": "org.apache.camel.management.mbean.ManagedCamelContext",
+        "desc": "Managed CamelContext"
+      },
+      "context=MyCamel,name=DefaultTypeConverter,type=services": {
+        "op": {
+          "getTypeConverterExistsLoggingLevel": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "TypeConverterExistsLoggingLevel"
+          },
+          "listTypeConverters": {
+            "args": [],
+            "ret": "javax.management.openmbean.TabularData",
+            "desc": "Lists all the type converters in the registry (from -> to)"
+          },
+          "hasTypeConverter": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "java.lang.String",
+                "desc": ""
+              },
+              {
+                "name": "p2",
+                "type": "java.lang.String",
+                "desc": ""
+              }
+            ],
+            "ret": "boolean",
+            "desc": "Checks whether a type converter exists for converting (from -> to)"
+          },
+          "isSupportSuspension": {
+            "args": [],
+            "ret": "boolean",
+            "desc": "SupportSuspension"
+          },
+          "getTypeConverterExists": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "TypeConverterExists"
+          },
+          "setStatisticsEnabled": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "boolean",
+                "desc": ""
+              }
+            ],
+            "ret": "void",
+            "desc": "StatisticsEnabled"
+          },
+          "getHitCounter": {
+            "args": [],
+            "ret": "long",
+            "desc": "HitCounter"
+          },
+          "getMissCounter": {
+            "args": [],
+            "ret": "long",
+            "desc": "MissCounter"
+          },
+          "suspend": {
+            "args": [],
+            "ret": "void",
+            "desc": "Suspend Service"
+          },
+          "resume": {
+            "args": [],
+            "ret": "void",
+            "desc": "Resume Service"
+          },
+          "getAttemptCounter": {
+            "args": [],
+            "ret": "long",
+            "desc": "AttemptCounter"
+          },
+          "isSuspended": {
+            "args": [],
+            "ret": "boolean",
+            "desc": "Suspended"
+          },
+          "start": {
+            "args": [],
+            "ret": "void",
+            "desc": "Start Service"
+          },
+          "getRouteId": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "RouteId"
+          },
+          "getBaseHitCounter": {
+            "args": [],
+            "ret": "long",
+            "desc": "BaseHitCounter"
+          },
+          "resetTypeConversionCounters": {
+            "args": [],
+            "ret": "void",
+            "desc": "Resets the type conversion counters"
+          },
+          "getCamelManagementName": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "CamelManagementName"
+          },
+          "getCamelId": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "CamelId"
+          },
+          "getState": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "State"
+          },
+          "stop": {
+            "args": [],
+            "ret": "void",
+            "desc": "Stop Service"
+          },
+          "isStaticService": {
+            "args": [],
+            "ret": "boolean",
+            "desc": "StaticService"
+          },
+          "getNoopCounter": {
+            "args": [],
+            "ret": "long",
+            "desc": "NoopCounter"
+          },
+          "getNumberOfTypeConverters": {
+            "args": [],
+            "ret": "int",
+            "desc": "NumberOfTypeConverters"
+          },
+          "getFailedCounter": {
+            "args": [],
+            "ret": "long",
+            "desc": "FailedCounter"
+          },
+          "getServiceType": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "ServiceType"
+          },
+          "isStatisticsEnabled": {
+            "args": [],
+            "ret": "boolean",
+            "desc": "StatisticsEnabled"
+          }
+        },
+        "attr": {
+          "CamelManagementName": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Camel ManagementName"
+          },
+          "StatisticsEnabled": {
+            "rw": true,
+            "type": "boolean",
+            "desc": "Utilization statistics enabled"
+          },
+          "NumberOfTypeConverters": {
+            "rw": false,
+            "type": "int",
+            "desc": "Number of type converters in the registry"
+          },
+          "CamelId": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Camel ID"
+          },
+          "SupportSuspension": {
+            "rw": false,
+            "type": "boolean",
+            "desc": "Whether this service supports suspension"
+          },
+          "RouteId": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Route ID"
+          },
+          "StaticService": {
+            "rw": false,
+            "type": "boolean",
+            "desc": "Whether this service is static"
+          },
+          "FailedCounter": {
+            "rw": false,
+            "type": "long",
+            "desc": "Number of type conversion failures (failed conversions)"
+          },
+          "TypeConverterExistsLoggingLevel": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Logging level to use if attempting to add a duplicate type converter"
+          },
+          "State": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Service State"
+          },
+          "ServiceType": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Service Type"
+          },
+          "BaseHitCounter": {
+            "rw": false,
+            "type": "long",
+            "desc": "Number of type conversion hits by base core converters (successful conversions)"
+          },
+          "HitCounter": {
+            "rw": false,
+            "type": "long",
+            "desc": "Number of type conversion hits (successful conversions)"
+          },
+          "AttemptCounter": {
+            "rw": false,
+            "type": "long",
+            "desc": "Number of type conversion attempts"
+          },
+          "TypeConverterExists": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "What to do if attempting to add a duplicate type converter (Override, Ignore or Fail)"
+          },
+          "Suspended": {
+            "rw": false,
+            "type": "boolean",
+            "desc": "Whether this service is suspended"
+          },
+          "NoopCounter": {
+            "rw": false,
+            "type": "long",
+            "desc": "Number of noop attempts (no type conversion was needed)"
+          },
+          "MissCounter": {
+            "rw": false,
+            "type": "long",
+            "desc": "Number of type conversion misses (no suitable type converter)"
+          }
+        },
+        "class": "org.apache.camel.management.mbean.ManagedTypeConverterRegistry",
+        "desc": "Managed TypeConverterRegistry"
+      },
+      "context=MyCamel,name=DefaultInflightRepository,type=services": {
+        "op": {
+          "suspend": {
+            "args": [],
+            "ret": "void",
+            "desc": "Suspend Service"
+          },
+          "resume": {
+            "args": [],
+            "ret": "void",
+            "desc": "Resume Service"
+          },
+          "isSuspended": {
+            "args": [],
+            "ret": "boolean",
+            "desc": "Suspended"
+          },
+          "start": {
+            "args": [],
+            "ret": "void",
+            "desc": "Start Service"
+          },
+          "getRouteId": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "RouteId"
+          },
+          "getCamelManagementName": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "CamelManagementName"
+          },
+          "getCamelId": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "CamelId"
+          },
+          "isSupportSuspension": {
+            "args": [],
+            "ret": "boolean",
+            "desc": "SupportSuspension"
+          },
+          "getSize": {
+            "args": [],
+            "ret": "int",
+            "desc": "Size"
+          },
+          "getState": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "State"
+          },
+          "stop": {
+            "args": [],
+            "ret": "void",
+            "desc": "Stop Service"
+          },
+          "size": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "java.lang.String",
+                "desc": ""
+              }
+            ],
+            "ret": "int",
+            "desc": "Current size of inflight exchanges which are from the given route."
+          },
+          "isStaticService": {
+            "args": [],
+            "ret": "boolean",
+            "desc": "StaticService"
+          },
+          "getServiceType": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "ServiceType"
+          },
+          "browse": [
+            {
+              "args": [
+                {
+                  "name": "p1",
+                  "type": "int",
+                  "desc": ""
+                },
+                {
+                  "name": "p2",
+                  "type": "boolean",
+                  "desc": ""
+                }
+              ],
+              "ret": "javax.management.openmbean.TabularData",
+              "desc": "Lists all the exchanges which are currently inflight, limited and sorted"
+            },
+            {
+              "args": [
+                {
+                  "name": "p1",
+                  "type": "java.lang.String",
+                  "desc": ""
+                },
+                {
+                  "name": "p2",
+                  "type": "int",
+                  "desc": ""
+                },
+                {
+                  "name": "p3",
+                  "type": "boolean",
+                  "desc": ""
+                }
+              ],
+              "ret": "javax.management.openmbean.TabularData",
+              "desc": "List all the exchanges that origins from the given route, which are currently inflight, limited and sorted"
+            },
+            {
+              "args": [],
+              "ret": "javax.management.openmbean.TabularData",
+              "desc": "Lists all the exchanges which are currently inflight"
+            }
+          ]
+        },
+        "attr": {
+          "CamelManagementName": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Camel ManagementName"
+          },
+          "State": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Service State"
+          },
+          "CamelId": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Camel ID"
+          },
+          "ServiceType": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Service Type"
+          },
+          "Size": {
+            "rw": false,
+            "type": "int",
+            "desc": "Current size of inflight exchanges."
+          },
+          "SupportSuspension": {
+            "rw": false,
+            "type": "boolean",
+            "desc": "Whether this service supports suspension"
+          },
+          "RouteId": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Route ID"
+          },
+          "Suspended": {
+            "rw": false,
+            "type": "boolean",
+            "desc": "Whether this service is suspended"
+          },
+          "StaticService": {
+            "rw": false,
+            "type": "boolean",
+            "desc": "Whether this service is static"
+          }
+        },
+        "class": "org.apache.camel.management.mbean.ManagedInflightRepository",
+        "desc": "Managed InflightRepository"
+      },
+      "context=MyCamel,name=DefaultTransformerRegistry,type=services": {
+        "op": {
+          "getDynamicSize": {
+            "args": [],
+            "ret": "java.lang.Integer",
+            "desc": "DynamicSize"
+          },
+          "suspend": {
+            "args": [],
+            "ret": "void",
+            "desc": "Suspend Service"
+          },
+          "resume": {
+            "args": [],
+            "ret": "void",
+            "desc": "Resume Service"
+          },
+          "isSuspended": {
+            "args": [],
+            "ret": "boolean",
+            "desc": "Suspended"
+          },
+          "start": {
+            "args": [],
+            "ret": "void",
+            "desc": "Start Service"
+          },
+          "getStaticSize": {
+            "args": [],
+            "ret": "java.lang.Integer",
+            "desc": "StaticSize"
+          },
+          "getRouteId": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "RouteId"
+          },
+          "purge": {
+            "args": [],
+            "ret": "void",
+            "desc": "Purges the cache"
+          },
+          "getCamelManagementName": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "CamelManagementName"
+          },
+          "getCamelId": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "CamelId"
+          },
+          "isSupportSuspension": {
+            "args": [],
+            "ret": "boolean",
+            "desc": "SupportSuspension"
+          },
+          "getSize": {
+            "args": [],
+            "ret": "java.lang.Integer",
+            "desc": "Size"
+          },
+          "getState": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "State"
+          },
+          "stop": {
+            "args": [],
+            "ret": "void",
+            "desc": "Stop Service"
+          },
+          "listTransformers": {
+            "args": [],
+            "ret": "javax.management.openmbean.TabularData",
+            "desc": "Lists all the transformers in the registry"
+          },
+          "getMaximumCacheSize": {
+            "args": [],
+            "ret": "java.lang.Integer",
+            "desc": "MaximumCacheSize"
+          },
+          "isStaticService": {
+            "args": [],
+            "ret": "boolean",
+            "desc": "StaticService"
+          },
+          "getSource": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "Source"
+          },
+          "getServiceType": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "ServiceType"
+          }
+        },
+        "attr": {
+          "CamelManagementName": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Camel ManagementName"
+          },
+          "CamelId": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Camel ID"
+          },
+          "Size": {
+            "rw": false,
+            "type": "java.lang.Integer",
+            "desc": "Number of total transformers cached"
+          },
+          "SupportSuspension": {
+            "rw": false,
+            "type": "boolean",
+            "desc": "Whether this service supports suspension"
+          },
+          "RouteId": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Route ID"
+          },
+          "StaticService": {
+            "rw": false,
+            "type": "boolean",
+            "desc": "Whether this service is static"
+          },
+          "Source": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Source"
+          },
+          "StaticSize": {
+            "rw": false,
+            "type": "java.lang.Integer",
+            "desc": "Number of static transformers cached"
+          },
+          "State": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Service State"
+          },
+          "ServiceType": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Service Type"
+          },
+          "MaximumCacheSize": {
+            "rw": false,
+            "type": "java.lang.Integer",
+            "desc": "Maximum cache size (capacity)"
+          },
+          "Suspended": {
+            "rw": false,
+            "type": "boolean",
+            "desc": "Whether this service is suspended"
+          },
+          "DynamicSize": {
+            "rw": false,
+            "type": "java.lang.Integer",
+            "desc": "Number of dynamic transformers cached"
+          }
+        },
+        "class": "org.apache.camel.management.mbean.ManagedTransformerRegistry",
+        "desc": "Managed TransformerRegistry"
+      },
+      "context=MyCamel,name=\"timer:\/\/foo\\?period=2000\",type=endpoints": {
+        "op": {
+          "explain": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "boolean",
+                "desc": ""
+              }
+            ],
+            "ret": "javax.management.openmbean.TabularData",
+            "desc": "Explain how this endpoint is configured"
+          },
+          "isFixedRate": {
+            "args": [],
+            "ret": "boolean",
+            "desc": "FixedRate"
+          },
+          "getEndpointUri": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "EndpointUri"
+          },
+          "getDelay": {
+            "args": [],
+            "ret": "long",
+            "desc": "Delay"
+          },
+          "setTimerName": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "java.lang.String",
+                "desc": ""
+              }
+            ],
+            "ret": "void",
+            "desc": "TimerName"
+          },
+          "isSingleton": {
+            "args": [],
+            "ret": "boolean",
+            "desc": "Singleton"
+          },
+          "isMultipleConsumersSupported": {
+            "args": [],
+            "ret": "boolean",
+            "desc": "MultipleConsumersSupported"
+          },
+          "setPeriod": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "long",
+                "desc": ""
+              }
+            ],
+            "ret": "void",
+            "desc": "Period"
+          },
+          "getTimerName": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "TimerName"
+          },
+          "getPeriod": {
+            "args": [],
+            "ret": "long",
+            "desc": "Period"
+          },
+          "getCamelManagementName": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "CamelManagementName"
+          },
+          "getCamelId": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "CamelId"
+          },
+          "setDaemon": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "boolean",
+                "desc": ""
+              }
+            ],
+            "ret": "void",
+            "desc": "Daemon"
+          },
+          "getState": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "State"
+          },
+          "setRepeatCount": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "long",
+                "desc": ""
+              }
+            ],
+            "ret": "void",
+            "desc": "RepeatCount"
+          },
+          "isDaemon": {
+            "args": [],
+            "ret": "boolean",
+            "desc": "Daemon"
+          },
+          "informationJson": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "Endpoint information as JSon"
+          },
+          "setFixedRate": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "boolean",
+                "desc": ""
+              }
+            ],
+            "ret": "void",
+            "desc": "FixedRate"
+          },
+          "setDelay": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "long",
+                "desc": ""
+              }
+            ],
+            "ret": "void",
+            "desc": "Delay"
+          },
+          "getRepeatCount": {
+            "args": [],
+            "ret": "long",
+            "desc": "RepeatCount"
+          }
+        },
+        "attr": {
+          "EndpointUri": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Endpoint URI"
+          },
+          "CamelManagementName": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Camel ManagementName"
+          },
+          "MultipleConsumersSupported": {
+            "rw": false,
+            "type": "boolean",
+            "desc": ""
+          },
+          "RepeatCount": {
+            "rw": true,
+            "type": "long",
+            "desc": "Repeat Count"
+          },
+          "Daemon": {
+            "rw": true,
+            "type": "boolean",
+            "desc": "Timer Daemon"
+          },
+          "State": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Endpoint State"
+          },
+          "Singleton": {
+            "rw": false,
+            "type": "boolean",
+            "desc": "Singleton"
+          },
+          "CamelId": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Camel ID"
+          },
+          "Period": {
+            "rw": true,
+            "type": "long",
+            "desc": "Timer Period"
+          },
+          "FixedRate": {
+            "rw": true,
+            "type": "boolean",
+            "desc": "Timer FixedRate"
+          },
+          "TimerName": {
+            "rw": true,
+            "type": "java.lang.String",
+            "desc": "Timer Name"
+          },
+          "Delay": {
+            "rw": true,
+            "type": "long",
+            "desc": "Timer Delay"
+          }
+        },
+        "class": "org.apache.camel.component.timer.TimerEndpoint",
+        "desc": "Managed TimerEndpoint"
+      },
+      "context=MyCamel,name=BacklogTracer,type=tracer": {
+        "op": {
+          "getBacklogSize": {
+            "args": [],
+            "ret": "int",
+            "desc": "BacklogSize"
+          },
+          "dumpAllTracedMessagesAsXml": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "Dumps all the traced messages in xml format"
+          },
+          "setTracePattern": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "java.lang.String",
+                "desc": ""
+              }
+            ],
+            "ret": "void",
+            "desc": "TracePattern"
+          },
+          "setTraceFilter": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "java.lang.String",
+                "desc": ""
+              }
+            ],
+            "ret": "void",
+            "desc": "TraceFilter"
+          },
+          "setBodyIncludeStreams": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "boolean",
+                "desc": ""
+              }
+            ],
+            "ret": "void",
+            "desc": "BodyIncludeStreams"
+          },
+          "setBodyMaxChars": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "int",
+                "desc": ""
+              }
+            ],
+            "ret": "void",
+            "desc": "BodyMaxChars"
+          },
+          "setBacklogSize": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "int",
+                "desc": ""
+              }
+            ],
+            "ret": "void",
+            "desc": "BacklogSize"
+          },
+          "getBodyMaxChars": {
+            "args": [],
+            "ret": "int",
+            "desc": "BodyMaxChars"
+          },
+          "resetTraceCounter": {
+            "args": [],
+            "ret": "void",
+            "desc": "Resets the trace counter"
+          },
+          "getTraceFilter": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "TraceFilter"
+          },
+          "getTraceCounter": {
+            "args": [],
+            "ret": "long",
+            "desc": "TraceCounter"
+          },
+          "isBodyIncludeFiles": {
+            "args": [],
+            "ret": "boolean",
+            "desc": "BodyIncludeFiles"
+          },
+          "setBodyIncludeFiles": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "boolean",
+                "desc": ""
+              }
+            ],
+            "ret": "void",
+            "desc": "BodyIncludeFiles"
+          },
+          "dumpTracedMessages": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "java.lang.String",
+                "desc": ""
+              }
+            ],
+            "ret": "java.util.List",
+            "desc": "Dumps the traced messages for the given node or route"
+          },
+          "isRemoveOnDump": {
+            "args": [],
+            "ret": "boolean",
+            "desc": "RemoveOnDump"
+          },
+          "dumpTracedMessagesAsXml": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "java.lang.String",
+                "desc": ""
+              }
+            ],
+            "ret": "java.lang.String",
+            "desc": "Dumps the traced messages for the given node or route in xml format"
+          },
+          "clear": {
+            "args": [],
+            "ret": "void",
+            "desc": "Clears the backlog"
+          },
+          "dumpAllTracedMessages": {
+            "args": [],
+            "ret": "java.util.List",
+            "desc": "Dumps all the traced messages"
+          },
+          "getCamelManagementName": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "CamelManagementName"
+          },
+          "getCamelId": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "CamelId"
+          },
+          "isBodyIncludeStreams": {
+            "args": [],
+            "ret": "boolean",
+            "desc": "BodyIncludeStreams"
+          },
+          "setEnabled": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "boolean",
+                "desc": ""
+              }
+            ],
+            "ret": "void",
+            "desc": "Enabled"
+          },
+          "isEnabled": {
+            "args": [],
+            "ret": "boolean",
+            "desc": "Enabled"
+          },
+          "setRemoveOnDump": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "boolean",
+                "desc": ""
+              }
+            ],
+            "ret": "void",
+            "desc": "RemoveOnDump"
+          },
+          "getTracePattern": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "TracePattern"
+          }
+        },
+        "attr": {
+          "BodyIncludeStreams": {
+            "rw": true,
+            "type": "boolean",
+            "desc": "Whether to include stream based message body in the trace message."
+          },
+          "CamelManagementName": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Camel ManagementName"
+          },
+          "BacklogSize": {
+            "rw": true,
+            "type": "int",
+            "desc": "Number of maximum traced messages in total to keep in the backlog (FIFO queue)"
+          },
+          "TraceCounter": {
+            "rw": false,
+            "type": "long",
+            "desc": "Number of total traced messages"
+          },
+          "CamelId": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Camel ID"
+          },
+          "RemoveOnDump": {
+            "rw": true,
+            "type": "boolean",
+            "desc": "Whether to remove traced message from backlog when dumping trace messages"
+          },
+          "BodyMaxChars": {
+            "rw": true,
+            "type": "int",
+            "desc": "Number of maximum chars in the message body in the trace message. Use zero or negative value to have unlimited size."
+          },
+          "Enabled": {
+            "rw": true,
+            "type": "boolean",
+            "desc": "Is tracing enabled"
+          },
+          "TraceFilter": {
+            "rw": true,
+            "type": "java.lang.String",
+            "desc": "To filter tracing by predicate (uses simple language by default)"
+          },
+          "BodyIncludeFiles": {
+            "rw": true,
+            "type": "boolean",
+            "desc": "Whether to include file based message body in the trace message."
+          },
+          "TracePattern": {
+            "rw": true,
+            "type": "java.lang.String",
+            "desc": "To filter tracing by nodes (pattern)"
+          }
+        },
+        "class": "org.apache.camel.management.mbean.ManagedBacklogTracer",
+        "desc": "Managed BacklogTracer"
+      }
+    },
+    "com.sun.management": {
+      "type=HotSpotDiagnostic": {
+        "op": {
+          "setVMOption": {
+            "args": [
+              {
+                "name": "p0",
+                "type": "java.lang.String",
+                "desc": "p0"
+              },
+              {
+                "name": "p1",
+                "type": "java.lang.String",
+                "desc": "p1"
+              }
+            ],
+            "ret": "void",
+            "desc": "setVMOption"
+          },
+          "getVMOption": {
+            "args": [
+              {
+                "name": "p0",
+                "type": "java.lang.String",
+                "desc": "p0"
+              }
+            ],
+            "ret": "javax.management.openmbean.CompositeData",
+            "desc": "getVMOption"
+          },
+          "dumpHeap": {
+            "args": [
+              {
+                "name": "p0",
+                "type": "java.lang.String",
+                "desc": "p0"
+              },
+              {
+                "name": "p1",
+                "type": "boolean",
+                "desc": "p1"
+              }
+            ],
+            "ret": "void",
+            "desc": "dumpHeap"
+          }
+        },
+        "attr": {
+          "DiagnosticOptions": {
+            "rw": false,
+            "type": "[Ljavax.management.openmbean.CompositeData;",
+            "desc": "DiagnosticOptions"
+          },
+          "ObjectName": {
+            "rw": false,
+            "type": "javax.management.ObjectName",
+            "desc": "ObjectName"
+          }
+        },
+        "class": "sun.management.HotSpotDiagnostic",
+        "desc": "Information on the management interface of the MBean"
+      },
+      "type=DiagnosticCommand": {
+        "op": {
+          "vmUptime": {
+            "args": [
+              {
+                "name": "arguments",
+                "type": "[Ljava.lang.String;",
+                "desc": "Array of Diagnostic Commands Arguments and Options"
+              }
+            ],
+            "ret": "java.lang.String",
+            "desc": "Print VM uptime."
+          },
+          "vmNativeMemory": {
+            "args": [
+              {
+                "name": "arguments",
+                "type": "[Ljava.lang.String;",
+                "desc": "Array of Diagnostic Commands Arguments and Options"
+              }
+            ],
+            "ret": "java.lang.String",
+            "desc": "Print native memory usage"
+          },
+          "gcClassHistogram": {
+            "args": [
+              {
+                "name": "arguments",
+                "type": "[Ljava.lang.String;",
+                "desc": "Array of Diagnostic Commands Arguments and Options"
+              }
+            ],
+            "ret": "java.lang.String",
+            "desc": "Provide statistics about the Java heap usage."
+          },
+          "gcRunFinalization": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "Call java.lang.System.runFinalization()."
+          },
+          "gcClassStats": {
+            "args": [
+              {
+                "name": "arguments",
+                "type": "[Ljava.lang.String;",
+                "desc": "Array of Diagnostic Commands Arguments and Options"
+              }
+            ],
+            "ret": "java.lang.String",
+            "desc": "Provide statistics about Java class meta data. Requires -XX:+UnlockDiagnosticVMOptions."
+          },
+          "threadPrint": {
+            "args": [
+              {
+                "name": "arguments",
+                "type": "[Ljava.lang.String;",
+                "desc": "Array of Diagnostic Commands Arguments and Options"
+              }
+            ],
+            "ret": "java.lang.String",
+            "desc": "Print all threads with stacktraces."
+          },
+          "gcFinalizerInfo": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "Provide information about Java finalization queue."
+          },
+          "gcRotateLog": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "Force the GC log file to be rotated."
+          },
+          "help": {
+            "args": [
+              {
+                "name": "arguments",
+                "type": "[Ljava.lang.String;",
+                "desc": "Array of Diagnostic Commands Arguments and Options"
+              }
+            ],
+            "ret": "java.lang.String",
+            "desc": "For more information about a specific command use 'help <command>'. With no argument this will show a list of available commands. 'help all' will show help for all commands."
+          },
+          "vmSystemProperties": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "Print system properties."
+          },
+          "vmClassloaderStats": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "Print statistics about all ClassLoaders."
+          },
+          "gcHeapInfo": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "Provide generic Java heap information."
+          },
+          "gcRun": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "Call java.lang.System.gc()."
+          },
+          "vmVersion": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "Print JVM version information."
+          },
+          "vmFlags": {
+            "args": [
+              {
+                "name": "arguments",
+                "type": "[Ljava.lang.String;",
+                "desc": "Array of Diagnostic Commands Arguments and Options"
+              }
+            ],
+            "ret": "java.lang.String",
+            "desc": "Print VM flag options and their current values."
+          },
+          "vmCommandLine": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "Print the command line used to start this VM instance."
+          },
+          "vmDynlibs": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "Print loaded dynamic libraries."
+          }
+        },
+        "class": "sun.management.DiagnosticCommandImpl",
+        "desc": "Diagnostic Commands"
+      }
+    },
+    "jmx4perl": {
+      "type=Config": {
+        "op": {
+          "setHistoryEntriesForOperation": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "java.lang.String",
+                "desc": ""
+              },
+              {
+                "name": "p2",
+                "type": "java.lang.String",
+                "desc": ""
+              },
+              {
+                "name": "p3",
+                "type": "java.lang.String",
+                "desc": ""
+              },
+              {
+                "name": "p4",
+                "type": "int",
+                "desc": ""
+              }
+            ],
+            "ret": "void",
+            "desc": "Operation exposed for management"
+          },
+          "setHistoryLimitForOperation": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "java.lang.String",
+                "desc": ""
+              },
+              {
+                "name": "p2",
+                "type": "java.lang.String",
+                "desc": ""
+              },
+              {
+                "name": "p3",
+                "type": "java.lang.String",
+                "desc": ""
+              },
+              {
+                "name": "p4",
+                "type": "int",
+                "desc": ""
+              },
+              {
+                "name": "p5",
+                "type": "long",
+                "desc": ""
+              }
+            ],
+            "ret": "void",
+            "desc": "Operation exposed for management"
+          },
+          "resetDebugInfo": {
+            "args": [],
+            "ret": "void",
+            "desc": "Operation exposed for management"
+          },
+          "resetHistoryEntries": {
+            "args": [],
+            "ret": "void",
+            "desc": "Operation exposed for management"
+          },
+          "setHistoryEntriesForAttribute": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "java.lang.String",
+                "desc": ""
+              },
+              {
+                "name": "p2",
+                "type": "java.lang.String",
+                "desc": ""
+              },
+              {
+                "name": "p3",
+                "type": "java.lang.String",
+                "desc": ""
+              },
+              {
+                "name": "p4",
+                "type": "java.lang.String",
+                "desc": ""
+              },
+              {
+                "name": "p5",
+                "type": "int",
+                "desc": ""
+              }
+            ],
+            "ret": "void",
+            "desc": "Operation exposed for management"
+          },
+          "setHistoryLimitForAttribute": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "java.lang.String",
+                "desc": ""
+              },
+              {
+                "name": "p2",
+                "type": "java.lang.String",
+                "desc": ""
+              },
+              {
+                "name": "p3",
+                "type": "java.lang.String",
+                "desc": ""
+              },
+              {
+                "name": "p4",
+                "type": "java.lang.String",
+                "desc": ""
+              },
+              {
+                "name": "p5",
+                "type": "int",
+                "desc": ""
+              },
+              {
+                "name": "p6",
+                "type": "long",
+                "desc": ""
+              }
+            ],
+            "ret": "void",
+            "desc": "Operation exposed for management"
+          },
+          "debugInfo": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "Operation exposed for management"
+          }
+        },
+        "attr": {
+          "HistorySize": {
+            "rw": false,
+            "type": "int",
+            "desc": "Attribute exposed for management"
+          },
+          "MaxDebugEntries": {
+            "rw": true,
+            "type": "int",
+            "desc": "Attribute exposed for management"
+          },
+          "HistoryMaxEntries": {
+            "rw": true,
+            "type": "int",
+            "desc": "Attribute exposed for management"
+          },
+          "Debug": {
+            "rw": true,
+            "type": "boolean",
+            "desc": "Attribute exposed for management"
+          }
+        },
+        "class": "org.jolokia.backend.Config",
+        "desc": "Information on the management interface of the MBean"
+      }
+    },
+    "java.nio": {
+      "name=direct,type=BufferPool": {
+        "attr": {
+          "TotalCapacity": {
+            "rw": false,
+            "type": "long",
+            "desc": "TotalCapacity"
+          },
+          "MemoryUsed": {
+            "rw": false,
+            "type": "long",
+            "desc": "MemoryUsed"
+          },
+          "Count": {
+            "rw": false,
+            "type": "long",
+            "desc": "Count"
+          },
+          "Name": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Name"
+          },
+          "ObjectName": {
+            "rw": false,
+            "type": "javax.management.ObjectName",
+            "desc": "ObjectName"
+          }
+        },
+        "class": "sun.management.ManagementFactoryHelper$1",
+        "desc": "Information on the management interface of the MBean"
+      },
+      "name=mapped,type=BufferPool": {
+        "attr": {
+          "TotalCapacity": {
+            "rw": false,
+            "type": "long",
+            "desc": "TotalCapacity"
+          },
+          "MemoryUsed": {
+            "rw": false,
+            "type": "long",
+            "desc": "MemoryUsed"
+          },
+          "Count": {
+            "rw": false,
+            "type": "long",
+            "desc": "Count"
+          },
+          "Name": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Name"
+          },
+          "ObjectName": {
+            "rw": false,
+            "type": "javax.management.ObjectName",
+            "desc": "ObjectName"
+          }
+        },
+        "class": "sun.management.ManagementFactoryHelper$1",
+        "desc": "Information on the management interface of the MBean"
+      }
+    },
+    "org.xnio": {
+      "address=\"\/0:0:0:0:0:0:0:0:8080\",provider=\"nio\",type=Xnio,worker=\"XNIO-2\"": {
+        "attr": {
+          "ProviderName": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "ProviderName"
+          },
+          "ConnectionCount": {
+            "rw": false,
+            "type": "int",
+            "desc": "ConnectionCount"
+          },
+          "ConnectionLimitLowWater": {
+            "rw": false,
+            "type": "int",
+            "desc": "ConnectionLimitLowWater"
+          },
+          "BindAddress": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "BindAddress"
+          },
+          "ConnectionLimitHighWater": {
+            "rw": false,
+            "type": "int",
+            "desc": "ConnectionLimitHighWater"
+          },
+          "WorkerName": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "WorkerName"
+          }
+        },
+        "class": "org.xnio.nio.QueuedNioTcpServer$3",
+        "desc": "Information on the management interface of the MBean"
+      },
+      "provider=\"nio\",type=Xnio": {
+        "attr": {
+          "Version": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Version"
+          },
+          "Name": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Name"
+          }
+        },
+        "class": "org.xnio.nio.NioXnio$3",
+        "desc": "Information on the management interface of the MBean"
+      },
+      "address=\"\/0:0:0:0:0:0:0:0:8081\",provider=\"nio\",type=Xnio,worker=\"XNIO-1\"": {
+        "attr": {
+          "ProviderName": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "ProviderName"
+          },
+          "ConnectionCount": {
+            "rw": false,
+            "type": "int",
+            "desc": "ConnectionCount"
+          },
+          "ConnectionLimitLowWater": {
+            "rw": false,
+            "type": "int",
+            "desc": "ConnectionLimitLowWater"
+          },
+          "BindAddress": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "BindAddress"
+          },
+          "ConnectionLimitHighWater": {
+            "rw": false,
+            "type": "int",
+            "desc": "ConnectionLimitHighWater"
+          },
+          "WorkerName": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "WorkerName"
+          }
+        },
+        "class": "org.xnio.nio.QueuedNioTcpServer$3",
+        "desc": "Information on the management interface of the MBean"
+      },
+      "provider=\"nio\",type=Xnio,worker=\"XNIO-1\"": {
+        "attr": {
+          "ProviderName": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "ProviderName"
+          },
+          "WorkerQueueSize": {
+            "rw": false,
+            "type": "int",
+            "desc": "WorkerQueueSize"
+          },
+          "ShutdownRequested": {
+            "rw": false,
+            "type": "boolean",
+            "desc": "ShutdownRequested"
+          },
+          "IoThreadCount": {
+            "rw": false,
+            "type": "int",
+            "desc": "IoThreadCount"
+          },
+          "CoreWorkerPoolSize": {
+            "rw": false,
+            "type": "int",
+            "desc": "CoreWorkerPoolSize"
+          },
+          "Name": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Name"
+          },
+          "MaxWorkerPoolSize": {
+            "rw": false,
+            "type": "int",
+            "desc": "MaxWorkerPoolSize"
+          }
+        },
+        "class": "org.xnio.nio.NioXnioWorker$1",
+        "desc": "Information on the management interface of the MBean"
+      },
+      "provider=\"nio\",type=Xnio,worker=\"XNIO-2\"": {
+        "attr": {
+          "ProviderName": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "ProviderName"
+          },
+          "WorkerQueueSize": {
+            "rw": false,
+            "type": "int",
+            "desc": "WorkerQueueSize"
+          },
+          "ShutdownRequested": {
+            "rw": false,
+            "type": "boolean",
+            "desc": "ShutdownRequested"
+          },
+          "IoThreadCount": {
+            "rw": false,
+            "type": "int",
+            "desc": "IoThreadCount"
+          },
+          "CoreWorkerPoolSize": {
+            "rw": false,
+            "type": "int",
+            "desc": "CoreWorkerPoolSize"
+          },
+          "Name": {
+            "rw": false,
+            "type": "java.lang.String",
+            "desc": "Name"
+          },
+          "MaxWorkerPoolSize": {
+            "rw": false,
+            "type": "int",
+            "desc": "MaxWorkerPoolSize"
+          }
+        },
+        "class": "org.xnio.nio.NioXnioWorker$1",
+        "desc": "Information on the management interface of the MBean"
+      }
+    },
+    "jolokia": {
+      "type=Discovery": {
+        "op": {
+          "lookupAgentsWithTimeout": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "int",
+                "desc": ""
+              }
+            ],
+            "ret": "java.util.List",
+            "desc": "Operation exposed for management"
+          },
+          "lookupAgents": {
+            "args": [],
+            "ret": "java.util.List",
+            "desc": "Operation exposed for management"
+          }
+        },
+        "class": "org.jolokia.discovery.JolokiaDiscovery",
+        "desc": "Information on the management interface of the MBean"
+      },
+      "type=ServerHandler": {
+        "op": {
+          "mBeanServersInfo": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "Operation exposed for management"
+          }
+        },
+        "class": "org.jolokia.backend.MBeanServerHandler",
+        "desc": "Information on the management interface of the MBean"
+      },
+      "type=Config": {
+        "op": {
+          "setHistoryEntriesForOperation": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "java.lang.String",
+                "desc": ""
+              },
+              {
+                "name": "p2",
+                "type": "java.lang.String",
+                "desc": ""
+              },
+              {
+                "name": "p3",
+                "type": "java.lang.String",
+                "desc": ""
+              },
+              {
+                "name": "p4",
+                "type": "int",
+                "desc": ""
+              }
+            ],
+            "ret": "void",
+            "desc": "Operation exposed for management"
+          },
+          "setHistoryLimitForOperation": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "java.lang.String",
+                "desc": ""
+              },
+              {
+                "name": "p2",
+                "type": "java.lang.String",
+                "desc": ""
+              },
+              {
+                "name": "p3",
+                "type": "java.lang.String",
+                "desc": ""
+              },
+              {
+                "name": "p4",
+                "type": "int",
+                "desc": ""
+              },
+              {
+                "name": "p5",
+                "type": "long",
+                "desc": ""
+              }
+            ],
+            "ret": "void",
+            "desc": "Operation exposed for management"
+          },
+          "resetDebugInfo": {
+            "args": [],
+            "ret": "void",
+            "desc": "Operation exposed for management"
+          },
+          "resetHistoryEntries": {
+            "args": [],
+            "ret": "void",
+            "desc": "Operation exposed for management"
+          },
+          "setHistoryEntriesForAttribute": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "java.lang.String",
+                "desc": ""
+              },
+              {
+                "name": "p2",
+                "type": "java.lang.String",
+                "desc": ""
+              },
+              {
+                "name": "p3",
+                "type": "java.lang.String",
+                "desc": ""
+              },
+              {
+                "name": "p4",
+                "type": "java.lang.String",
+                "desc": ""
+              },
+              {
+                "name": "p5",
+                "type": "int",
+                "desc": ""
+              }
+            ],
+            "ret": "void",
+            "desc": "Operation exposed for management"
+          },
+          "setHistoryLimitForAttribute": {
+            "args": [
+              {
+                "name": "p1",
+                "type": "java.lang.String",
+                "desc": ""
+              },
+              {
+                "name": "p2",
+                "type": "java.lang.String",
+                "desc": ""
+              },
+              {
+                "name": "p3",
+                "type": "java.lang.String",
+                "desc": ""
+              },
+              {
+                "name": "p4",
+                "type": "java.lang.String",
+                "desc": ""
+              },
+              {
+                "name": "p5",
+                "type": "int",
+                "desc": ""
+              },
+              {
+                "name": "p6",
+                "type": "long",
+                "desc": ""
+              }
+            ],
+            "ret": "void",
+            "desc": "Operation exposed for management"
+          },
+          "debugInfo": {
+            "args": [],
+            "ret": "java.lang.String",
+            "desc": "Operation exposed for management"
+          }
+        },
+        "attr": {
+          "HistorySize": {
+            "rw": false,
+            "type": "int",
+            "desc": "Attribute exposed for management"
+          },
+          "MaxDebugEntries": {
+            "rw": true,
+            "type": "int",
+            "desc": "Attribute exposed for management"
+          },
+          "HistoryMaxEntries": {
+            "rw": true,
+            "type": "int",
+            "desc": "Attribute exposed for management"
+          },
+          "Debug": {
+            "rw": true,
+            "type": "boolean",
+            "desc": "Attribute exposed for management"
+          }
+        },
+        "class": "org.jolokia.backend.Config",
+        "desc": "Information on the management interface of the MBean"
+      }
+    }
+  },
+  "timestamp": 1587557519,
+  "status": 200
+}

--- a/oauthclient.yml
+++ b/oauthclient.yml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: OAuthClient
 metadata:
   name: hawtio-online-dev
+grantMethod: auto
 redirectURIs:
 - http://localhost:2772
 - http://localhost:8080

--- a/packages/common/src/management/management.service.ts
+++ b/packages/common/src/management/management.service.ts
@@ -51,6 +51,7 @@ namespace Online {
           if (podStatusFilter(mPod.pod) === 'Running') {
             req++;
             mPod.jolokia.search('org.apache.camel:context=*,type=routes,*', {
+              method: 'POST',
               success: (routes:[]) => {
                 res++;
                 Core.pathSet(mPod.pod, 'management.camel.routes_count', routes.length);


### PR DESCRIPTION
This PR adds RBAC to the management endpoint, i.e., the ability to control access to the Jolokia endpoints based on roles.

See https://issues.redhat.com/browse/ENTESB-8065 for more details.

TODO:
- [x] Support Jolokia bulk requests
- [x] Parameterize ACL file location, so that it can be secret mounted
- [x] Handle `canInvoke` operation, for seamless compatibility with client-side RBAC plugin
- [x] Migrate default ACL from Karaf into the new ACL format
- [x] Tests suite
- [x] Provide deployment templates