### PR TITLE
fix: Solves the problem of devServer failing to prefix urls correctly…

### DIFF
--- a/packages/kubernetes-api-app/.env.defaults
+++ b/packages/kubernetes-api-app/.env.defaults
@@ -6,7 +6,6 @@ PORT=2772
 CLUSTER_AUTH_TYPE=form
 
 # The URL for the form to use for form-type authentication
-# If not present then oauth authentication is assumed
 CLUSTER_AUTH_FORM=/login
 
 # The url of the cluster master

--- a/packages/kubernetes-api-app/.env.example
+++ b/packages/kubernetes-api-app/.env.example
@@ -6,7 +6,6 @@ PORT=2772
 CLUSTER_AUTH_TYPE=form
 
 # The URL for the form to use for form-type authentication
-# If not present then oauth authentication is assumed
 CLUSTER_AUTH_FORM=/login
 
 # The url of the cluster master

--- a/packages/kubernetes-api-app/public/index.html
+++ b/packages/kubernetes-api-app/public/index.html
@@ -2,8 +2,8 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <base href="%PUBLIC_URL%/" />
-    <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
+    <base href="<%= htmlWebpackPlugin.options.publicPath %>/" />
+    <link rel="icon" href="<%= htmlWebpackPlugin.options.publicPath %>/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
     <meta name="description" content="Hawtio Kubernetes API" />
@@ -15,7 +15,7 @@
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
-    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+    <link rel="manifest" href="<%= htmlWebpackPlugin.options.publicPath %>/manifest.json" />
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.

--- a/packages/kubernetes-api-app/webpack.config.js
+++ b/packages/kubernetes-api-app/webpack.config.js
@@ -43,6 +43,12 @@ module.exports = () => {
   const devPort = process.env.PORT || 2772
   const proxiedMaster = `http://localhost:${devPort}/master`
 
+  //
+  // No support for the dev server providing a default router prefix
+  // so need to specify here
+  //
+  const publicPath = '/online'
+
   return {
     mode: 'development',
     devtool: 'eval-source-map',
@@ -124,6 +130,7 @@ module.exports = () => {
       new HtmlWebpackPlugin({
         inject: true,
         template: path.resolve(__dirname, 'public', 'index.html'),
+        publicPath: publicPath,
       }),
       new InterpolateHtmlPlugin({
         NODE_ENV: 'development',
@@ -136,7 +143,9 @@ module.exports = () => {
     ],
     output: {
       path: path.resolve(__dirname, 'build'),
-      publicPath: 'auto',
+
+      // Set base path to desired publicPath
+      publicPath: publicPath,
       pathinfo: true,
       filename: 'static/js/bundle.js',
       chunkFilename: 'static/js/[name].chunk.js',
@@ -189,13 +198,30 @@ module.exports = () => {
       ],
 
       static: {
+        publicPath: publicPath,
         directory: path.join(__dirname, 'public'),
+      },
+
+      historyApiFallback: {
+        disableDotRule: true,
+        index: publicPath,
+      },
+
+      /*
+       * Vital for binding the react app to the desired url path
+       */
+      devMiddleware: {
+        publicPath: publicPath,
       },
 
       setupMiddlewares: (middlewares, devServer) => {
         if (!devServer) {
           throw new Error('webpack-dev-server is not defined')
         }
+
+        // Redirect / or /${publicPath} to /${publicPath}/
+        devServer.app.get('/', (_, res) => res.redirect(`${publicPath}/`))
+        devServer.app.get(`/${publicPath}$`, (_, res) => res.redirect(`${publicPath}/`))
 
         /*
          * Function to construct the config.json file
@@ -263,30 +289,12 @@ module.exports = () => {
           res.send(JSON.stringify(oscConfig))
         }
 
-        devServer.app.get('/osconsole/config.json', osconsole)
-        devServer.app.get('/online/osconsole/config.json', osconsole)
-        devServer.app.get('/integration/osconsole/config.json', osconsole)
-
-        const username = 'developer'
-        const login = false
         const proxyEnabled = false
         const keycloakEnabled = false
 
-        devServer.app.get('/hawtio/user', (_, res) => res.send(`"${username}"`))
-        devServer.app.post('/hawtio/auth/login', (_, res) => res.send(String(login)))
-        devServer.app.get('/hawtio/auth/logout', (_, res) => res.redirect('/hawtio/login'))
-        devServer.app.get('/hawtio/proxy/enabled', (_, res) => res.send(String(proxyEnabled)))
-        devServer.app.get('/hawtio/keycloak/enabled', (_, res) => res.send(String(keycloakEnabled)))
-        devServer.app.get('/keycloak/enabled', (_, res) => res.redirect('/hawtio/keycloak/enabled'))
-
-        //
-        // Use historyApiFallback to plug-in to the react router
-        // for accessing /login from the app. Having it here allows
-        // the paths above to remain external to the app
-        //
-        const history = historyApiFallback()
-        devServer.app.get('/', history)
-        devServer.app.get('/login', history)
+        devServer.app.get(`${publicPath}/osconsole/config.json`, osconsole)
+        devServer.app.get(`${publicPath}/keycloak/enabled`, (_, res) => res.send(String(keycloakEnabled)))
+        devServer.app.get(`${publicPath}/proxy/enabled`, (_, res) => res.send(String(proxyEnabled)))
 
         return middlewares
       },

--- a/packages/management-api-app/.env.defaults
+++ b/packages/management-api-app/.env.defaults
@@ -6,7 +6,6 @@ PORT=2772
 CLUSTER_AUTH_TYPE=form
 
 # The URL for the form to use for form-type authentication
-# If not present then oauth authentication is assumed
 CLUSTER_AUTH_FORM=/login
 
 # The url of the cluster master

--- a/packages/management-api-app/.env.example
+++ b/packages/management-api-app/.env.example
@@ -6,7 +6,6 @@ PORT=2772
 CLUSTER_AUTH_TYPE=form
 
 # The URL for the form to use for form-type authentication
-# If not present then oauth authentication is assumed
 CLUSTER_AUTH_FORM=/login
 
 # The url of the cluster master

--- a/packages/management-api-app/public/index.html
+++ b/packages/management-api-app/public/index.html
@@ -2,8 +2,8 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <base href="%PUBLIC_URL%/" />
-    <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
+    <base href="<%= htmlWebpackPlugin.options.publicPath %>/" />
+    <link rel="icon" href="<%= htmlWebpackPlugin.options.publicPath %>/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
     <meta name="description" content="Hawtio Kubernetes API" />
@@ -15,7 +15,7 @@
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
-    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+    <link rel="manifest" href="<%= htmlWebpackPlugin.options.publicPath %>/manifest.json" />
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.

--- a/packages/management-api-app/webpack.config.js
+++ b/packages/management-api-app/webpack.config.js
@@ -43,6 +43,12 @@ module.exports = () => {
   const devPort = process.env.PORT || 2772
   const proxiedMaster = `http://localhost:${devPort}/master`
 
+  //
+  // No support for the dev server providing a default router prefix
+  // so need to specify here
+  //
+  const publicPath = '/online'
+
   return {
     mode: 'development',
     devtool: 'eval-source-map',
@@ -129,6 +135,7 @@ module.exports = () => {
       new HtmlWebpackPlugin({
         inject: true,
         template: path.resolve(__dirname, 'public', 'index.html'),
+        publicPath: publicPath,
       }),
       new InterpolateHtmlPlugin({
         NODE_ENV: 'development',
@@ -141,7 +148,9 @@ module.exports = () => {
     ],
     output: {
       path: path.resolve(__dirname, 'build'),
-      publicPath: 'auto',
+
+      // Set base path to desired publicPath
+      publicPath: publicPath,
       pathinfo: true,
       filename: 'static/js/bundle.js',
       chunkFilename: 'static/js/[name].chunk.js',
@@ -194,13 +203,30 @@ module.exports = () => {
       ],
 
       static: {
+        publicPath: publicPath,
         directory: path.join(__dirname, 'public'),
+      },
+
+      historyApiFallback: {
+        disableDotRule: true,
+        index: publicPath,
+      },
+
+      /*
+       * Vital for binding the react app to the desired url path
+       */
+      devMiddleware: {
+        publicPath: publicPath,
       },
 
       setupMiddlewares: (middlewares, devServer) => {
         if (!devServer) {
           throw new Error('webpack-dev-server is not defined')
         }
+
+        // Redirect / or /${publicPath} to /${publicPath}/
+        devServer.app.get('/', (_, res) => res.redirect(`${publicPath}/`))
+        devServer.app.get(`/${publicPath}$`, (_, res) => res.redirect(`${publicPath}/`))
 
         /*
          * Function to construct the config.json file
@@ -281,30 +307,14 @@ module.exports = () => {
           }
         }
 
-        const username = 'developer'
-        const login = false
         const proxyEnabled = true
         const keycloakEnabled = false
 
-        devServer.app.get('/osconsole/config.json', osconsole)
+        devServer.app.get(`${publicPath}/osconsole/config.json`, osconsole)
+        devServer.app.get(`${publicPath}/keycloak/enabled`, (_, res) => res.send(String(keycloakEnabled)))
+        devServer.app.get(`${publicPath}/proxy/enabled`, (_, res) => res.send(String(proxyEnabled)))
         devServer.app.get('/management/*', management)
         devServer.app.post('/management/*', management)
-
-        devServer.app.get('/hawtio/user', (_, res) => res.send(`"${username}"`))
-        devServer.app.post('/hawtio/auth/login', (_, res) => res.send(String(login)))
-        devServer.app.get('/hawtio/auth/logout', (_, res) => res.redirect('/hawtio/login'))
-        devServer.app.get('/hawtio/proxy/enabled', (_, res) => res.send(String(proxyEnabled)))
-        devServer.app.get('/hawtio/keycloak/enabled', (_, res) => res.send(String(keycloakEnabled)))
-        devServer.app.get('/keycloak/enabled', (_, res) => res.redirect('/hawtio/keycloak/enabled'))
-
-        //
-        // Use historyApiFallback to plug-in to the react router
-        // for accessing /login from the app. Having it here allows
-        // the paths above to remain external to the app
-        //
-        const history = historyApiFallback()
-        devServer.app.get('/', history)
-        devServer.app.get('/login', history)
 
         return middlewares
       },

--- a/packages/oauth-app/.env.defaults
+++ b/packages/oauth-app/.env.defaults
@@ -6,7 +6,6 @@ PORT=2772
 CLUSTER_AUTH_TYPE=form
 
 # The URL for the form to use for form-type authentication
-# If not present then oauth authentication is assumed
 CLUSTER_AUTH_FORM=/login
 
 # The url of the cluster master

--- a/packages/oauth-app/.env.example
+++ b/packages/oauth-app/.env.example
@@ -6,7 +6,6 @@ PORT=2772
 CLUSTER_AUTH_TYPE=form
 
 # The URL for the form to use for form-type authentication
-# If not present then oauth authentication is assumed
 CLUSTER_AUTH_FORM=/login
 
 # The url of the cluster master

--- a/packages/oauth-app/public/index.html
+++ b/packages/oauth-app/public/index.html
@@ -2,8 +2,8 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <base href="%PUBLIC_URL%/" />
-    <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
+    <base href="<%= htmlWebpackPlugin.options.publicPath %>/" />
+    <link rel="icon" href="<%= htmlWebpackPlugin.options.publicPath %>/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
     <meta name="description" content="Hawtio OAuth API" />
@@ -15,7 +15,7 @@
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
-    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+    <link rel="manifest" href="<%= htmlWebpackPlugin.options.publicPath %>/manifest.json" />
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.

--- a/packages/oauth-app/webpack.config.js
+++ b/packages/oauth-app/webpack.config.js
@@ -44,6 +44,12 @@ module.exports = () => {
   const devPort = process.env.PORT || 2772
   const proxiedMaster = `http://localhost:${devPort}/master`
 
+  //
+  // No support for the dev server providing a default router prefix
+  // so need to specify here
+  //
+  const publicPath = '/online'
+
   return {
     mode: 'development',
     devtool: 'eval-source-map',
@@ -125,6 +131,7 @@ module.exports = () => {
       new HtmlWebpackPlugin({
         inject: true,
         template: path.resolve(__dirname, 'public', 'index.html'),
+        publicPath: publicPath,
       }),
       new InterpolateHtmlPlugin({
         NODE_ENV: 'development',
@@ -137,7 +144,9 @@ module.exports = () => {
     ],
     output: {
       path: path.resolve(__dirname, 'build'),
-      publicPath: 'auto',
+
+      // Set base path to desired publicPath
+      publicPath: publicPath,
       pathinfo: true,
       filename: 'static/js/bundle.js',
       chunkFilename: 'static/js/[name].chunk.js',
@@ -190,13 +199,30 @@ module.exports = () => {
       ],
 
       static: {
+        publicPath: publicPath,
         directory: path.join(__dirname, 'public'),
+      },
+
+      historyApiFallback: {
+        disableDotRule: true,
+        index: publicPath,
+      },
+
+      /*
+       * Vital for binding the react app to the desired url path
+       */
+      devMiddleware: {
+        publicPath: publicPath,
       },
 
       setupMiddlewares: (middlewares, devServer) => {
         if (!devServer) {
           throw new Error('webpack-dev-server is not defined')
         }
+
+        // Redirect / or /${publicPath} to /${publicPath}/
+        devServer.app.get('/', (_, res) => res.redirect(`${publicPath}/`))
+        devServer.app.get(`/${publicPath}$`, (_, res) => res.redirect(`${publicPath}/`))
 
         /*
          * Function to construct the config.json file
@@ -264,28 +290,19 @@ module.exports = () => {
           res.send(JSON.stringify(oscConfig))
         }
 
-        devServer.app.get('/osconsole/config.json', osconsole)
-        devServer.app.get('/online/osconsole/config.json', osconsole)
-        devServer.app.get('/integration/osconsole/config.json', osconsole)
-
-        const username = 'developer'
-        const login = false
         const proxyEnabled = false
         const keycloakEnabled = false
 
-        devServer.app.get('/hawtio/user', (_, res) => res.send(`"${username}"`))
-        devServer.app.post('/hawtio/auth/login', (_, res) => res.send(String(login)))
-        devServer.app.get('/hawtio/auth/logout', (_, res) => res.redirect('/hawtio/login'))
-        devServer.app.get('/hawtio/proxy/enabled', (_, res) => res.send(String(proxyEnabled)))
-        devServer.app.get('/hawtio/keycloak/enabled', (_, res) => res.send(String(keycloakEnabled)))
-        devServer.app.get('/keycloak/enabled', (_, res) => res.redirect('/hawtio/keycloak/enabled'))
+        devServer.app.get(`${publicPath}/osconsole/config.json`, osconsole)
+        devServer.app.get(`${publicPath}/keycloak/enabled`, (_, res) => res.send(String(keycloakEnabled)))
+        devServer.app.get(`${publicPath}/proxy/enabled`, (_, res) => res.send(String(proxyEnabled)))
 
         /*
          * Provide a server-side implementation of /auth/logout page to
          * allow use of the Clear-Site-Data header that will clear
          * all entries from the cache and storage relating to the app
          */
-        devServer.app.get('/auth/logout', (req, res) => {
+        devServer.app.get(`${publicPath}/auth/logout`, (req, res) => {
           let redirectUri = req.query.redirect_uri
 
           if (!redirectUri) {
@@ -302,15 +319,6 @@ module.exports = () => {
             res.redirect(r)
           }
         })
-
-        //
-        // Use historyApiFallback to plug-in to the react router
-        // for accessing /login from the app. Having it here allows
-        // the paths above to remain external to the app
-        //
-        const history = historyApiFallback()
-        devServer.app.get('/', history)
-        devServer.app.get('/login', history)
 
         return middlewares
       },

--- a/packages/online-shell/.env.defaults
+++ b/packages/online-shell/.env.defaults
@@ -9,8 +9,7 @@ HAWTIO_MODE=namespace
 CLUSTER_AUTH_TYPE=form
 
 # The URL for the form to use for form-type authentication
-# If not present then oauth authentication is assumed
-CLUSTER_AUTH_FORM=/login
+#CLUSTER_AUTH_FORM=/online/login
 
 # The url of the cluster master
 CLUSTER_MASTER=https://localhost:8443/master

--- a/packages/online-shell/.env.example
+++ b/packages/online-shell/.env.example
@@ -9,8 +9,7 @@ HAWTIO_MODE=namespace
 CLUSTER_AUTH_TYPE=form
 
 # The URL for the form to use for form-type authentication
-# If not present then oauth authentication is assumed
-CLUSTER_AUTH_FORM=/login
+#CLUSTER_AUTH_FORM=/online/login
 
 # The url of the cluster master
 CLUSTER_MASTER=https://localhost:8443/master

--- a/packages/online-shell/public/hawtconfig.json
+++ b/packages/online-shell/public/hawtconfig.json
@@ -4,13 +4,13 @@
     "productInfo": [],
     "additionalInfo": "The Hawtio Console eases the discovery and management of 'hawtio-enabled' applications deployed on OpenShift.",
     "copyright": "© Hawtio project",
-    "imgSrc": "/hawtio-logo.svg"
+    "imgSrc": "/online/hawtio-logo.svg"
   },
   "branding": {
     "appName": "Hawtio Console",
-    "appLogoUrl": "/hawtio-logo.svg",
+    "appLogoUrl": "/online/hawtio-logo.svg",
     "css": "branding.css",
-    "favicon": "favicon.ico"
+    "favicon": "/online/favicon.ico"
   },
   "login": {
     "title": "Log in with your token"

--- a/packages/online-shell/webpack.config.common.js
+++ b/packages/online-shell/webpack.config.common.js
@@ -6,10 +6,9 @@ const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin')
 const path = require('path')
 const { dependencies } = require('./package.json')
 
-const common = mode => {
+const common = (mode, publicPath) => {
   console.log(`Compilation Mode: ${mode}`)
-
-  const publicPath = mode === 'production' ? '/online' : ''
+  console.log(`Public Path: ${publicPath}`)
 
   return {
     mode: mode,
@@ -99,9 +98,8 @@ const common = mode => {
     output: {
       path: path.resolve(__dirname, 'build'),
 
-      // Set base path to /
-      publicPath: '/',
-
+      // Set base path to desired publicPath
+      publicPath: publicPath,
       pathinfo: true,
       filename: 'static/js/bundle.js',
       chunkFilename: 'static/js/[name].chunk.js',

--- a/packages/online-shell/webpack.config.prod.js
+++ b/packages/online-shell/webpack.config.prod.js
@@ -5,7 +5,12 @@ const path = require('path')
 const { common } = require('./webpack.config.common.js')
 
 module.exports = () => {
-  return merge(common('production'), {
+  //
+  // Prefix path will be determined by the installed web server platform
+  //
+  const publicPath = '/'
+
+  return merge(common('production', publicPath), {
     devtool: 'source-map',
 
     plugins: [


### PR DESCRIPTION
… (#344)

* Originally devServer prefix was reverted due to different urls in the app not working correctly.

* However, reverting exposed a problem with connecting to jolokia urls (Hawtio-Next #793) so need to reinstate it and fix.

* The publicPath config property must be set in the following locations and must be consistent:
  * webpack.config....js * HtmlWebpackPlugin * output * static * historyApiFallback * devMiddleware (really important!) * any devServer.app.get(..) calls in setupMiddlewares

* .../public/index.html
 * Must reference the publicPath property correctly

* Removes all keycloak urls to stop the keycloak plugin taking over the authentication duties
* Synchronizes all the test apps to the same configuration as the online-shell