### PR TITLE
feat: upgrade @hawtio/react to 1.1.0

### DIFF
--- a/packages/kubernetes-api-app/package.json
+++ b/packages/kubernetes-api-app/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@hawtio/online-kubernetes-api": "workspace:*",
-    "@hawtio/react": "^1.0.7",
+    "@hawtio/react": "^1.1.0",
     "@patternfly/react-core": "^4.278.1",
     "@patternfly/react-styles": "^4.92.6",
     "@patternfly/react-table": "^4.113.7",

--- a/packages/kubernetes-api/jest.config.ts
+++ b/packages/kubernetes-api/jest.config.ts
@@ -17,6 +17,7 @@ export default {
     '\\.(css|less)$': '<rootDir>/src/__mocks__/styleMock.js',
     'react-markdown': '<rootDir>/../../node_modules/@hawtio/react/node_modules/react-markdown/react-markdown.min.js',
     '@patternfly/react-code-editor': path.resolve(__dirname, './src/__mocks__/codeEditorMock.js'),
+    oauth4webapi: path.resolve(__dirname, './src/__mocks__/oauth4webapi.js'),
   },
 
   // The path to a module that runs some code to configure or set up the testing

--- a/packages/kubernetes-api/package.json
+++ b/packages/kubernetes-api/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@hawtio/online-oauth": "workspace:*",
-    "@hawtio/react": "^1.0.7",
+    "@hawtio/react": "^1.1.0",
     "@types/jquery": "^3.5.29",
     "@types/jsonpath": "^0.2.4",
     "@types/node": "^18.19.21",

--- a/packages/kubernetes-api/src/__mocks__/oauth4webapi.js
+++ b/packages/kubernetes-api/src/__mocks__/oauth4webapi.js
@@ -1,0 +1,1 @@
+module.exports = {}

--- a/packages/management-api-app/package.json
+++ b/packages/management-api-app/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@hawtio/online-management-api": "workspace:*",
-    "@hawtio/react": "^1.0.7",
+    "@hawtio/react": "^1.1.0",
     "@patternfly/react-core": "^4.278.1",
     "@patternfly/react-styles": "^4.92.6",
     "@patternfly/react-table": "^4.113.7",

--- a/packages/management-api/package.json
+++ b/packages/management-api/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@hawtio/online-kubernetes-api": "workspace:*",
-    "@hawtio/react": "^1.0.7",
+    "@hawtio/react": "^1.1.0",
     "eventemitter3": "^5.0.1",
     "jolokia.js": "^2.0.0",
     "jquery": "^3.7.0",

--- a/packages/oauth-app/package.json
+++ b/packages/oauth-app/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@hawtio/online-oauth": "workspace:*",
-    "@hawtio/react": "^1.0.7",
+    "@hawtio/react": "^1.1.0",
     "@patternfly/react-core": "^4.278.1",
     "@patternfly/react-styles": "^4.92.6",
     "@patternfly/react-table": "^4.113.7",

--- a/packages/oauth/package.json
+++ b/packages/oauth/package.json
@@ -29,7 +29,7 @@
     "prepack": "yarn build && yarn replace-version"
   },
   "dependencies": {
-    "@hawtio/react": "^1.0.7",
+    "@hawtio/react": "^1.1.0",
     "@thumbmarkjs/thumbmarkjs": "^0.14.1",
     "babel-jest": "^29.6.1",
     "fetch-intercept": "^2.4.0",

--- a/packages/online-shell/package.json
+++ b/packages/online-shell/package.json
@@ -35,7 +35,7 @@
     "@fortawesome/react-fontawesome": "^0.2.0",
     "@hawtio/online-kubernetes-api": "workspace:*",
     "@hawtio/online-management-api": "workspace:*",
-    "@hawtio/react": "^1.0.7",
+    "@hawtio/react": "^1.1.0",
     "@patternfly/react-core": "^4.278.1",
     "@patternfly/react-styles": "^4.92.6",
     "@patternfly/react-table": "^4.113.7",

--- a/scripts/update-hawtio-react.sh
+++ b/scripts/update-hawtio-react.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+set -e
+
+if [ -z "$1" ]; then
+  echo Use this script to update @hawtio/react version in the project.
+  echo
+  echo Usage:
+  echo "  $(basename "$0") <new version>"
+  exit
+fi
+
+if ! command -v ag > /dev/null; then
+  echo This script requires ag, the silver searcher. Install it and try again.
+  echo
+  echo "  dnf install the_silver_searcher"
+  exit
+fi
+
+version=$1
+echo Updating @hawtio/react to "$version"
+
+ag @hawtio/react -G package.json -l | xargs sed -i "s|\"@hawtio/react\": \".*\"|\"@hawtio/react\": \"^$version\"|g"
+
+echo Run \'yarn install\' to update yarn.lock

--- a/yarn.lock
+++ b/yarn.lock
@@ -1929,17 +1929,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hawtio/camel-model-v3@npm:@hawtio/camel-model@^3.21.2":
-  version: 3.21.2
-  resolution: "@hawtio/camel-model@npm:3.21.2"
-  checksum: 10/feebd08f32479336191e5df8e859d1dcfc32c0d05b307a5d05ce7a2a2730b9de110951fc6787664c43a2ddb1146bcbe2bfa441a467320f2d2c492d1335c840cc
+"@hawtio/camel-model-v4_0@npm:@hawtio/camel-model@~4.0.4":
+  version: 4.0.4
+  resolution: "@hawtio/camel-model@npm:4.0.4"
+  checksum: 10/c4c92f7dc07216205adb84e544b52d0d1c7d7271cc42925ac9dc290cf3abd74cce4fc7910f8a65d409a4e7df53d5f9db84e5223ffb3d0ee5bbd9e0a81679ddb4
   languageName: node
   linkType: hard
 
-"@hawtio/camel-model-v4@npm:@hawtio/camel-model@~4.0.3":
-  version: 4.0.3
-  resolution: "@hawtio/camel-model@npm:4.0.3"
-  checksum: 10/0270c632bdeea39fdc1febd0380d862eeb1059cbd9c6627a41fa02fdba175a6d67a089cbf953db32a62f402de546b5a212e3d0745bcbc9a4518002cb928dae1c
+"@hawtio/camel-model-v4_4@npm:@hawtio/camel-model@~4.4.0":
+  version: 4.4.0
+  resolution: "@hawtio/camel-model@npm:4.4.0"
+  checksum: 10/895dbe3988e552842ab6443574631b185145fe6c97123cc24d43eef074815bdac5bd0c06a648e795dd366d12fafb280a30fe76f81a7f79e32884c01a49af3fa2
   languageName: node
   linkType: hard
 
@@ -1954,7 +1954,7 @@ __metadata:
   resolution: "@hawtio/online-kubernetes-api-app@workspace:packages/kubernetes-api-app"
   dependencies:
     "@hawtio/online-kubernetes-api": "workspace:*"
-    "@hawtio/react": "npm:^1.0.7"
+    "@hawtio/react": "npm:^1.1.0"
     "@patternfly/react-core": "npm:^4.278.1"
     "@patternfly/react-styles": "npm:^4.92.6"
     "@patternfly/react-table": "npm:^4.113.7"
@@ -1992,7 +1992,7 @@ __metadata:
   resolution: "@hawtio/online-kubernetes-api@workspace:packages/kubernetes-api"
   dependencies:
     "@hawtio/online-oauth": "workspace:*"
-    "@hawtio/react": "npm:^1.0.7"
+    "@hawtio/react": "npm:^1.1.0"
     "@testing-library/jest-dom": "npm:^6.4.2"
     "@types/jest": "npm:^29.5.12"
     "@types/jquery": "npm:^3.5.29"
@@ -2026,7 +2026,7 @@ __metadata:
   resolution: "@hawtio/online-management-api-app@workspace:packages/management-api-app"
   dependencies:
     "@hawtio/online-management-api": "workspace:*"
-    "@hawtio/react": "npm:^1.0.7"
+    "@hawtio/react": "npm:^1.1.0"
     "@patternfly/react-core": "npm:^4.278.1"
     "@patternfly/react-styles": "npm:^4.92.6"
     "@patternfly/react-table": "npm:^4.113.7"
@@ -2064,7 +2064,7 @@ __metadata:
   resolution: "@hawtio/online-management-api@workspace:packages/management-api"
   dependencies:
     "@hawtio/online-kubernetes-api": "workspace:*"
-    "@hawtio/react": "npm:^1.0.7"
+    "@hawtio/react": "npm:^1.1.0"
     "@types/jest": "npm:^29.5.12"
     "@types/jquery": "npm:^3.5.29"
     "@types/jsonpath": "npm:^0.2.4"
@@ -2097,7 +2097,7 @@ __metadata:
   resolution: "@hawtio/online-oauth-app@workspace:packages/oauth-app"
   dependencies:
     "@hawtio/online-oauth": "workspace:*"
-    "@hawtio/react": "npm:^1.0.7"
+    "@hawtio/react": "npm:^1.1.0"
     "@patternfly/react-core": "npm:^4.278.1"
     "@patternfly/react-styles": "npm:^4.92.6"
     "@patternfly/react-table": "npm:^4.113.7"
@@ -2136,7 +2136,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@hawtio/online-oauth@workspace:packages/oauth"
   dependencies:
-    "@hawtio/react": "npm:^1.0.7"
+    "@hawtio/react": "npm:^1.1.0"
     "@thumbmarkjs/thumbmarkjs": "npm:^0.14.1"
     "@types/jest": "npm:^29.5.12"
     "@types/jquery": "npm:^3.5.29"
@@ -2187,7 +2187,7 @@ __metadata:
     "@fortawesome/react-fontawesome": "npm:^0.2.0"
     "@hawtio/online-kubernetes-api": "workspace:*"
     "@hawtio/online-management-api": "workspace:*"
-    "@hawtio/react": "npm:^1.0.7"
+    "@hawtio/react": "npm:^1.1.0"
     "@patternfly/react-core": "npm:^4.278.1"
     "@patternfly/react-styles": "npm:^4.92.6"
     "@patternfly/react-table": "npm:^4.113.7"
@@ -2235,12 +2235,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@hawtio/react@npm:^1.0.7":
-  version: 1.0.7
-  resolution: "@hawtio/react@npm:1.0.7"
+"@hawtio/react@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@hawtio/react@npm:1.1.0"
   dependencies:
-    "@hawtio/camel-model-v3": "npm:@hawtio/camel-model@^3.21.2"
-    "@hawtio/camel-model-v4": "npm:@hawtio/camel-model@~4.0.3"
+    "@hawtio/camel-model-v4_0": "npm:@hawtio/camel-model@~4.0.4"
+    "@hawtio/camel-model-v4_4": "npm:@hawtio/camel-model@~4.4.0"
     "@module-federation/utilities": "npm:^3.0.5"
     "@patternfly/react-charts": "npm:~6.94.21"
     "@patternfly/react-code-editor": "npm:~4.82.122"
@@ -2249,12 +2249,12 @@ __metadata:
     "@testing-library/jest-dom": "npm:^6.4.2"
     "@testing-library/react": "npm:^14.2.1"
     "@testing-library/user-event": "npm:^14.5.2"
-    "@thumbmarkjs/thumbmarkjs": "npm:^0.13.5"
+    "@thumbmarkjs/thumbmarkjs": "npm:^0.14.1"
     "@types/dagre": "npm:^0.7.52"
     "@types/dagre-layout": "npm:^0.8.5"
     "@types/jest": "npm:^29.5.12"
     "@types/jquery": "npm:^3.5.29"
-    "@types/node": "npm:^18.19.17"
+    "@types/node": "npm:^18.19.21"
     "@types/react": "npm:^18.2.23"
     "@types/react-dom": "npm:^18.2.19"
     "@types/react-router-dom": "npm:^5.3.3"
@@ -2263,17 +2263,19 @@ __metadata:
     jolokia.js: "npm:^2.0.0"
     jquery: "npm:^3.7.1"
     js-logger: "npm:^1.6.1"
-    keycloak-js: "npm:^23.0.6"
+    jwt-decode: "npm:^4.0.0"
+    keycloak-js: "npm:^23.0.7"
     monaco-editor: "npm:^0.46.0"
+    oauth4webapi: "npm:^2.10.3"
     react: "npm:^18.2.0"
     react-dom: "npm:^18.2.0"
     react-markdown: "npm:^8.0.7"
     react-monaco-editor: "npm:^0.55.0"
-    react-router-dom: "npm:^6.22.1"
+    react-router-dom: "npm:^6.22.2"
     react-split: "npm:^2.0.14"
     reactflow: "npm:^11.10.4"
     superstruct: "npm:^1.0.3"
-    typescript: "npm:^5.2.2"
+    typescript: "npm:^5.3.3"
     xml-formatter: "npm:^3.6.2"
   peerDependencies:
     "@patternfly/react-core": ^4.278.1
@@ -2283,7 +2285,7 @@ __metadata:
   peerDependenciesMeta:
     keycloak-js:
       optional: true
-  checksum: 10/ce4664feb91d1dc92b03bbf49267e2d8aed0d81be299101ec85f4d6c5e725f71c1d76a3a6e7efef328a03cf149116b18489f4bd7c8861ad6a44cc3dae075e4f3
+  checksum: 10/0f68151a22a111e0a9cee81283b530207c9cc84f4d6692cbb212b5b4c7d6c561b139e4ddc3498939b62314181383f2909f82e815f111ae40e8fff2e7aea975b0
   languageName: node
   linkType: hard
 
@@ -2936,13 +2938,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@remix-run/router@npm:1.15.1":
-  version: 1.15.1
-  resolution: "@remix-run/router@npm:1.15.1"
-  checksum: 10/d262285d155f80779894ee1d9ef07e35421986ba2546378dfe0e3b09397ce71becb6a4677e9efcd4155e2bd3f9f7f7ecbc110cd99bacee6dd7d3e5ce51b7caa8
-  languageName: node
-  linkType: hard
-
 "@remix-run/router@npm:1.15.2":
   version: 1.15.2
   resolution: "@remix-run/router@npm:1.15.2"
@@ -3142,13 +3137,6 @@ __metadata:
   peerDependencies:
     "@testing-library/dom": ">=7.21.4"
   checksum: 10/49821459d81c6bc435d97128d6386ca24f1e4b3ba8e46cb5a96fe3643efa6e002d88c1b02b7f2ec58da593e805c59b78d7fdf0db565c1f02ba782f63ee984040
-  languageName: node
-  linkType: hard
-
-"@thumbmarkjs/thumbmarkjs@npm:^0.13.5":
-  version: 0.13.5
-  resolution: "@thumbmarkjs/thumbmarkjs@npm:0.13.5"
-  checksum: 10/b39044d8703c44fd50c396d2d1d99b81512c15ebdf486d5847fa3c9ee65dfb604e2927c3a3f86bdf4e4e55ab45ab47e75e0641d52e07a9a783d10c7127503fbc
   languageName: node
   linkType: hard
 
@@ -3846,15 +3834,6 @@ __metadata:
   version: 20.5.1
   resolution: "@types/node@npm:20.5.1"
   checksum: 10/e91034ba7eda82171dff73d3b30f584941400a5611b45d73a4d8159dc1fc309d4f1a423fbe84fd22d1ba7833383ee299c81ace6fab035c17affd0f4f0cbe7a89
-  languageName: node
-  linkType: hard
-
-"@types/node@npm:^18.19.17":
-  version: 18.19.17
-  resolution: "@types/node@npm:18.19.17"
-  dependencies:
-    undici-types: "npm:~5.26.4"
-  checksum: 10/7bef9d73227c6c47f0b616ff47df8390d03c6ea2ea4b60b272f336b58c928dbd02cc1f3e399e68660d37ee41836db91358b816575286a3b3114e4384bbd076e3
   languageName: node
   linkType: hard
 
@@ -10066,14 +10045,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"keycloak-js@npm:^23.0.6":
-  version: 23.0.6
-  resolution: "keycloak-js@npm:23.0.6"
+"keycloak-js@npm:^23.0.7":
+  version: 23.0.7
+  resolution: "keycloak-js@npm:23.0.7"
   dependencies:
     base64-js: "npm:^1.5.1"
     js-sha256: "npm:^0.10.1"
     jwt-decode: "npm:^4.0.0"
-  checksum: 10/66f5fcfec147f372b93c61a0c0dac4617889b327d96abc8b938e093ee224e07339d6d3bf7c1063c5a872949f281e7583cc9fc92fc0c7bf499d0de8f30c110e58
+  checksum: 10/61c127a9ac4954d1d0f7f1eee2348043322e21ec956f1ac7819bced39ce1360470cbbb5bd6f81ac1ee59a6fecc1cc5c2667f4e4f249c9c9b86a747a3654efb97
   languageName: node
   linkType: hard
 
@@ -11492,6 +11471,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"oauth4webapi@npm:^2.10.3":
+  version: 2.10.3
+  resolution: "oauth4webapi@npm:2.10.3"
+  checksum: 10/5914a7c8234084275771e2e24337becee1350042c94815bec28134e6572df5f926e47f8a31ae4a22a213203bb68585e9712ba3386b5de61516487f241fe1979b
+  languageName: node
+  linkType: hard
+
 "object-assign@npm:^4.0.1, object-assign@npm:^4.1.1":
   version: 4.1.1
   resolution: "object-assign@npm:4.1.1"
@@ -12410,19 +12396,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-router-dom@npm:^6.22.1":
-  version: 6.22.1
-  resolution: "react-router-dom@npm:6.22.1"
-  dependencies:
-    "@remix-run/router": "npm:1.15.1"
-    react-router: "npm:6.22.1"
-  peerDependencies:
-    react: ">=16.8"
-    react-dom: ">=16.8"
-  checksum: 10/73ab964083bb407773a5c4ca61249ed6b0a1b47fa58c39afca08a361eb25b349be2bcbaf6d89e112b020f6e55e40e62689c9fe2beae524030ce5ccede3c7d9e3
-  languageName: node
-  linkType: hard
-
 "react-router-dom@npm:^6.22.2":
   version: 6.22.2
   resolution: "react-router-dom@npm:6.22.2"
@@ -12433,17 +12406,6 @@ __metadata:
     react: ">=16.8"
     react-dom: ">=16.8"
   checksum: 10/1469ea32fd5b35d44909c8e64a778620e990b43a1c6f4d5989630e769a9956e0057a54771ccde2e434a9aff7591c02752dcfe0678a1868d4e53411cec7ecf7a8
-  languageName: node
-  linkType: hard
-
-"react-router@npm:6.22.1":
-  version: 6.22.1
-  resolution: "react-router@npm:6.22.1"
-  dependencies:
-    "@remix-run/router": "npm:1.15.1"
-  peerDependencies:
-    react: ">=16.8"
-  checksum: 10/f6e814b8e3005f16a5fb0e831f0e4352076cde65ab25448d56dba87a43fd3e102f55f9b366bdf1fbd8136fc1dc141bcec8d6b85d45f309e89180fb50f173744d
   languageName: node
   linkType: hard
 
@@ -14334,7 +14296,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^4.6.4 || ^5.0.0, typescript@npm:^5.2.2":
+"typescript@npm:^4.6.4 || ^5.0.0":
   version: 5.2.2
   resolution: "typescript@npm:5.2.2"
   bin:
@@ -14354,7 +14316,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A^4.6.4 || ^5.0.0#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A^5.2.2#optional!builtin<compat/typescript>":
+"typescript@patch:typescript@npm%3A^4.6.4 || ^5.0.0#optional!builtin<compat/typescript>":
   version: 5.2.2
   resolution: "typescript@patch:typescript@npm%3A5.2.2#optional!builtin<compat/typescript>::version=5.2.2&hash=f3b441"
   bin:


### PR DESCRIPTION
This also means now hawtio-online supports Camel model 4.0.x and 4.4.x, dropping 3.x support.