### PR TITLE
fix: Fixes github test build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,6 +8,7 @@
 !.yarnrc.yml
 !.yarn/plugins
 !.yarn/releases
+!.yarn/patches
 
 **/node_modules/
 **/site/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        node: [ '12', '14' ]
+        node: [ '16', '18' ]
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -29,7 +29,7 @@ jobs:
           echo "deb [signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg] http://nginx.org/packages/ubuntu `lsb_release -cs` nginx" | sudo tee /etc/apt/sources.list.d/nginx.list
           echo -e "Package: *\nPin: origin nginx.org\nPin: release o=nginx\nPin-Priority: 900\n" | sudo tee /etc/apt/preferences.d/99nginx
           sudo apt-get update -y
-          sudo apt-get install -y nginx=1.18.0-2~focal nginx-module-njs=1.18.0.0.4.4-2~focal
+          sudo apt-get install -y nginx=1.24.0-1~focal nginx-module-njs=1.24.0+0.8.1-1~focal
       - name: Show NJS versions for debugging
         run: sudo apt-cache showpkg nginx-module-njs
       - name: Set up node/yarn

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "docker"
   ],
   "scripts": {
-    "build": "yarn build:online",
+    "build": "yarn build:online && yarn build:docker",
+    "build:docker": "yarn workspace @hawtio/online-docker build",
     "start:online": "yarn build:mgmt && yarn start:shell",
     "build:online": "yarn build:mgmt && yarn build:shell",
     "start:shell": "yarn workspace @hawtio/online-shell start",
@@ -38,8 +39,9 @@
     "license": "license-reporter merge --mpn='hawtio-online' --mlx='./packages/online/licenses/licenses.xml,./packages/integration/licenses/licenses.xml' --mo=licenses.xml -o=docker/licenses",
     "gen:proxying": "./scripts/generate-proxying.sh",
     "gen:serving": "./scripts/generate-serving.sh",
-    "test:docker": "jasmine docker/*.spec.js",
-    "test:nginx": "cd docker/ && HAWTIO_ONLINE_RBAC_ACL= njs test.js",
+    "test": "yarn test:docker && yarn test:nginx",
+    "test:docker": "yarn workspace @hawtio/online-docker test",
+    "test:nginx": "yarn workspace @hawtio/online-docker njs:test",
     "deploy:k8s:namespace": "kubectl apply --kustomize deploy/k8s/namespace/",
     "deploy:k8s:cluster": "kubectl apply --kustomize deploy/k8s/cluster/",
     "deploy:openshift:namespace": "oc apply --kustomize deploy/openshift/namespace/",


### PR DESCRIPTION
* .dockerignore
  * adds the patch for js-yaml

* Dockerfile
  * Updates the build instructions to include the building of nginx.js

* package.json
  * Adds the requisite commands for building

* .github/workflows/test.yml
  * Updates versions of node to match hawtio/next (and rollup version is not compatible with < node 14)
  * Updates versions of nginx and njs to 1.24