### PR TITLE
Handle jolokia connection failure and extending delay when connection errors

### DIFF
--- a/packages/management-api-app/src/ManagementPods.tsx
+++ b/packages/management-api-app/src/ManagementPods.tsx
@@ -17,7 +17,7 @@ type ManagedPodsProps = {
 
 const podDetailStyle = (pod: ManagedPod) => {
   return {
-    color: pod.management.status.error ? 'red' : 'blue',
+    color: pod.getManagement().status.error ? 'red' : 'blue',
     fontWeight: 'bold',
   }
 }
@@ -40,12 +40,12 @@ export const ManagementPods: React.FunctionComponent<ManagedPodsProps> = (props:
             </Thead>
             <Tbody>
               {props.pods.map(pod => (
-                <Tr key={pod.metadata?.uid}>
-                  <Td dataLabel='Name'>{pod.metadata?.name}</Td>
-                  <Td dataLabel='Namespace'>{pod.metadata?.namespace}</Td>
+                <Tr key={pod.getMetadata()?.uid}>
+                  <Td dataLabel='Name'>{pod.getMetadata()?.name}</Td>
+                  <Td dataLabel='Namespace'>{pod.getMetadata()?.namespace}</Td>
                   <Td dataLabel='Labels'>
                     <DescriptionList>
-                      {Object.entries(pod.metadata?.labels || {}).map(([key, value]) => {
+                      {Object.entries(pod.getMetadata()?.labels || {}).map(([key, value]) => {
                         return (
                           <DescriptionListGroup key={key}>
                             <DescriptionListTerm>{key}</DescriptionListTerm>
@@ -57,7 +57,7 @@ export const ManagementPods: React.FunctionComponent<ManagedPodsProps> = (props:
                   </Td>
                   <Td dataLabel='Annotations'>
                     <DescriptionList>
-                      {Object.entries(pod.metadata?.annotations || {}).map(([key, value]) => {
+                      {Object.entries(pod.getMetadata()?.annotations || {}).map(([key, value]) => {
                         return (
                           <DescriptionListGroup key={key}>
                             <DescriptionListTerm>{key}</DescriptionListTerm>
@@ -70,9 +70,9 @@ export const ManagementPods: React.FunctionComponent<ManagedPodsProps> = (props:
                   <Td dataLabel='Status'>{k8Service.podStatus(pod.pod)}</Td>
                   <Td dataLabel='Management'>
                     <div style={podDetailStyle(pod)}>
-                      <pre>{JSON.stringify(pod.management, null, 2)}</pre>
+                      <pre>{JSON.stringify(pod.getManagement(), null, 2)}</pre>
                     </div>
-                    {pod.management.status.error && (
+                    {pod.getManagement().status.error && (
                       <div>
                         <p>Jolokia connections are not succeeding. Possible reasons:</p>
                         <ol>

--- a/packages/management-api/src/jolokia-response-utils.ts
+++ b/packages/management-api/src/jolokia-response-utils.ts
@@ -1,0 +1,46 @@
+import {
+  Response as JolokiaResponse,
+  ErrorResponse as JolokiaErrorResponse,
+  VersionResponse as JolokiaVersionResponse,
+} from 'jolokia.js'
+
+export type ParseResult<T> = { hasError: false; parsed: T } | { hasError: true; error: string }
+
+function isObject(value: unknown): value is object {
+  const type = typeof value
+  return value != null && (type === 'object' || type === 'function')
+}
+
+export function isJolokiaResponseType(o: unknown): o is JolokiaResponse {
+  return isObject(o) && 'status' in o && 'timestamp' in o && 'value' in o
+}
+
+export function isJolokiaResponseErrorType(o: unknown): o is JolokiaErrorResponse {
+  return isObject(o) && 'error_type' in o && 'error' in o
+}
+
+export function isJolokiaVersionResponseType(o: unknown): o is JolokiaVersionResponse {
+  return isObject(o) && 'protocol' in o && 'agent' in o && 'info' in o
+}
+
+export function jolokiaResponseParse(text: string): ParseResult<JolokiaResponse> {
+  try {
+    const parsed = JSON.parse(text)
+
+    if (isJolokiaResponseErrorType(parsed)) {
+      const errorResponse: JolokiaErrorResponse = parsed as JolokiaErrorResponse
+      return { error: errorResponse.error, hasError: true }
+    } else if (isJolokiaResponseType(parsed)) {
+      const response: JolokiaResponse = parsed as JolokiaResponse
+      return { parsed: response, hasError: false }
+    } else {
+      return { error: 'Unrecognised jolokia response', hasError: true }
+    }
+  } catch (e) {
+    let msg
+    if (e instanceof Error) msg = e.message
+    else msg = String(e)
+
+    return { error: msg, hasError: true }
+  }
+}

--- a/packages/management-api/src/managed-pod.ts
+++ b/packages/management-api/src/managed-pod.ts
@@ -8,6 +8,7 @@ import { log } from './globals'
 import jsonpath from 'jsonpath'
 import { k8Api, KubePod, k8Service, ObjectMeta, PodStatus, joinPaths, PodSpec } from '@hawtio/online-kubernetes-api'
 import { ParseResult, isJolokiaVersionResponseType, jolokiaResponseParse } from './jolokia-response-utils'
+import { eventService } from '@hawtio/react'
 
 const DEFAULT_JOLOKIA_OPTIONS: BaseRequestOptions = {
   method: 'post',
@@ -210,5 +211,14 @@ export class ManagedPod {
         failCb(this.getManagementError() as Error)
       },
     })
+  }
+
+  errorNotify() {
+    const name = this.getMetadata()?.name || '<unknown>'
+    const mgmtError = this.getManagementError()
+    if (mgmtError) {
+      const msg = `${name}: ${mgmtError.message}`
+      eventService.notify({ type: 'danger', message: msg })
+    }
   }
 }

--- a/packages/management-api/src/managed-pod.ts
+++ b/packages/management-api/src/managed-pod.ts
@@ -106,23 +106,23 @@ export class ManagedPod {
     return new Jolokia(options)
   }
 
-  get kind(): string | undefined {
+  getKind(): string | undefined {
     return this.pod.kind
   }
 
-  get metadata(): ObjectMeta | undefined {
+  getMetadata(): ObjectMeta | undefined {
     return this.pod.metadata
   }
 
-  get spec(): PodSpec | undefined {
+  getSpec(): PodSpec | undefined {
     return this.pod.spec
   }
 
-  get status(): PodStatus | undefined {
+  getStatus(): PodStatus | undefined {
     return this.pod.status
   }
 
-  get management(): Management {
+  getManagement(): Management {
     return this._management
   }
 

--- a/packages/online-shell/src/discover/Discover.css
+++ b/packages/online-shell/src/discover/Discover.css
@@ -58,9 +58,20 @@
 }
 
 .pod-item-connect-button {
+  display: flex;
+  flex-direction: column;
+  flex-grow: 0;
+  flex-basis: 20%;
+  align-items: end;
   max-height: 2em;
   margin-top: auto;
   margin-bottom: auto;
+}
+
+.pod-item-connect-error-Label {
+  margin-top: 0.2em;
+  text-align: right;
+  color: red;
 }
 
 .state-icon {

--- a/packages/online-shell/src/discover/Discover.css
+++ b/packages/online-shell/src/discover/Discover.css
@@ -58,20 +58,20 @@
 }
 
 .pod-item-connect-button {
-  display: flex;
-  flex-direction: column;
-  flex-grow: 0;
-  flex-basis: 20%;
-  align-items: end;
   max-height: 2em;
   margin-top: auto;
   margin-bottom: auto;
 }
 
-.pod-item-connect-error-Label {
-  margin-top: 0.2em;
-  text-align: right;
-  color: red;
+.pod-item-connect-error-badge {
+  margin-right: 0.2em;
+}
+
+.pod-item-connect-error-badge span {
+  width: 1.5em;
+  height: 1.6em;
+  padding-left: 0.25em;
+  padding-top: 0.1em;
 }
 
 .state-icon {

--- a/packages/online-shell/src/discover/DiscoverPodConnect.tsx
+++ b/packages/online-shell/src/discover/DiscoverPodConnect.tsx
@@ -1,5 +1,12 @@
 import React from 'react'
-import { Button, Dropdown, DropdownItem, DropdownToggle } from '@patternfly/react-core'
+import {
+  Button,
+  Dropdown,
+  DropdownItem,
+  DropdownToggle,
+  ExpandableSection,
+  ExpandableSectionVariant,
+} from '@patternfly/react-core'
 import { mgmtService } from '@hawtio/online-management-api'
 import { DiscoverPod } from './globals'
 import './Discover.css'
@@ -12,10 +19,16 @@ export const DiscoverPodConnect: React.FunctionComponent<DiscoverPodConnectProps
   props: DiscoverPodConnectProps,
 ) => {
   const connectionNames: string[] = mgmtService.refreshConnections(props.pod.mPod)
+  const mgmtError = props.pod.mPod?.getManagementError()
 
+  const [isErrorExpanded, setIsErrorExpanded] = React.useState(false)
   const [isOpen, setIsOpen] = React.useState(false)
 
-  const onToggle = (isOpen: boolean) => {
+  const onErrorToggle = (isExpanded: boolean) => {
+    setIsErrorExpanded(isExpanded)
+  }
+
+  const onConnectToggle = (isOpen: boolean) => {
     setIsOpen(isOpen)
   }
 
@@ -30,7 +43,7 @@ export const DiscoverPodConnect: React.FunctionComponent<DiscoverPodConnectProps
   }
 
   const disableContainerButton = (): boolean => {
-    return mgmtService.podStatus(props.pod.mPod) !== 'Running' || connectionNames.length === 0
+    return mgmtService.podStatus(props.pod.mPod) !== 'Running' || connectionNames.length === 0 || mgmtError !== null
   }
 
   const onConnect = (connectName: string) => {
@@ -56,7 +69,7 @@ export const DiscoverPodConnect: React.FunctionComponent<DiscoverPodConnectProps
           className='connect-button-dropdown'
           onSelect={onSelect}
           toggle={
-            <DropdownToggle id='toggle-initial-selection' toggleVariant='primary' onToggle={onToggle}>
+            <DropdownToggle id='toggle-initial-selection' toggleVariant='primary' onToggle={onConnectToggle}>
               Connect
             </DropdownToggle>
           }
@@ -73,6 +86,19 @@ export const DiscoverPodConnect: React.FunctionComponent<DiscoverPodConnectProps
             )
           })}
         />
+      )}
+
+      {mgmtError && (
+        <div className='pod-item-connect-error-Label'>
+          <ExpandableSection
+            variant={ExpandableSectionVariant.truncate}
+            toggleText={isErrorExpanded ? 'Show less' : 'Show more'}
+            onToggle={onErrorToggle}
+            isExpanded={isErrorExpanded}
+          >
+            {String(mgmtError)}
+          </ExpandableSection>
+        </div>
       )}
     </React.Fragment>
   )

--- a/packages/online-shell/src/discover/DiscoverPodConnect.tsx
+++ b/packages/online-shell/src/discover/DiscoverPodConnect.tsx
@@ -4,8 +4,8 @@ import {
   Dropdown,
   DropdownItem,
   DropdownToggle,
-  ExpandableSection,
-  ExpandableSectionVariant,
+  NotificationBadge,
+  NotificationBadgeVariant,
 } from '@patternfly/react-core'
 import { mgmtService } from '@hawtio/online-management-api'
 import { DiscoverPod } from './globals'
@@ -21,12 +21,7 @@ export const DiscoverPodConnect: React.FunctionComponent<DiscoverPodConnectProps
   const connectionNames: string[] = mgmtService.refreshConnections(props.pod.mPod)
   const mgmtError = props.pod.mPod?.getManagementError()
 
-  const [isErrorExpanded, setIsErrorExpanded] = React.useState(false)
   const [isOpen, setIsOpen] = React.useState(false)
-
-  const onErrorToggle = (isExpanded: boolean) => {
-    setIsErrorExpanded(isExpanded)
-  }
 
   const onConnectToggle = (isOpen: boolean) => {
     setIsOpen(isOpen)
@@ -52,6 +47,15 @@ export const DiscoverPodConnect: React.FunctionComponent<DiscoverPodConnectProps
 
   return (
     <React.Fragment>
+      {mgmtError && (
+        <NotificationBadge
+          variant={NotificationBadgeVariant.attention}
+          onClick={() => props.pod.mPod.errorNotify()}
+          aria-label='Display Connect Error'
+          className='pod-item-connect-error-badge'
+        />
+      )}
+
       {connectionNames.length <= 1 && (
         <Button
           variant='primary'
@@ -86,19 +90,6 @@ export const DiscoverPodConnect: React.FunctionComponent<DiscoverPodConnectProps
             )
           })}
         />
-      )}
-
-      {mgmtError && (
-        <div className='pod-item-connect-error-Label'>
-          <ExpandableSection
-            variant={ExpandableSectionVariant.truncate}
-            toggleText={isErrorExpanded ? 'Show less' : 'Show more'}
-            onToggle={onErrorToggle}
-            isExpanded={isErrorExpanded}
-          >
-            {String(mgmtError)}
-          </ExpandableSection>
-        </div>
       )}
     </React.Fragment>
   )

--- a/packages/online-shell/src/discover/DiscoverPodItem.tsx
+++ b/packages/online-shell/src/discover/DiscoverPodItem.tsx
@@ -42,6 +42,15 @@ export const DiscoverPodItem: React.FunctionComponent<DiscoverPodItemProps> = (p
       )
     }
 
+    const error = props.pod.mPod.management.status.error
+    if (error) {
+      return (
+        <Label color='red' icon={<CamelRouteIcon />} className='pod-item-routes'>
+          {`?? routes`}
+        </Label>
+      )
+    }
+
     const total = props.pod.mPod.management.camel.routes_count
     return (
       <Label color='gold' icon={<CamelRouteIcon />} className='pod-item-routes'>

--- a/packages/online-shell/src/discover/DiscoverPodItem.tsx
+++ b/packages/online-shell/src/discover/DiscoverPodItem.tsx
@@ -17,24 +17,24 @@ interface DiscoverPodItemProps {
 
 export const DiscoverPodItem: React.FunctionComponent<DiscoverPodItemProps> = (props: DiscoverPodItemProps) => {
   const nodeLabel = (): ReactNode => {
-    if (props.pod.mPod.spec?.nodeName) {
+    if (props.pod.mPod.getSpec()?.nodeName) {
       return (
-        <ConsoleLink type={ConsoleType.node} selector={props.pod.mPod.spec?.nodeName}>
-          {props.pod.mPod.spec?.nodeName}
+        <ConsoleLink type={ConsoleType.node} selector={props.pod.mPod.getSpec()?.nodeName}>
+          {props.pod.mPod.getSpec()?.nodeName}
         </ConsoleLink>
       )
     }
 
-    return props.pod.mPod.status?.hostIP
+    return props.pod.mPod.getStatus()?.hostIP
   }
 
   const containersLabel = (): ReactNode => {
-    const total = props.pod.mPod.spec?.containers.length || 0
+    const total = props.pod.mPod.getSpec()?.containers.length || 0
     return `${total} container${total !== 1 ? 's' : ''}`
   }
 
   const routesLabel = (): ReactNode => {
-    if (!props.pod.mPod.management.status.managed) {
+    if (!props.pod.mPod.getManagement().status.managed) {
       return (
         <Label color='grey' icon={<FontAwesomeIcon icon={faSpinner} spin />} className='pod-item-routes'>
           {`querying routes ...`}
@@ -42,7 +42,7 @@ export const DiscoverPodItem: React.FunctionComponent<DiscoverPodItemProps> = (p
       )
     }
 
-    const error = props.pod.mPod.management.status.error
+    const error = props.pod.mPod.getManagement().status.error
     if (error) {
       return (
         <Label color='red' icon={<CamelRouteIcon />} className='pod-item-routes'>
@@ -51,7 +51,7 @@ export const DiscoverPodItem: React.FunctionComponent<DiscoverPodItemProps> = (p
       )
     }
 
-    const total = props.pod.mPod.management.camel.routes_count
+    const total = props.pod.mPod.getManagement().camel.routes_count
     return (
       <Label color='gold' icon={<CamelRouteIcon />} className='pod-item-routes'>
         {`${total} route${total !== 1 ? 's' : ''}`}

--- a/packages/online-shell/src/discover/context.ts
+++ b/packages/online-shell/src/discover/context.ts
@@ -25,6 +25,12 @@ export function useDisplayItems() {
     const [newDiscoverGroups, newDiscoverPods] = filterAndGroupPods(filters, [...discoverGroups])
     setDiscoverGroups([...newDiscoverGroups])
     setDiscoverPods([...newDiscoverPods])
+
+    newDiscoverGroups.flatMap(discoverGroup =>
+      discoverGroup.replicas.map(discoverPod => discoverPod.mPod.errorNotify()),
+    )
+
+    newDiscoverPods.map(discoverPod => discoverPod.mPod.errorNotify())
   }
 
   useEffect(() => {

--- a/packages/online-shell/src/discover/discover-service.ts
+++ b/packages/online-shell/src/discover/discover-service.ts
@@ -107,7 +107,9 @@ function groupPodsByDeployment(
 
     const theExDiscoverGroups = exDiscoverGroups.filter(group => {
       return (
-        group.uid === pod.getMetadata()?.uid && group.namespace === pod.getMetadata()?.namespace && group.name === ownerRef?.name
+        group.uid === pod.getMetadata()?.uid &&
+        group.namespace === pod.getMetadata()?.namespace &&
+        group.name === ownerRef?.name
       )
     })
 


### PR DESCRIPTION
- fix: Handle jolokia probe failure (#354)
  - managed-pod.ts
    -  Extends the error property of Management to store more detail of errors, ie. messsage and http code
    - error property returned to undefined upon successful connection
    - Modifies the probe function to store the errors that may be generated
  - management-service.ts
    - Moves search into managed-pod
  - DiscoverPodConnect.tsx
    - Adds Error section to display error failure
    - Disables the connect button if a mgmt error has occurred
  - DiscoverPodItem.tsx
    - If error has occurred then display 'unknown routes' label

- fix: Extends the delay in polling for pods in error
  - If a pod cannot be connected to then it has a mgmt error. In that case
      don't keep polling it every 2 seconds but double the delay before
      trying to connect again.
  - managed-pod.ts
    - Adds error polling state for storing both the polling count and the
       threshold
  - management-service.ts
    - If the pod has a management error then increment the error poll count
       and its threshold to increasingly delay before trying again
    - Once it does poll and successfully connects then resets the error poll
       count