### PR TITLE
DO NOT MERGE - feat(nginx): support basic auth for connection between nginx proxy and Jolokia endpoint

### DIFF
--- a/docker/nginx-gateway.conf
+++ b/docker/nginx-gateway.conf
@@ -1,5 +1,7 @@
 js_import gateway from conf.d/nginx.js;
 
+js_set $credentials gateway.readCredentials;
+
 proxy_cache_path /var/cache/nginx/pods levels=1:2 keys_zone=pods:1m max_size=2m inactive=60m use_temp_path=off;
 proxy_cache_path /var/cache/nginx/rbac levels=1:2 keys_zone=rbac:100k max_size=1m inactive=60m use_temp_path=off;
 proxy_cache_path /var/cache/nginx/rbac2 levels=1:2 keys_zone=rbac2:100k max_size=1m inactive=60m use_temp_path=off;
@@ -122,8 +124,8 @@ server {
         proxy_ssl_certificate     /etc/tls/private/proxying/tls.crt;
         proxy_ssl_certificate_key /etc/tls/private/proxying/tls.key;
         proxy_ssl_session_reuse   on;
-        # Do not foward authorization header
-        proxy_set_header          Authorization "";
+        # Send basic auth credentials (for Artemis) or otherwise empty
+        proxy_set_header          Authorization $credentials;
     }
 
     # Get the OpenShift console URL

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "build": "gulp build",
     "license": "license-reporter merge --mpn='hawtio-online' --mlx='./packages/online/licenses/licenses.xml,./packages/integration/licenses/licenses.xml' --mo=licenses.xml -o=docker/licenses",
     "generate-certificate": "./scripts/generate-certificate.sh",
-    "nginx-test": "cd docker/ && njs test.js"
+    "nginx-test": "cd docker/ && HAWTIO_ONLINE_RBAC_ACL= njs test.js"
   },
   "devDependencies": {
     "@hawtio/node-backend": "^4.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -34,9 +34,9 @@
     urijs "1.19.0"
 
 "@hawtio/integration@~4.13.0":
-  version "4.13.6"
-  resolved "https://registry.yarnpkg.com/@hawtio/integration/-/integration-4.13.6.tgz#686c7d3db6c17532f9dbcccda7d6296c56c03b49"
-  integrity sha512-tCn9wwUygbxKtlFvwaLIS4gJMSgfO/U6Ml1JNYdXJRlqgey8mTpTWSZaoBEyGH6m4jcmm+5lxXyLxUF3D/J1ug==
+  version "4.13.7"
+  resolved "https://registry.yarnpkg.com/@hawtio/integration/-/integration-4.13.7.tgz#ad50721464cc709c09c9266ba14b318cc9a96dab"
+  integrity sha512-UozwYpMNHn9uPiw8hQ0dl89cFIBILR6mP0er8dYO3CNYbDs+Xi5tjjc/6akMDFEdtLs0aM5qRMBi98KZSBJbdg==
   dependencies:
     "@hawtio/core" "^4.13.0"
     "@types/angular-cookies" "^1.4.5"


### PR DESCRIPTION
This is still work-in-progress and not a complete fix, so please don't merge it.

I still haven't abandoned the approach to make it possible that the nginx proxy connects to a Jolokia endpoint provided by an Artemis broker with basic auth, instead of client certificate auth. This is preferable in that you don't need to nudge Artemis dev team to make the Artemis container image support client certificate auth and we can complete the task within hawtio-online. That's why I still stick to the option :-)

I've come up with a _hacky_ way to support basic auth. The patch is still incomplete but has reached the point where at least it partially works, so I'd like to share it with you and ask for your opinions.

@astefanutti What do you think about this approach?  Could you please review it and let me know your thoughts?

One concern is the way it passes the auth credentials to the nginx proxy server, which currently just embeds it to the proxied url. Maybe we can pass it in a request header with name something like `X-Hawtio-Authorization`.