### PR TITLE
Stops display of the token if not JWT and if Openshift cluster fetches the username from the master API

### DIFF
--- a/docker/nginx.sh
+++ b/docker/nginx.sh
@@ -5,15 +5,13 @@ set -eu
 
 NGINX_HTML="/usr/share/nginx/html"
 HAWTIO_HTML="${NGINX_HTML}/online"
-mkdir -p "${HAWTIO_HTML}/osconsole"
-./config.sh > "${HAWTIO_HTML}/osconsole/config.json"
 
 # nginx.conf parameter default values
 export NGINX_SUBREQUEST_OUTPUT_BUFFER_SIZE=${NGINX_SUBREQUEST_OUTPUT_BUFFER_SIZE:-10m}
 export NGINX_CLIENT_BODY_BUFFER_SIZE=${NGINX_CLIENT_BODY_BUFFER_SIZE:-256k}
 export NGINX_PROXY_BUFFERS=${NGINX_PROXY_BUFFERS:-16 128k}
 
-OPENSHIFT=true
+export OPENSHIFT=true
 
 check_openshift_api() {
   APISERVER="https://${CLUSTER_MASTER:-kubernetes.default.svc}"
@@ -29,6 +27,13 @@ check_openshift_api() {
 }
 
 check_openshift_api
+
+#
+# Create osconsole/config.json after openshift api check
+# so that the OPENSHIFT flag can be provided to it
+#
+mkdir -p "${HAWTIO_HTML}/osconsole"
+./config.sh > "${HAWTIO_HTML}/osconsole/config.json"
 
 generate_nginx_gateway_conf() {
   TEMPLATE=/nginx-gateway.conf.template

--- a/docker/osconsole/config.sh
+++ b/docker/osconsole/config.sh
@@ -6,6 +6,7 @@ openshift_config_cluster() {
   cat << EOF
 {
   "master_uri": "/master",
+  "master_kind": "${MASTER_KIND}",
   "hawtio": {
     "mode": "${HAWTIO_ONLINE_MODE}"
   },
@@ -24,6 +25,7 @@ openshift_config_namespace() {
   cat << EOF
 {
   "master_uri": "/master",
+  "master_kind": "${MASTER_KIND}",
   "hawtio": {
     "mode": "${HAWTIO_ONLINE_MODE}",
     "namespace": "${HAWTIO_ONLINE_NAMESPACE}"
@@ -43,6 +45,7 @@ form_config_cluster() {
   cat << EOF
 {
   "master_uri": "/master",
+  "master_kind": "${MASTER_KIND}",
   "hawtio": {
     "mode": "${HAWTIO_ONLINE_MODE}"
   },
@@ -57,6 +60,7 @@ form_config_namespace() {
   cat << EOF
 {
   "master_uri": "/master",
+  "master_kind": "${MASTER_KIND}",
   "hawtio": {
     "mode": "${HAWTIO_ONLINE_MODE}",
     "namespace": "${HAWTIO_ONLINE_NAMESPACE}"
@@ -98,6 +102,12 @@ invalid() {
   >&2 echo It should either be \'cluster\' or \'namespace\', but is "${HAWTIO_ONLINE_MODE:-not set}".
   exit 1
 }
+
+if [ "${OPENSHIFT}" == "true" ]; then
+  MASTER_KIND=openshift
+else
+  MASTER_KIND=kubernetes
+fi
 
 case "${HAWTIO_ONLINE_MODE}" in
   "cluster") cluster;;

--- a/packages/kubernetes-api-app/.env.defaults
+++ b/packages/kubernetes-api-app/.env.defaults
@@ -1,6 +1,13 @@
 # The port to run the dev server
 PORT=2772
 
+#
+# The kind of master
+# [kubernetes|openshift]
+# Note. Determined automatically in production server
+#
+MASTER_KIND=kubernetes
+
 # The type of authentication to use
 # [oauth | form]
 CLUSTER_AUTH_TYPE=form

--- a/packages/kubernetes-api-app/.env.example
+++ b/packages/kubernetes-api-app/.env.example
@@ -1,6 +1,13 @@
 # The port to run the dev server
 PORT=2772
 
+#
+# The kind of master
+# [kubernetes|openshift]
+# Note. Determined automatically in production server
+#
+MASTER_KIND=kubernetes
+
 # The type of authentication to use
 # [oauth | form]
 CLUSTER_AUTH_TYPE=form

--- a/packages/kubernetes-api-app/webpack.config.js
+++ b/packages/kubernetes-api-app/webpack.config.js
@@ -14,6 +14,7 @@ const { dependencies } = require('./package.json')
 dotenv.config({ path: path.join(__dirname, '.env') })
 
 module.exports = () => {
+  const masterKind = process.env.MASTER_KIND || 'kubernetes'
   const clusterAuthType = process.env.CLUSTER_AUTH_TYPE || 'oauth'
 
   const master_uri = process.env.CLUSTER_MASTER
@@ -34,6 +35,7 @@ module.exports = () => {
   if (clusterAuthFormUri) console.log('Using Cluster Auth Form URL:', clusterAuthFormUri)
 
   console.log('Using Cluster URL:', master_uri)
+  console.log('Using Master Kind:', masterKind)
   console.log('Using Cluster Namespace:', namespace)
   console.log('Using Hawtio Cluster Mode:', mode)
   console.log('USing OAuth Client Id:', clientId)
@@ -234,6 +236,7 @@ module.exports = () => {
         const osconsole = (_, res) => {
           const oscConfig = {
             master_uri: proxiedMaster,
+            master_kind: masterKind,
             hawtio: {
               mode: mode,
             },

--- a/packages/management-api-app/.env.defaults
+++ b/packages/management-api-app/.env.defaults
@@ -1,6 +1,13 @@
 # The port to run the dev server
 PORT=2772
 
+#
+# The kind of master
+# [kubernetes|openshift]
+# Note. Determined automatically in production server
+#
+MASTER_KIND=kubernetes
+
 # The type of authentication to use
 # [oauth | form]
 CLUSTER_AUTH_TYPE=form

--- a/packages/management-api-app/.env.example
+++ b/packages/management-api-app/.env.example
@@ -1,6 +1,13 @@
 # The port to run the dev server
 PORT=2772
 
+#
+# The kind of master
+# [kubernetes|openshift]
+# Note. Determined automatically in production server
+#
+MASTER_KIND=kubernetes
+
 # The type of authentication to use
 # [oauth | form]
 CLUSTER_AUTH_TYPE=form

--- a/packages/management-api-app/webpack.config.js
+++ b/packages/management-api-app/webpack.config.js
@@ -14,6 +14,7 @@ const { dependencies } = require('./package.json')
 dotenv.config({ path: path.join(__dirname, '.env') })
 
 module.exports = () => {
+  const masterKind = process.env.MASTER_KIND || 'kubernetes'
   const clusterAuthType = process.env.CLUSTER_AUTH_TYPE || 'oauth'
 
   const master_uri = process.env.CLUSTER_MASTER
@@ -34,6 +35,7 @@ module.exports = () => {
   if (clusterAuthFormUri) console.log('Using Cluster Auth Form URL:', clusterAuthFormUri)
 
   console.log('Using Cluster URL:', master_uri)
+  console.log('Using Master Kind:', masterKind)
   console.log('Using Cluster Namespace:', namespace)
   console.log('Using Hawtio Cluster Mode:', mode)
   console.log('USing OAuth Client Id:', clientId)
@@ -239,6 +241,7 @@ module.exports = () => {
         const osconsole = (_, res) => {
           const oscConfig = {
             master_uri: proxiedMaster,
+            master_kind: masterKind,
             hawtio: {
               mode: mode,
             },

--- a/packages/oauth-app/.env.defaults
+++ b/packages/oauth-app/.env.defaults
@@ -1,6 +1,13 @@
 # The port to run the dev server
 PORT=2772
 
+#
+# The kind of master
+# [kubernetes|openshift]
+# Note. Determined automatically in production server
+#
+MASTER_KIND=kubernetes
+
 # The type of authentication to use
 # [oauth | form]
 CLUSTER_AUTH_TYPE=form

--- a/packages/oauth-app/.env.example
+++ b/packages/oauth-app/.env.example
@@ -1,6 +1,13 @@
 # The port to run the dev server
 PORT=2772
 
+#
+# The kind of master
+# [kubernetes|openshift]
+# Note. Determined automatically in production server
+#
+MASTER_KIND=kubernetes
+
 # The type of authentication to use
 # [oauth | form]
 CLUSTER_AUTH_TYPE=form

--- a/packages/oauth-app/webpack.config.js
+++ b/packages/oauth-app/webpack.config.js
@@ -15,6 +15,7 @@ const { dependencies } = require('./package.json')
 dotenv.config({ path: path.join(__dirname, '.env') })
 
 module.exports = () => {
+  const masterKind = process.env.MASTER_KIND || 'kubernetes'
   const clusterAuthType = process.env.CLUSTER_AUTH_TYPE || 'oauth'
 
   const master_uri = process.env.CLUSTER_MASTER
@@ -35,6 +36,7 @@ module.exports = () => {
   if (clusterAuthFormUri) console.log('Using Cluster Auth Form URL:', clusterAuthFormUri)
 
   console.log('Using Cluster URL:', master_uri)
+  console.log('Using Master Kind:', masterKind)
   console.log('Using Cluster Namespace:', namespace)
   console.log('Using Hawtio Cluster Mode:', mode)
   console.log('USing OAuth Client Id:', clientId)
@@ -235,6 +237,7 @@ module.exports = () => {
         const osconsole = (_, res) => {
           const oscConfig = {
             master_uri: proxiedMaster,
+            master_kind: masterKind,
             hawtio: {
               mode: mode,
             },

--- a/packages/oauth/src/globals.ts
+++ b/packages/oauth/src/globals.ts
@@ -7,8 +7,13 @@ export const log = Logger.get(moduleName)
 export const PATH_OSCONSOLE_CLIENT_CONFIG = 'osconsole/config.json'
 export const LOGOUT_ENDPOINT = '/auth/logout'
 
+// Kinds identified for the master cluster
+export const OPENSHIFT_MASTER_KIND = 'OPENSHIFT'
+export const KUBERNETES_MASTER_KIND = 'KUBERNETES'
+
 export interface OAuthConfig {
   master_uri?: string
+  master_kind: string
   hawtio?: Hawtio
   form?: FormConfig
   openshift?: OpenShiftOAuthConfig
@@ -29,6 +34,7 @@ export class UserProfile {
   // Type of oauth is the profile, eg. openshift, form
   private oAuthType = 'unknown'
   private masterUri?: string
+  private masterKind?: string
   private token?: string
   private error: Error | null = null
   private metadata: Record<string, unknown> = {}
@@ -63,6 +69,19 @@ export class UserProfile {
 
   setMasterUri(masterUri: string) {
     this.masterUri = masterUri
+  }
+
+  getMasterKind(): string {
+    return this.masterKind ? this.masterKind : ''
+  }
+
+  setMasterKind(masterKind: string) {
+    const ucType = masterKind.toUpperCase()
+    if (ucType === KUBERNETES_MASTER_KIND || ucType === OPENSHIFT_MASTER_KIND) this.masterKind = ucType
+    else {
+      log.warn(`Unknown value set for master_kind in config (${masterKind}). Defaulting master kind to kubernetes`)
+      this.masterKind = KUBERNETES_MASTER_KIND
+    }
   }
 
   hasError() {

--- a/packages/oauth/src/oauth-service.ts
+++ b/packages/oauth/src/oauth-service.ts
@@ -1,4 +1,4 @@
-import { log, OAuthProtoService, UserProfile } from './globals'
+import { KUBERNETES_MASTER_KIND, log, OAuthProtoService, UserProfile } from './globals'
 import { fetchPath } from './utils'
 import { DEFAULT_HAWTIO_MODE, DEFAULT_HAWTIO_NAMESPACE, HAWTIO_MODE_KEY, HAWTIO_NAMESPACE_KEY } from './metadata'
 import { OAuthConfig, PATH_OSCONSOLE_CLIENT_CONFIG } from './globals'
@@ -41,6 +41,7 @@ class OAuthService {
 
     log.debug('Adding master uri to profile')
     this.userProfile.setMasterUri(relToAbsUrl(config.master_uri || '/master'))
+    this.userProfile.setMasterKind(config.master_kind || KUBERNETES_MASTER_KIND)
 
     log.debug('Adding hawtio-mode to profile metadata')
     const hawtioMode = config.hawtio?.mode || DEFAULT_HAWTIO_MODE

--- a/packages/online-shell/.env.defaults
+++ b/packages/online-shell/.env.defaults
@@ -1,6 +1,13 @@
 # The port to run the dev server
 PORT=2772
 
+#
+# The kind of master
+# [kubernetes|openshift]
+# Note. Determined automatically in production server
+#
+MASTER_KIND=kubernetes
+
 # The scope of access across the cluster [namespace|cluster]
 HAWTIO_MODE=namespace
 

--- a/packages/online-shell/.env.example
+++ b/packages/online-shell/.env.example
@@ -1,6 +1,13 @@
 # The port to run the dev server
 PORT=2772
 
+#
+# The kind of master
+# [kubernetes|openshift]
+# Note. Determined automatically in production server
+#
+MASTER_KIND=kubernetes
+
 # The scope of access across the cluster [namespace|cluster]
 HAWTIO_MODE=namespace
 

--- a/packages/online-shell/webpack.config.dev.js
+++ b/packages/online-shell/webpack.config.dev.js
@@ -18,6 +18,7 @@ const { common } = require('./webpack.config.common.js')
 dotenv.config({ path: path.join(__dirname, '.env') })
 
 module.exports = () => {
+  const masterKind = process.env.MASTER_KIND || 'kubernetes'
   const clusterAuthType = process.env.CLUSTER_AUTH_TYPE || 'oauth'
 
   const master_uri = process.env.CLUSTER_MASTER
@@ -47,6 +48,7 @@ module.exports = () => {
   if (clusterAuthFormUri) console.log('Using Cluster Auth Form URL:', clusterAuthFormUri)
 
   console.log('Using Cluster URL:', master_uri)
+  console.log('Using Master Kind:', masterKind)
   console.log('Using Cluster Namespace:', namespace)
   console.log('Using Hawtio Cluster Mode:', mode)
   console.log('USing OAuth Client Id:', clientId)
@@ -131,6 +133,7 @@ module.exports = () => {
         const osconsole = (_, res) => {
           const oscConfig = {
             master_uri: proxiedMaster,
+            master_kind: masterKind,
             hawtio: {
               mode: mode,
             },


### PR DESCRIPTION
Asks the Openshift cluster for the username associated with the given token.

If using form-login and connecting to Openshift, it is possible to obtain the username associated with the login token using the OS REST API.

Adds a small function to the `form-service.ts` that fetches the username upon successful login.

![Screenshot_20231220_190358](https://github.com/hawtio/hawtio-online/assets/1634180/ce352b7d-4ebf-4f5e-b27c-67b3661dd7b1)
