### PR TITLE
[CVE-2022-0613][CVE-2022-24723] Upgrade urijs to 1.19.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "license-reporter": "^1.2.1",
     "mime-types": "^2.1.18",
     "stringify-object": "~2.4.0",
-    "urijs": "^1.19.0",
+    "urijs": "^1.19.9",
     "yargs": "^9.0.0"
   },
   "flat": true,
@@ -168,7 +168,7 @@
     "wordwrap": "0.0.3",
     "bufferstreams": "1.1.3",
     "vinyl-file": "1.3.0",
-    "urijs": "1.19.0",
+    "urijs": "1.19.9",
     "minimist": "1.2.0",
     "semver": "5.4.1",
     "moment": "2.29.4",


### PR DESCRIPTION
https://nvd.nist.gov/vuln/detail/CVE-2022-0613
https://nvd.nist.gov/vuln/detail/CVE-2022-24723