### PR TITLE
fix: Substitute placeholder for real version in About box #211

### DIFF
--- a/packages/kubernetes-api/src/index.ts
+++ b/packages/kubernetes-api/src/index.ts
@@ -1,17 +1,8 @@
-import { configManager } from '@hawtio/react'
 import { oAuthInit } from '@hawtio/online-oauth'
 import { k8Init } from './init'
 import { log } from './globals'
 
-let configAdded = false
-
 const registerK8Api = async (): Promise<boolean> => {
-  if (!configAdded) {
-    // Add Product Info
-    configManager.addProductInfo('Hawtio Kubernetes API', 'PACKAGE_VERSION_PLACEHOLDER')
-    configAdded = true
-  }
-
   log.debug('Awaiting registering of OAuth')
   oAuthInit()
 

--- a/packages/management-api/src/index.ts
+++ b/packages/management-api/src/index.ts
@@ -1,19 +1,10 @@
-import { configManager } from '@hawtio/react'
 import { ManagementService } from './management-service'
 import { log } from './globals'
 import { isK8ApiRegistered } from '@hawtio/online-kubernetes-api'
 
 export const mgmtService = new ManagementService()
 
-let configAdded = false
-
 const registerManagementApi = async (): Promise<boolean> => {
-  if (!configAdded) {
-    // Add Product Info
-    configManager.addProductInfo('Hawtio Management API', 'PACKAGE_VERSION_PLACEHOLDER')
-    configAdded = true
-  }
-
   await isK8ApiRegistered()
 
   log.debug('Awaiting registering of ManagementService')

--- a/packages/oauth/src/index.ts
+++ b/packages/oauth/src/index.ts
@@ -1,4 +1,4 @@
-import { hawtio, HawtioPlugin, configManager } from '@hawtio/react'
+import { hawtio, HawtioPlugin } from '@hawtio/react'
 import { log } from './globals'
 import { getActiveProfile } from './api'
 import { oAuthService } from './oauth-service'
@@ -26,9 +26,6 @@ export function oAuthInitialised(): boolean {
 }
 
 export const oAuthInit: HawtioPlugin = async () => {
-  // Add Product Info
-  configManager.addProductInfo('Hawtio OAuth', 'PACKAGE_VERSION_PLACEHOLDER')
-
   if (hawtio.getPlugins().filter(plugin => plugin.id === FORM_AUTH_PROTOCOL_MODULE).length === 0) {
     hawtio.addPlugin({
       id: FORM_AUTH_PROTOCOL_MODULE,

--- a/packages/online-shell/package.json
+++ b/packages/online-shell/package.json
@@ -20,7 +20,9 @@
   ],
   "scripts": {
     "start": "webpack serve --hot --mode development --progress --config webpack.config.dev.js",
-    "build": "webpack --mode production --progress --config webpack.config.prod.js --output-public-path='/online/'",
+    "build": "yarn build:webpack && yarn replace-version yarn",
+    "build:webpack": "webpack --mode production --progress --config webpack.config.prod.js --output-public-path='/online/'",
+    "replace-version": "replace __PACKAGE_VERSION_PLACEHOLDER__ $npm_package_version ./build -r",
     "test": "jest --watchAll=false --passWithNoTests src/**/*.test.ts*",
     "test:coverage": "yarn test --coverage"
   },
@@ -64,6 +66,7 @@
     "os-browserify": "^0.3.0",
     "path-browserify": "^1.0.1",
     "process": "^0.11.10",
+    "replace": "^1.2.2",
     "source-map-loader": "^4.0.1",
     "style-loader": "^3.3.3",
     "ts-loader": "^9.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2213,6 +2213,7 @@ __metadata:
     react-dom: ^18.2.0
     react-markdown: ^9.0.1
     react-router-dom: ^6.20.0
+    replace: ^1.2.2
     source-map-loader: ^4.0.1
     style-loader: ^3.3.3
     ts-loader: ^9.5.1


### PR DESCRIPTION
* kubernetes-api, management-api, oauth
  * Remove unnecessary about additions from internal packages

* online-shell
  * Adds replace-version command to package and modifies build command to include it.