### PR TITLE
Allow to filter projects with a label selector

### DIFF
--- a/package.json
+++ b/package.json
@@ -273,7 +273,6 @@
     "p-locate": "3.0.0",
     "p-limit": "2.3.0",
     "p-try": "2.2.0",
-    "@hawtio/core": "4.13.1",
     "@hawtio/oauth": "4.12.3",
     "vinyl": "2.1.0",
     "process-nextick-args": "2.0.1",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -12,8 +12,8 @@
     "build": "gulp build"
   },
   "dependencies": {
-    "@hawtio/core": "~4.13.0",
-    "@hawtio/kubernetes-api": "~4.11.0",
+    "@hawtio/core": "~4.14.0",
+    "@hawtio/kubernetes-api": "~4.12.0",
     "eventemitter3": "^3.1.0",
     "jolokia.js": "^1.6.0-1",
     "jsonpath": "^1.0.0"

--- a/packages/common/src/openshift/openshift.service.ts
+++ b/packages/common/src/openshift/openshift.service.ts
@@ -26,13 +26,19 @@ namespace Online {
       private $window: ng.IWindowService,
       private K8SClientFactory: KubernetesAPI.K8SClientFactory,
       private $q: ng.IQService,
+      private configManager: Core.ConfigManager,
     ) {
       'ngInject';
 
       super();
 
       if (this.is(HawtioMode.Cluster)) {
-        const projects_client = this.K8SClientFactory.create(KubernetesAPI.WatchTypes.PROJECTS);
+        const projects_client = this.K8SClientFactory.create(
+          {
+           kind: KubernetesAPI.WatchTypes.PROJECTS,
+           labelSelector: _.get(configManager.config, "online.projectSelector", null),
+          }
+        );
         this._loading++;
         const projects_watch = projects_client.watch(projects => {
           // subscribe to pods update for new projects

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,10 +9,10 @@
   dependencies:
     "@types/jquery" "2.0.53"
 
-"@hawtio/core@4.13.1", "@hawtio/core@^4.0.0", "@hawtio/core@^4.13.0", "@hawtio/core@~4.13.0":
-  version "4.13.1"
-  resolved "https://registry.yarnpkg.com/@hawtio/core/-/core-4.13.1.tgz#787a10757c23d6bf0a5e7756b5cfe8f4cebb7518"
-  integrity sha512-nLUNgzdGuYkNKtdbzg7F6wFzSCngkF3zjn/XY5G+BKfm82XhTwHCPuggnKHWcdtnoLQOkIuzIa7KPHBN5/qI3g==
+"@hawtio/core@^4.0.0", "@hawtio/core@^4.13.0", "@hawtio/core@~4.14.0":
+  version "4.14.0"
+  resolved "https://registry.yarnpkg.com/@hawtio/core/-/core-4.14.0.tgz#dfcf898ad76b16b8425fbfae3ca04863bc086c9c"
+  integrity sha512-WSEH1E5YWPYH2bRG3MaglmQquQrTpM+cIjQ36by9qWMUxoUsK/ucmkX8d9gI69FBxXcWi2uJH0aJgsXNR0IQsA==
   dependencies:
     "@hawtio/core-dts" "~3.3.0"
     "@patternfly/patternfly" "^2.0.0"
@@ -59,10 +59,10 @@
     ng-infinite-scroll "1.3.0"
     patternfly-bootstrap-treeview "~2.1.0"
 
-"@hawtio/kubernetes-api@~4.11.0":
-  version "4.11.0"
-  resolved "https://registry.yarnpkg.com/@hawtio/kubernetes-api/-/kubernetes-api-4.11.0.tgz#cf8e5e9485580b4ddad28eb796342ecc0cf27918"
-  integrity sha512-mlYt3G2il3Y2QQQtkrdEIFYlQ15obpSuQIw/MQUqZGo0VbDZu93syCYLI8LcN+RZD6Q8cTSBrap9wHREOYczVg==
+"@hawtio/kubernetes-api@~4.12.0":
+  version "4.12.0"
+  resolved "https://registry.yarnpkg.com/@hawtio/kubernetes-api/-/kubernetes-api-4.12.0.tgz#0ba4aa38f1c528894aa1d6534a93e6208928a186"
+  integrity sha512-bCGsTZI6cZ8SFJZX3eCxgcOsDpazT28FhF9QXe6ewHhqGRC+jpst8bf6G6ZhPgJqyOcQMu1875om9bRKJpzzFA==
   dependencies:
     "@hawtio/core" "^4.0.0"
     "@hawtio/oauth" "^4.0.0"


### PR DESCRIPTION


This allows a user to pass a `projectSelector` with the 
hawtconfig.json.

The string needs to be in the same format as the kubectl/oc
`-l` cli arg.

Example:

```
{
  "online": {
    "projectSelector": "environment=dev,networkzone=internal"
  },  
  "about": {
    "title": "Red Hat Fuse Console",
    "productInfo": [], 
    "additionalInfo": "The Red Hat Fuse Console eases the discovery and management of Fuse applications deployed on OpenShift.",
    "copyright": "", 
    "imgSrc": "../online/img/Logo-RedHat-A-Reverse-RGB.png"
  }
  ... 
}
```

Depends on hawtio/hawtio-kubernetes-api#15 and hawtio/hawtio-core#44

Ref ENTESB-14539 and hawtio/hawtio-online#64
