### PR TITLE
fix: use official node 18 image #260

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,6 @@
-FROM quay.io/jitesoft/node:16 as builder
+FROM docker.io/node:18 as builder
 
 WORKDIR /hawtio-online
-
-RUN npm install -g yarn
 
 COPY package.json yarn.lock ./
 COPY .yarnrc.yml ./


### PR DESCRIPTION
* Node image already contains yarn so no need to install it