### PR TITLE
build: use compression for big modules & configure NGINX to use them

### DIFF
--- a/docker/nginx-gateway.conf.template
+++ b/docker/nginx-gateway.conf.template
@@ -24,6 +24,7 @@ server {
     ssl_certificate_key /etc/tls/private/serving/tls.key;
     absolute_redirect   off;
     gzip                on;
+    gzip_types text/plain application/javascript text/javascript;
     root                /usr/share/nginx/html/;
 
     # Limit the keepalive of connections (60s default)
@@ -79,6 +80,7 @@ server {
         add_header location-rule ONLINE always;
         alias     /usr/share/nginx/html/online;
         try_files $uri$args $uri /online/index.html;
+        gzip_static on;
     }
 
     # Kubernetes master API reverse proxying

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "kustomize:image": "cd deploy/base && kustomize edit set image hawtio/online=quay.io/${ORG:-hawtio}/${PROJECT:-online}:${TAG:-latest}"
   },
   "devDependencies": {
+    "compression-webpack-plugin": "^11.1.0",
     "concurrently": "^8.2.2",
     "cz-conventional-changelog": "3.3.0",
     "eslint": "^8.57.0",

--- a/packages/online-shell/src/bootstrap.tsx
+++ b/packages/online-shell/src/bootstrap.tsx
@@ -4,8 +4,12 @@ import { camel, configManager, hawtio, Hawtio, jmx, logs, quartz, rbac, runtime,
 import { isMgmtApiRegistered } from '@hawtio/online-management-api'
 import { reportWebVitals } from './reportWebVitals'
 import { discover } from './discover'
+import { InitLoading } from './console/InitLoading'
 
 configManager.addProductInfo('Hawtio Online', '__PACKAGE_VERSION_PLACEHOLDER__')
+
+const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement)
+root.render(<InitLoading />)
 
 // Register kubernetes & management - only then complete hawtio bootstrap
 isMgmtApiRegistered().then(() => {
@@ -24,7 +28,6 @@ isMgmtApiRegistered().then(() => {
   // Bootstrap Hawtio
   hawtio.bootstrap()
 
-  const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement)
   root.render(
     <React.StrictMode>
       <Hawtio />

--- a/packages/online-shell/src/console/InitLoading.tsx
+++ b/packages/online-shell/src/console/InitLoading.tsx
@@ -1,0 +1,13 @@
+import { Card, CardBody, CardTitle, Spinner } from '@patternfly/react-core'
+import React from 'react'
+
+export const InitLoading: React.FunctionComponent = () => (
+  <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', marginTop: '20%' }}>
+    <Card>
+      <CardTitle style={{ textAlign: 'center' }}>Initializing Hawtio...</CardTitle>
+      <CardBody>
+        <Spinner /> Connecting to OpenShift API
+      </CardBody>
+    </Card>
+  </div>
+)

--- a/packages/online-shell/webpack.config.prod.js
+++ b/packages/online-shell/webpack.config.prod.js
@@ -4,6 +4,8 @@ const CopyWebpackPlugin = require('copy-webpack-plugin')
 const path = require('path')
 const { common } = require('./webpack.config.common.js')
 
+const CompressionPlugin = require('compression-webpack-plugin')
+
 module.exports = () => {
   //
   // Prefix path will be determined by the installed web server platform
@@ -16,6 +18,9 @@ module.exports = () => {
     plugins: [
       new CopyWebpackPlugin({
         patterns: [{ from: 'public/manifest.json' }, { from: 'public/hawtio-logo.svg' }],
+      }),
+      new CompressionPlugin({
+        threshold: 8192,
       }),
     ],
   })

--- a/yarn.lock
+++ b/yarn.lock
@@ -2166,6 +2166,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@hawtio/online-root@workspace:."
   dependencies:
+    compression-webpack-plugin: "npm:^11.1.0"
     concurrently: "npm:^8.2.2"
     cz-conventional-changelog: "npm:3.3.0"
     eslint: "npm:^8.57.0"
@@ -5760,6 +5761,18 @@ __metadata:
   dependencies:
     mime-db: "npm:>= 1.43.0 < 2"
   checksum: 10/58321a85b375d39230405654721353f709d0c1442129e9a17081771b816302a012471a9b8f4864c7dbe02eef7f2aaac3c614795197092262e94b409c9be108f0
+  languageName: node
+  linkType: hard
+
+"compression-webpack-plugin@npm:^11.1.0":
+  version: 11.1.0
+  resolution: "compression-webpack-plugin@npm:11.1.0"
+  dependencies:
+    schema-utils: "npm:^4.2.0"
+    serialize-javascript: "npm:^6.0.2"
+  peerDependencies:
+    webpack: ^5.1.0
+  checksum: 10/9068fc0fe8feb3c342043b58d42756006b5e85393bd40356e2bd9b68b70adb77782cd42bda2c84bc26c749d7357ae195b526aad3e6e6ffb51db1a23217bf6357
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This significantly reduces the size of the two biggest bundles, the most significant change is from 11 MB to 2 MB.