### PR TITLE
fix: Stops displaying no containers page while waiting for pods #210

### DIFF
--- a/packages/management-api/src/managed-pod.ts
+++ b/packages/management-api/src/managed-pod.ts
@@ -13,6 +13,7 @@ const DEFAULT_JOLOKIA_OPTIONS: BaseRequestOptions = {
 
 export type Management = {
   status: {
+    managed: boolean
     running: boolean
     error: boolean
   }
@@ -30,6 +31,7 @@ export class ManagedPod {
 
   private _management: Management = {
     status: {
+      managed: false,
       running: false,
       error: false,
     },

--- a/packages/online-shell/src/discover/Discover.css
+++ b/packages/online-shell/src/discover/Discover.css
@@ -23,6 +23,16 @@
   display: none;
 }
 
+.discover-loading {
+  width: 85%;
+  text-align: center;
+  margin-left: auto;
+  margin-right: auto;
+  margin-top: 2em;
+  background-color: transparent;
+  font-style: italic;
+}
+
 .discover-group-label {
   text-align: left;
   color: rgb(117, 117, 117);

--- a/packages/online-shell/src/discover/Discover.tsx
+++ b/packages/online-shell/src/discover/Discover.tsx
@@ -9,6 +9,10 @@ import {
   List,
   PageSection,
   PageSectionVariants,
+  Panel,
+  PanelHeader,
+  PanelMain,
+  PanelMainBody,
   Title,
 } from '@patternfly/react-core'
 import { CubesIcon } from '@patternfly/react-icons'
@@ -24,7 +28,18 @@ export const Discover: React.FunctionComponent = () => {
     useDisplayItems()
 
   if (isLoading) {
-    return <HawtioLoadingCard />
+    return (
+      <PageSection variant={PageSectionVariants.light}>
+        <Panel className='discover-loading'>
+          <PanelHeader>Waiting for Hawtio Containers ...</PanelHeader>
+          <PanelMain>
+            <PanelMainBody>
+              <HawtioLoadingCard />
+            </PanelMainBody>
+          </PanelMain>
+        </Panel>
+      </PageSection>
+    )
   }
 
   if (error) {
@@ -43,15 +58,17 @@ export const Discover: React.FunctionComponent = () => {
 
   if (discoverGroups.length + discoverPods.length === 0) {
     return (
-      <EmptyState>
-        <EmptyStateIcon icon={CubesIcon} />
-        <Title headingLevel='h1' size='lg'>
-          No Hawtio Containers
-        </Title>
-        <EmptyStateBody>
-          There are no containers running with a port configured whose name is <code>jolokia</code>.
-        </EmptyStateBody>
-      </EmptyState>
+      <PageSection variant={PageSectionVariants.light}>
+        <EmptyState>
+          <EmptyStateIcon icon={CubesIcon} />
+          <Title headingLevel='h1' size='lg'>
+            No Hawtio Containers
+          </Title>
+          <EmptyStateBody>
+            There are no containers running with a port configured whose name is <code>jolokia</code>.
+          </EmptyStateBody>
+        </EmptyState>
+      </PageSection>
     )
   }
 

--- a/packages/online-shell/src/discover/DiscoverPodItem.tsx
+++ b/packages/online-shell/src/discover/DiscoverPodItem.tsx
@@ -1,6 +1,8 @@
 import React, { ReactNode } from 'react'
 import { Label, LabelGroup, ListItem, Title } from '@patternfly/react-core'
 import { DatabaseIcon, HomeIcon, OutlinedHddIcon } from '@patternfly/react-icons'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faSpinner } from '@fortawesome/free-solid-svg-icons'
 import { ConsoleLink, ConsoleType } from '../console'
 import { Labels } from '../labels'
 import { DiscoverPod } from './globals'
@@ -32,8 +34,20 @@ export const DiscoverPodItem: React.FunctionComponent<DiscoverPodItemProps> = (p
   }
 
   const routesLabel = (): ReactNode => {
+    if (!props.pod.mPod.management.status.managed) {
+      return (
+        <Label color='grey' icon={<FontAwesomeIcon icon={faSpinner} spin />} className='pod-item-routes'>
+          {`querying routes ...`}
+        </Label>
+      )
+    }
+
     const total = props.pod.mPod.management.camel.routes_count
-    return `${total} route${total !== 1 ? 's' : ''}`
+    return (
+      <Label color='gold' icon={<CamelRouteIcon />} className='pod-item-routes'>
+        {`${total} route${total !== 1 ? 's' : ''}`}
+      </Label>
+    )
   }
 
   return (
@@ -68,9 +82,7 @@ export const DiscoverPodItem: React.FunctionComponent<DiscoverPodItemProps> = (p
           {containersLabel()}
         </Label>
 
-        <Label color='gold' icon={<CamelRouteIcon />} className='pod-item-routes'>
-          {routesLabel()}
-        </Label>
+        {routesLabel()}
       </LabelGroup>
 
       <div className='pod-item-connect-button'>


### PR DESCRIPTION
* management-service.ts
  * The management service is responsible for emitting an update on all the pods being managed or not. However, no update is emitted if there are no pods. As a result, the Discover component has to assume there are no pods while waiting for them.
  * To allow for the Discover component to wait for the update (showing 'loading'), fire an update when there are no pods
  * Also for each pod add a flag to show that it has now been 'managed'

* context.ts
  * Differentiate between initialising / mounting of the context and the first call to organising the pods and the later mgmt service listener
  * Once mounted, only when the listener receives its first update will the context signal it is loaded (that signal will be either when there are pods or not hence the mandated firing from the mgmt service)

* Discover.tsx
  * Improves the loading component to show a header to the loading card

* DiscoverPodItem.tsx
  * In the event that a new pod is spun up, it can take several seconds for an update to be received concerning the number of routes. As a result, have the routes count label display a spinner and `querying ...` label before being updated to the correct total