### PR TITLE
fix: Updates njs tests to return a failure

### DIFF
--- a/docker/test.js
+++ b/docker/test.js
@@ -9,8 +9,32 @@ var fs = require('fs');
 
 var listMBeans = fs.readFileSync('test.listMBeans.json');
 
+function report(code, expectedCode, message) {
+  console.log('code:', code);
+  console.log('message:', message, "\n");
+
+  if (code !== expectedCode)
+    throw new Error(`Failure: Return status code ${code} does not match expected ${expectedCode}`);
+}
+
+function callGateway(input) {
+  var options = {
+    return: (code, message) => {
+      report(code, input.expectedCode, message);
+    },
+    log: (message) => {
+      console.log(message);
+    }
+  }
+
+  var payload = Object.assign(input, options);
+  return gateway.proxyJolokiaAgent(payload);
+}
+
 function requestWithViewerRoleTest() {
-  return gateway.proxyJolokiaAgent({
+  console.log('=== requestWithViewerRoleTest');
+  return callGateway({
+    method: 'POST',
     uri: '/management/namespaces/test/pods/https:pod:443/remaining',
     requestBody: JSON.stringify({
       type: 'exec',
@@ -19,14 +43,14 @@ function requestWithViewerRoleTest() {
     }),
     headersOut: {},
     subrequest: doWithViewerRole,
-    return: (code, message) => {
-      console.log('code:', code, 'message:', message);
-    },
+    expectedCode: 200
   });
 }
 
 function bulkRequestWithViewerRoleTest() {
-  return gateway.proxyJolokiaAgent({
+  console.log('=== bulkRequestWithViewerRoleTest');
+  return callGateway({
+    method: 'POST',
     uri: '/management/namespaces/test/pods/https:pod:443/remaining',
     requestBody: JSON.stringify([
       {
@@ -42,14 +66,14 @@ function bulkRequestWithViewerRoleTest() {
     ]),
     headersOut: {},
     subrequest: doWithViewerRole,
-    return: (code, message) => {
-      console.log('code:', code, 'message:', message);
-    },
+    expectedCode: 200
   });
 }
 
 function requestOperationWithArgumentsAndNoRoleTest() {
-  return gateway.proxyJolokiaAgent({
+  console.log('=== requestOperationWithArgumentsAndNoRoleTest');
+  return callGateway({
+    method: 'POST',
     uri: '/management/namespaces/test/pods/https:pod:443/remaining',
     requestBody: JSON.stringify({
       type: 'exec',
@@ -61,14 +85,14 @@ function requestOperationWithArgumentsAndNoRoleTest() {
     }),
     headersOut: {},
     subrequest: doWithViewerRole,
-    return: (code, message) => {
-      console.log('code:', code, 'message:', message);
-    },
+    expectedCode: 403 // viewer not allowed to uninstall
   });
 }
 
 function requestOperationWithArgumentsAndViewerRoleTest() {
-  return gateway.proxyJolokiaAgent({
+  console.log('=== requestOperationWithArgumentsAndViewerRoleTest');
+  return callGateway({
+    method: 'POST',
     uri: '/management/namespaces/test/pods/https:pod:443/remaining',
     requestBody: JSON.stringify({
       type: 'exec',
@@ -81,14 +105,14 @@ function requestOperationWithArgumentsAndViewerRoleTest() {
     }),
     headersOut: {},
     subrequest: doWithViewerRole,
-    return: (code, message) => {
-      console.log('code:', code, 'message:', message);
-    },
+    expectedCode: 403 // viewer not allowed to exec an operation
   });
 }
 
 function searchCamelRoutesTest() {
-  return gateway.proxyJolokiaAgent({
+  console.log('=== searchCamelRoutesTest');
+  return callGateway({
+    method: 'POST',
     uri: '/management/namespaces/test/pods/https:pod:443/remaining',
     requestBody: JSON.stringify({
       type: 'search',
@@ -96,14 +120,14 @@ function searchCamelRoutesTest() {
     }),
     headersOut: {},
     subrequest: doWithViewerRole,
-    return: (code, message) => {
-      console.log('code:', code, 'message:', message);
-    },
+    expectedCode: 200
   });
 }
 
 function searchRbacMBeanTest() {
-  return gateway.proxyJolokiaAgent({
+  console.log('=== searchRbacMBeanTest');
+  return callGateway({
+    method: 'POST',
     uri: '/management/namespaces/test/pods/https:pod:443/remaining',
     requestBody: JSON.stringify({
       type: 'search',
@@ -111,14 +135,14 @@ function searchRbacMBeanTest() {
     }),
     headersOut: {},
     subrequest: doWithViewerRole,
-    return: (code, message) => {
-      console.log('code:', code, 'message:', message);
-    },
+    expectedCode: 200
   });
 }
 
 function bulkRequestWithInterceptionTest() {
-  return gateway.proxyJolokiaAgent({
+  console.log('=== bulkRequestWithInterceptionTest');
+  return callGateway({
+    method: 'POST',
     uri: '/management/namespaces/test/pods/https:pod:443/remaining',
     requestBody: JSON.stringify([
       {
@@ -137,14 +161,14 @@ function bulkRequestWithInterceptionTest() {
     ]),
     headersOut: {},
     subrequest: doWithViewerRole,
-    return: (code, message) => {
-      console.log('code:', code, 'message:', message);
-    },
+    expectedCode: 200
   });
 }
 
 function canInvokeSingleOperationTest() {
-  return gateway.proxyJolokiaAgent({
+  console.log('=== canInvokeSingleOperationTest');
+  return callGateway({
+    method: 'POST',
     uri: '/management/namespaces/test/pods/https:pod:443/remaining',
     requestBody: JSON.stringify({
       'type': 'exec',
@@ -157,14 +181,14 @@ function canInvokeSingleOperationTest() {
     }),
     headersOut: {},
     subrequest: doWithViewerRole,
-    return: (code, message) => {
-      console.log('code:', code, 'message:', message);
-    },
+    expectedCode: 200
   });
 }
 
 function canInvokeSingleAttributeTest() {
-  return gateway.proxyJolokiaAgent({
+  console.log('=== canInvokeSingleAttributeTest');
+  return callGateway({
+    method: 'POST',
     uri: '/management/namespaces/test/pods/https:pod:443/remaining',
     requestBody: JSON.stringify({
       'type': 'exec',
@@ -177,14 +201,14 @@ function canInvokeSingleAttributeTest() {
     }),
     headersOut: {},
     subrequest: doWithViewerRole,
-    return: (code, message) => {
-      console.log('code:', code, 'message:', message);
-    },
+    expectedCode: 200
   });
 }
 
 function canInvokeMapTest() {
-  return gateway.proxyJolokiaAgent({
+  console.log('=== canInvokeMapTest');
+  return callGateway({
+    method: 'POST',
     uri: '/management/namespaces/test/pods/https:pod:443/remaining',
     requestBody: JSON.stringify({
       'type': 'exec',
@@ -208,9 +232,7 @@ function canInvokeMapTest() {
     }),
     headersOut: {},
     subrequest: doWithViewerRole,
-    return: (code, message) => {
-      console.log('code:', code, 'message:', message);
-    },
+    expectedCode: 200
   });
 }
 


### PR DESCRIPTION
- Executing tests on github, even if they fail the test suite has a 0 exit code so everything is green.
 
- Updates the test script to throw an error if there is a failure and the script exit's 1 instead
 
- Pass into the report function the expected result status code to compare with the actual which then determines if there is a failure.

See #152 for discussion