### PR TITLE
HAWNG-557: Stop login page appearing briefly before redirection

### DIFF
--- a/packages/oauth/src/api.ts
+++ b/packages/oauth/src/api.ts
@@ -18,6 +18,7 @@ export interface Hawtio {
 }
 
 export interface OAuthProtoService {
+  isRedirecting(): Promise<boolean>
   isLoggedIn(): Promise<boolean>
   registerUserHooks(): void
 }

--- a/packages/oauth/src/form/form-service.ts
+++ b/packages/oauth/src/form/form-service.ts
@@ -31,6 +31,7 @@ export class FormService implements OAuthProtoService {
   private readonly login: Promise<boolean>
   private formConfig: FormConfig | null
   private fetchUnregister: (() => void) | null
+  private redirecting = false
 
   constructor(formConfig: FormConfig | null, userProfile: UserProfile) {
     log.debug('Initialising Form Auth Service')
@@ -112,6 +113,7 @@ export class FormService implements OAuthProtoService {
       return
     }
 
+    this.redirecting = true
     redirect(targetUri)
   }
 
@@ -179,6 +181,11 @@ export class FormService implements OAuthProtoService {
     // Redirect to /auth/logout endpoint if possible
     const targetUri = this.buildLoginUrl({ uri: currentURI })
     logoutRedirect(targetUri)
+  }
+
+  async isRedirecting(): Promise<boolean> {
+    await this.login
+    return this.redirecting
   }
 
   async isLoggedIn(): Promise<boolean> {

--- a/packages/oauth/src/index.ts
+++ b/packages/oauth/src/index.ts
@@ -12,6 +12,9 @@ const oAuthRegister = async (): Promise<void> => {
 
   log.info('Initialising the active profile')
   try {
+    const redirecting = await oAuthRedirecting()
+    if (redirecting) return
+
     oAuthService.registerUserHooks()
     await getActiveProfile()
     log.info('All OAuth plugins have been executed.')
@@ -23,6 +26,10 @@ const oAuthRegister = async (): Promise<void> => {
 
 export function oAuthInitialised(): boolean {
   return initialised
+}
+
+export function oAuthRedirecting(): Promise<boolean> {
+  return oAuthService.isRedirecting()
 }
 
 export const oAuthInit: HawtioPlugin = async () => {

--- a/packages/oauth/src/oauth-service.ts
+++ b/packages/oauth/src/oauth-service.ts
@@ -94,6 +94,20 @@ class OAuthService {
     return protoServiceActive && this.userProfile.isActive()
   }
 
+  async isRedirecting(): Promise<boolean> {
+    const protoService = await this.protoService
+    if (!protoService) {
+      return false
+    }
+
+    if (this.userProfile.hasError()) {
+      log.debug('Cannot login as user profile has error: ', this.userProfile.getError())
+      return false
+    }
+
+    return await protoService.isRedirecting()
+  }
+
   getUserProfile(): UserProfile {
     return this.userProfile
   }

--- a/packages/oauth/src/openshift/osoauth-service.ts
+++ b/packages/oauth/src/openshift/osoauth-service.ts
@@ -44,6 +44,7 @@ export class OSOAuthService implements OAuthProtoService {
   private userInfoUri = ''
   private keepaliveInterval = 10
   private keepAliveHandler: NodeJS.Timeout | null = null
+  private redirecting = false
 
   private userProfile: UserProfile
   private readonly adaptedConfig: Promise<OpenShiftOAuthConfig | null>
@@ -280,6 +281,7 @@ export class OSOAuthService implements OAuthProtoService {
   }
 
   private tryLogin(config: OpenShiftOAuthConfig, uri: URL) {
+    this.redirecting = true
     const targetUri = buildLoginUrl(config, { uri: uri.toString() })
     redirect(targetUri)
   }
@@ -295,6 +297,11 @@ export class OSOAuthService implements OAuthProtoService {
     // So little point in trying to delete the token. Lets do in client-side only
     //
     forceRelogin(currentURI, config)
+  }
+
+  async isRedirecting(): Promise<boolean> {
+    await this.login
+    return this.redirecting
   }
 
   async isLoggedIn(): Promise<boolean> {

--- a/packages/online-shell/src/bootstrap.tsx
+++ b/packages/online-shell/src/bootstrap.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import { camel, configManager, hawtio, Hawtio, jmx, logs, quartz, rbac, runtime, springboot } from '@hawtio/react'
 import { isMgmtApiRegistered } from '@hawtio/online-management-api'
+import { oAuthRedirecting } from '@hawtio/online-oauth'
 import { reportWebVitals } from './reportWebVitals'
 import { discover } from './discover'
 
@@ -22,17 +23,21 @@ isMgmtApiRegistered().then(() => {
   discover()
 
   // Bootstrap Hawtio
-  hawtio.bootstrap()
+  hawtio.bootstrap().then(() => {
+    oAuthRedirecting().then((redirecting: boolean) => {
+      if (redirecting) return
 
-  const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement)
-  root.render(
-    <React.StrictMode>
-      <Hawtio />
-    </React.StrictMode>,
-  )
+      const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement)
+      root.render(
+        <React.StrictMode>
+          <Hawtio />
+        </React.StrictMode>,
+      )
 
-  // If you want to start measuring performance in your app, pass a function
-  // to log results (for example: reportWebVitals(console.log))
-  // or send to an analytics endpoint. Learn more: https://bit.ly/CRA-vitals
-  reportWebVitals()
+      // If you want to start measuring performance in your app, pass a function
+      // to log results (for example: reportWebVitals(console.log))
+      // or send to an analytics endpoint. Learn more: https://bit.ly/CRA-vitals
+      reportWebVitals()
+    })
+  })
 })


### PR DESCRIPTION
* Due to JS single thread, the redirection of the page does not actually fire until the bootstrap function has completed. This means that a very brief rendering of the Hawtio login page is possible

* bootstrap.tsx
 * Wait for hawtio to finish bootstrapping before considering whether a redirecting has been flagged to occur. In such an event do not show the hawtio rendering

* oauth...
 * Provides an oAuthRendering function that will return whether the oauth service has signalled a redirection to occur

* form/osoauth-service
 * Sets a redirecting flag to true prior to calling redirect()