### PR TITLE
chore: Remove react-markdown from kubernetes-api

### DIFF
--- a/packages/kubernetes-api/jest.config.ts
+++ b/packages/kubernetes-api/jest.config.ts
@@ -15,7 +15,7 @@ export default {
     '\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga|md)$':
       '<rootDir>/src/__mocks__/fileMock.js',
     '\\.(css|less)$': '<rootDir>/src/__mocks__/styleMock.js',
-    'react-markdown': '<rootDir>/../../node_modules/react-markdown/react-markdown.min.js',
+    'react-markdown': '<rootDir>/../../node_modules/@hawtio/react/node_modules/react-markdown/react-markdown.min.js',
     '@patternfly/react-code-editor': path.resolve(__dirname, './src/__mocks__/codeEditorMock.js'),
   },
 

--- a/packages/kubernetes-api/package.json
+++ b/packages/kubernetes-api/package.json
@@ -51,7 +51,6 @@
     "jest-extended": "^4.0.0",
     "jest-fetch-mock": "^3.0.3",
     "jest-watch-typeahead": "^2.2.2",
-    "react-markdown": "^8.0.7",
     "replace": "^1.2.2",
     "ts-jest": "^29.1.2",
     "tsup": "^8.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2010,7 +2010,6 @@ __metadata:
     js-logger: "npm:^1.6.1"
     jsonpath: "npm:^1.1.1"
     kubernetes-types: "npm:^1.26.0"
-    react-markdown: "npm:^8.0.7"
     replace: "npm:^1.2.2"
     ts-jest: "npm:^29.1.2"
     ts-node: "npm:^10.9.2"


### PR DESCRIPTION
* Only included to satisfy jest configuration when importing @hawtio/react. By updating the path in jest configuration we can avoid the need to include entirely.