### PR TITLE
HAWNG-395: Handle warnings and false-positives

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,25 @@
+# Title for the gitleaks configuration file.
+title = "Gitleaks Configuration"
+
+# Extend the base (this) configuration. When you extend a configuration
+# the base rules take precedence over the extended rules. I.e., if there are
+# duplicate rules in both the base configuration and the extended configuration
+# the base rules will override the extended rules.
+# Another thing to know with extending configurations is you can chain together
+# multiple configuration files to a depth of 2. Allowlist arrays are appended
+# and can contain duplicates.
+# useDefault and path can NOT be used at the same time. Choose one.
+[extend]
+# useDefault will extend the base configuration with the default gitleaks config:
+# https://github.com/zricethezav/gitleaks/blob/master/config/gitleaks.toml
+useDefault = true
+
+# This is a global allowlist which has a higher order of precedence than rule-specific allowlists.
+# If a commit listed in the `commits` field below is encountered then that commit will be skipped and no
+# secrets will be detected for said commit. The same logic applies for regexes and paths.
+[allowlist]
+description = "Ignore False-Positives"
+paths = [
+	'''.yarn/.*''',
+	'''packages/oauth/src/form/jwt-decode.test.ts'''
+]

--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,5 @@
+exclude:
+    global:
+        # Exclude all development webpack build config files
+            - "webpack.config.dev.js"
+						- "webpack.config.js"

--- a/deploy/script/generate-proxying.sh
+++ b/deploy/script/generate-proxying.sh
@@ -32,7 +32,8 @@ EOT
 }
 
 kube_binary() {
-  local k=$(command -v ${1} 2> /dev/null)
+  local k
+  k=$(command -v ${1} 2> /dev/null)
   if [ $? != 0 ]; then
     return
   fi

--- a/deploy/script/generate-serving.sh
+++ b/deploy/script/generate-serving.sh
@@ -18,7 +18,8 @@ EOT
 }
 
 kube_binary() {
-  local k=$(command -v ${1} 2> /dev/null)
+  local k
+  k=$(command -v ${1} 2> /dev/null)
   if [ $? != 0 ]; then
     return
   fi

--- a/docker/nginx.sh
+++ b/docker/nginx.sh
@@ -1,8 +1,5 @@
 #!/bin/sh
 
-# Fail on a single failed command in a pipeline (if supported)
-(set -o | grep -q pipefail) && set -o pipefail
-
 # Fail on error and undefined vars
 set -eu
 
@@ -45,7 +42,7 @@ generate_nginx_gateway_conf() {
     ' < $TEMPLATE > /etc/nginx/conf.d/nginx.conf
 }
 
-if [ -v HAWTIO_ONLINE_RBAC_ACL ]; then
+if [ -n "${HAWTIO_ONLINE_RBAC_ACL+x}" ]; then
   echo Using RBAC NGINX configuration
   generate_nginx_gateway_conf
 elif [ "${HAWTIO_ONLINE_GATEWAY:-}" = "true" ]; then

--- a/packages/oauth-app/webpack.config.js
+++ b/packages/oauth-app/webpack.config.js
@@ -291,6 +291,9 @@ module.exports = () => {
 
             // Adds the Clear-Site-Data header
             res.header('Clear-Site-Data', '"*"')
+
+            // False-positive for coverity SAST scan
+            // Ignored since this is just the dev server
             res.redirect(r)
           }
         })

--- a/packages/oauth/src/form/jwt-decode.test.ts
+++ b/packages/oauth/src/form/jwt-decode.test.ts
@@ -2,12 +2,16 @@ import { jwtDecode } from './jwt-decode'
 
 describe('decode', () => {
   test('not JWT token', () => {
+    // False-positive for coverity SAST scan
+    // Ignored in .gitleaks.toml as this is just a unit-test
     const token = 'c3ViamVjdDpvYmplY3Q6dGVzdA=='
     expect(() => jwtDecode(token)).toThrowError()
   })
 
   test('JWT token', () => {
     const expected = { iat: 1516239022, name: 'John Doe', sub: '1234567890' }
+    // False-positive for coverity SAST scan
+    // Ignored in .gitleaks.toml as this is just a unit-test
     const token =
       'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c'
     const decoded = jwtDecode(token)


### PR DESCRIPTION
* .gitleaks.toml
 * Provides an extension config which lists the false-positives that should be ignored

* generate-.*\.sh
 * Fixes shellcheck warnings is assignments

* nginx.sh
 * Removes pipefail setting as non-POSIX and since pipes not actually used in script then removed entirely
 * Replaces bash (-v) which POSIX compatible equivalent

* ws-handler.ts
 * Checks the origin of the MessageEvent. Since the messages are expected from the cluster they should only comes from ${APP_HOST}/master so any other origin is not appropriate so should be ignored

* .snyk
 * Exclude non-production files from snyk analysis