### PR TITLE
fix: Move online-shell dev env to /online documentBase - #242

### DIFF
--- a/packages/online-shell/public/hawtconfig.json
+++ b/packages/online-shell/public/hawtconfig.json
@@ -4,11 +4,11 @@
     "productInfo": [],
     "additionalInfo": "The Hawtio Console eases the discovery and management of 'hawtio-enabled' applications deployed on OpenShift.",
     "copyright": "© Hawtio project",
-    "imgSrc": "/hawtio-logo.svg"
+    "imgSrc": "/online/hawtio-logo.svg"
   },
   "branding": {
     "appName": "Hawtio Console",
-    "appLogoUrl": "/hawtio-logo.svg",
+    "appLogoUrl": "/online/hawtio-logo.svg",
     "css": "branding.css",
     "favicon": "favicon.ico"
   },

--- a/packages/online-shell/webpack.config.common.js
+++ b/packages/online-shell/webpack.config.common.js
@@ -9,7 +9,7 @@ const { dependencies } = require('./package.json')
 const common = mode => {
   console.log(`Compilation Mode: ${mode}`)
 
-  const publicPath = mode === 'production' ? '/online' : ''
+  const publicPath = '/online'
 
   return {
     mode: mode,

--- a/packages/online-shell/webpack.config.dev.js
+++ b/packages/online-shell/webpack.config.dev.js
@@ -40,6 +40,7 @@ module.exports = () => {
   const kube = new URL(kubeBase)
   const devPort = process.env.PORT || 2772
   const proxiedMaster = `http://localhost:${devPort}/master`
+  const publicPath = '/online'
 
   return merge(common('development'), {
     devtool: 'eval-source-map',
@@ -54,6 +55,11 @@ module.exports = () => {
         ignoreStub: true,
       }),
     ],
+
+    output: {
+      // Set base path to /
+      publicPath: publicPath,
+    },
 
     devServer: {
       compress: true,
@@ -78,6 +84,7 @@ module.exports = () => {
 
       static: {
         directory: path.join(__dirname, 'public'),
+        publicPath: publicPath,
       },
 
       setupMiddlewares: (middlewares, devServer) => {
@@ -174,7 +181,10 @@ module.exports = () => {
           pkceMethod: 'S256',
         }
 
-        devServer.app.get('/osconsole/config.json', osconsole)
+        // This path has been coded as relative to documentBase
+        // Therefore need to add publicPath to the front of it
+        devServer.app.get(`${publicPath}/osconsole/config.json`, osconsole)
+
         devServer.app.get('/management/*', management)
         devServer.app.post('/management/*', management)
 
@@ -216,6 +226,7 @@ module.exports = () => {
         //
         const history = historyApiFallback()
         devServer.app.get('/', history)
+        devServer.app.get('/discover', history)
         devServer.app.get('/login', history)
 
         return middlewares


### PR DESCRIPTION
* Aligns the online-shell dev server with the production build by making the documentBase of the app /online.

* Avoids the problem, reported in #242, of an invalid double-slash url since the documentBase is identified as /online.

* hawtconfig.json
  * Corrects urls for hawtio-logo not showing up correctly in dev with documentBase but still showing up correctly in production

* webpack.config.common.js
  * Does not effect production but make publicPath always /online regardless of mode

* webpack.config.dev.js
  * Modifies output and static to include the publicPath
  * Updates the osconsole url which is the only path relative in the code base so needs the publicPath prepended