### PR TITLE
fix: Sorts out the updating of the Discover component (#397)

### DIFF
--- a/packages/online-shell/src/discover/Discover.tsx
+++ b/packages/online-shell/src/discover/Discover.tsx
@@ -56,25 +56,9 @@ export const Discover: React.FunctionComponent = () => {
     )
   }
 
-  if (discoverGroups.length + discoverPods.length === 0) {
-    return (
-      <PageSection variant={PageSectionVariants.light}>
-        <EmptyState>
-          <EmptyStateIcon icon={CubesIcon} />
-          <Title headingLevel='h1' size='lg'>
-            No Hawtio Containers
-          </Title>
-          <EmptyStateBody>
-            There are no containers running with a port configured whose name is <code>jolokia</code>.
-          </EmptyStateBody>
-        </EmptyState>
-      </PageSection>
-    )
-  }
-
   return (
     <PageSection variant={PageSectionVariants.light}>
-      <Title headingLevel='h1'>Pods</Title>
+      <Title headingLevel='h1'>Hawtio Containers</Title>
 
       <DiscoverContext.Provider
         value={{
@@ -87,6 +71,18 @@ export const Discover: React.FunctionComponent = () => {
         }}
       >
         <DiscoverToolbar />
+
+        {discoverGroups.length + discoverPods.length === 0 && (
+          <EmptyState>
+            <EmptyStateIcon icon={CubesIcon} />
+            <Title headingLevel='h1' size='lg'>
+              No Hawtio Containers
+            </Title>
+            <EmptyStateBody>
+              There are no containers running with a port configured whose name is <code>jolokia</code>.
+            </EmptyStateBody>
+          </EmptyState>
+        )}
 
         {discoverGroups.length > 0 && <DiscoverGroupList />}
 

--- a/packages/online-shell/src/discover/Discover.tsx
+++ b/packages/online-shell/src/discover/Discover.tsx
@@ -17,7 +17,7 @@ import {
 } from '@patternfly/react-core'
 import { CubesIcon } from '@patternfly/react-icons'
 import { HawtioLoadingCard } from '@hawtio/react'
-import * as discoverService from './discover-service'
+import { discoverService } from './discover-service'
 import { DiscoverToolbar } from './DiscoverToolbar'
 import { DiscoverContext, useDisplayItems } from './context'
 import { DiscoverGroupList } from './DiscoverGroupList'

--- a/packages/online-shell/src/discover/DiscoverToolbar.tsx
+++ b/packages/online-shell/src/discover/DiscoverToolbar.tsx
@@ -16,7 +16,6 @@ import {
 import { LongArrowAltUpIcon, LongArrowAltDownIcon } from '@patternfly/react-icons'
 import { DiscoverContext } from './context'
 import { DiscoverItem, TypeFilter } from './globals'
-import { filterAndGroupPods } from './discover-service'
 
 const defaultFilterInputPlaceholder = 'Filter by Name...'
 const headers = ['Name', 'Namespace']
@@ -57,10 +56,6 @@ export const DiscoverToolbar: React.FunctionComponent = () => {
     const emptyFilters: TypeFilter[] = []
     setFilters(emptyFilters)
     setFilterInput('')
-
-    const [newDiscoverGroups, newDiscoverPods] = filterAndGroupPods(emptyFilters, [...discoverGroups])
-    setDiscoverGroups(newDiscoverGroups)
-    setDiscoverPods(newDiscoverPods)
   }
 
   const onSelectFilterType = (
@@ -103,10 +98,6 @@ export const DiscoverToolbar: React.FunctionComponent = () => {
 
     const newFilters = filters.concat(filter)
     setFilters(newFilters)
-
-    const [newDiscoverGroups, newDiscoverPods] = filterAndGroupPods(newFilters, [...discoverGroups])
-    setDiscoverGroups(newDiscoverGroups)
-    setDiscoverPods(newDiscoverPods)
   }
 
   const deleteFilter = (filterChip: string) => {
@@ -115,10 +106,6 @@ export const DiscoverToolbar: React.FunctionComponent = () => {
     })
 
     setFilters(remaining)
-
-    const [newDiscoverGroups, newDiscoverPods] = filterAndGroupPods(remaining, [...discoverGroups])
-    setDiscoverGroups(newDiscoverGroups)
-    setDiscoverPods(newDiscoverPods)
   }
 
   const onSelectSortType = (

--- a/packages/online-shell/src/discover/StatusIcon.tsx
+++ b/packages/online-shell/src/discover/StatusIcon.tsx
@@ -10,7 +10,7 @@ import {
   faTimes,
   faQuestion,
 } from '@fortawesome/free-solid-svg-icons'
-import * as discoverService from './discover-service'
+import { discoverService } from './discover-service'
 import { DiscoverPod } from './globals'
 import './Discover.css'
 

--- a/packages/online-shell/src/discover/context.ts
+++ b/packages/online-shell/src/discover/context.ts
@@ -1,5 +1,4 @@
 import { createContext, useEffect, useRef, useState } from 'react'
-import { k8Api, k8Service } from '@hawtio/online-kubernetes-api'
 import { MgmtActions, isMgmtApiRegistered, mgmtService } from '@hawtio/online-management-api'
 import { filterAndGroupPods } from './discover-service'
 import { DiscoverGroup, DiscoverPod, TypeFilter } from './globals'
@@ -11,7 +10,7 @@ type UpdateListener = () => void
  */
 export function useDisplayItems() {
   const timerRef = useRef<NodeJS.Timeout | null>(null)
-  const [isMounting, setIsMounting] = useState(true)
+  const updateListenerRef = useRef<UpdateListener>()
   const [isLoading, setIsLoading] = useState(true)
   const [error, setError] = useState<Error | null>()
   const [discoverGroups, setDiscoverGroups] = useState<DiscoverGroup[]>([])
@@ -19,7 +18,6 @@ export function useDisplayItems() {
 
   // Set of filters created by filter control and displayed as chips
   const [filters, setFilters] = useState<TypeFilter[]>([])
-  const updateListener = useRef<UpdateListener>()
 
   const organisePods = (discoverGroups: DiscoverGroup[], filters: TypeFilter[]) => {
     const [newDiscoverGroups, newDiscoverPods] = filterAndGroupPods(filters, [...discoverGroups])
@@ -31,65 +29,41 @@ export function useDisplayItems() {
     )
 
     newDiscoverPods.map(discoverPod => discoverPod.mPod.errorNotify())
+    setIsLoading(false)
   }
 
   useEffect(() => {
-    setIsMounting(true)
-
-    const checkLoading = async () => {
-      const mgmtLoaded = await isMgmtApiRegistered()
-
-      if (!mgmtLoaded) return
-
-      if (k8Api.hasError()) {
-        setError(k8Api.error)
-        setIsMounting(false)
+    const waitLoading = async () => {
+      await isMgmtApiRegistered()
+      if (mgmtService.hasError()) {
+        setError(mgmtService.error)
+        setIsLoading(false)
         return
       }
 
-      if (k8Service.hasError()) {
-        setError(k8Service.error)
-        setIsMounting(false)
-        return
+      /*
+      * First pass:
+      *  - mgmtService already has fully initialized pods
+      *  - pods partially updated and waiting to complete data from an update
+      */
+      organisePods(discoverGroups, filters)
+
+      const updateListener = () => {
+        organisePods(discoverGroups, filters)
       }
 
-      //
-      // First-time update pod organisation
-      //
-      organisePods([], [])
-      setIsMounting(false)
+      mgmtService.on(MgmtActions.UPDATED, updateListener)
+      updateListenerRef.current = updateListener
     }
 
-    checkLoading()
-
-    timerRef.current = setTimeout(checkLoading, 1000)
+    timerRef.current = setTimeout(waitLoading, 1000)
 
     return () => {
       if (timerRef.current) clearTimeout(timerRef.current)
+
+      if (updateListenerRef.current) mgmtService.off(MgmtActions.UPDATED, updateListenerRef.current)
     }
   }, []) // One time set-up on mounting
-
-  /*
-   * Hook-up the pod organisation to the UPDATED listener
-   * event of the ManagementService
-   *
-   * Ensures that the number of registered listeners is
-   * managed properly and stale listeners are not left registered
-   */
-  useEffect(() => {
-    const mgmtListener = () => {
-      organisePods(discoverGroups, filters)
-      // Listener inited so loading now complete
-      setIsLoading(false)
-    }
-
-    mgmtService.on(MgmtActions.UPDATED, mgmtListener)
-    updateListener.current = mgmtListener
-
-    return () => {
-      if (updateListener.current) mgmtService.off(MgmtActions.UPDATED, updateListener.current)
-    }
-  }, [isMounting, filters, discoverGroups])
 
   return { error, isLoading, discoverGroups, setDiscoverGroups, discoverPods, setDiscoverPods, filters, setFilters }
 }

--- a/packages/online-shell/src/discover/discover-service.ts
+++ b/packages/online-shell/src/discover/discover-service.ts
@@ -2,156 +2,172 @@ import { OwnerReference } from '@hawtio/online-kubernetes-api'
 import { ManagedPod, mgmtService } from '@hawtio/online-management-api'
 import { DiscoverGroup, DiscoverPod, DiscoverType, TypeFilter } from './globals'
 
-export function unwrap(error: Error): string {
-  if (!error) return 'unknown error'
-
-  if (error.cause instanceof Error) return unwrap(error.cause)
-
-  return error.message
-}
-
-function applyFilter(filter: TypeFilter, pod: ManagedPod): boolean {
-  if (!pod.getMetadata()) return false
-
-  type KubeObjKey = keyof typeof pod.getMetadata
-
-  const podProp = pod.getMetadata[filter.type.toLowerCase() as KubeObjKey] as string
-
-  // Want to filter on this property but value
-  // is null so filter fails
-  if (!podProp) return false
-
-  return podProp.toLowerCase().includes(filter.value.toLowerCase())
-}
-
-function recordValue(values: Record<string, string> | undefined, key: string): string | undefined {
-  if (!values) return undefined
-  return values[key]
-}
-
-function toDiscoverGroup(
-  pod: ManagedPod,
-  owner: OwnerReference,
-  replicas: ManagedPod[],
-  expanded: boolean,
-): DiscoverGroup {
-  const discoverReplicas = [pod, ...replicas].map(replica => createDiscoverPod(replica))
-
-  return {
-    type: DiscoverType.Group,
-    name: owner.name,
-    uid: owner.uid,
-    namespace: pod.getMetadata()?.namespace || '<unknown>',
-    replicas: discoverReplicas || [],
-    expanded: expanded,
-    config: recordValue(pod.getMetadata()?.annotations, 'openshift.io/deployment-config.name'),
-    version: recordValue(pod.getMetadata()?.annotations, 'openshift.io/deployment-config.latest-version'),
-    statefulset: recordValue(pod.getMetadata()?.labels, 'statefulset.kubernetes.io/pod-name'),
-  }
-}
-
-function createDiscoverPod(pod: ManagedPod): DiscoverPod {
-  return {
-    type: DiscoverType.Pod,
-    name: pod.getMetadata()?.name || '<unknown>',
-    uid: pod.getMetadata()?.uid || '<unknown>',
-    namespace: pod.getMetadata()?.namespace || '<unknown>',
-    labels: pod.getMetadata()?.labels || {},
-    annotations: pod.getMetadata()?.annotations || {},
-    mPod: pod,
-  }
-}
-
-function podOwner(pod: ManagedPod): OwnerReference | null {
-  const metadata = pod.getMetadata()
-  if (!metadata || !metadata.ownerReferences) return null
-
-  if (metadata.ownerReferences.length === 0) return null
-
-  return metadata.ownerReferences[0]
-}
-
-function podsWithOwner(remainingPods: ManagedPod[], ownerRef: OwnerReference): ManagedPod[] {
-  if (!remainingPods) return []
-
-  return remainingPods.filter(pod => {
-    const oRef = podOwner(pod)
-    return oRef?.uid === ownerRef.uid
-  })
-}
-
-function groupPodsByDeployment(
-  pods: ManagedPod[],
-  exDiscoverGroups: DiscoverGroup[],
-): [DiscoverGroup[], DiscoverPod[]] {
-  const discoverPods: DiscoverPod[] = []
-  const discoverGroups: DiscoverGroup[] = []
-
-  pods.forEach((pod, index) => {
-    const ownerRef = podOwner(pod)
-    if (!ownerRef || !ownerRef?.uid) {
-      discoverPods.push(createDiscoverPod(pod))
-      return
-    }
-
-    const groups = discoverGroups.filter(group => group.uid === ownerRef.uid)
-    if (groups.length > 0) return // pod already processed into a display group
-
-    /*
-     * Pod has an owner uid but not yet processed
-     */
-
-    // find pods with same owner uid as this one
-    const remainingPods = index < pods.length - 1 ? pods.slice(index + 1) : []
-    const replicas = podsWithOwner(remainingPods, ownerRef)
-
-    const theExDiscoverGroups = exDiscoverGroups.filter(group => {
-      return (
-        group.uid === pod.getMetadata()?.uid &&
-        group.namespace === pod.getMetadata()?.namespace &&
-        group.name === ownerRef?.name
-      )
-    })
-
-    // Determine if group previously expanded
-    const expanded = theExDiscoverGroups.length > 0 ? theExDiscoverGroups[0].expanded : true
-
-    discoverGroups.push(toDiscoverGroup(pod, ownerRef, replicas, expanded))
-  })
-
-  return [discoverGroups, discoverPods]
-}
-
-export function filterAndGroupPods(
-  theFilters: TypeFilter[],
-  currentGroups: DiscoverGroup[],
-): [DiscoverGroup[], DiscoverPod[]] {
-  const pods: ManagedPod[] = mgmtService.pods || []
-
-  if (!theFilters || theFilters.length === 0) return groupPodsByDeployment(pods, currentGroups)
-
-  const filtered = pods.filter(pod => {
-    let status = true
-    for (const filter of theFilters) {
-      if (!applyFilter(filter, pod)) {
-        // service fails filter so return
-        status = false
-        break
-      }
-
-      // service passes this filter so continue
-    }
-    return status
-  })
-
-  return groupPodsByDeployment(filtered, currentGroups)
-}
-
-export function getStatus(pod: DiscoverPod): string {
-  return mgmtService.podStatus(pod.mPod)
-}
-
 export enum ViewType {
   listView = 'listView',
   cardView = 'cardView',
 }
+
+class DiscoverService {
+  private discoverGroups: DiscoverGroup[] = []
+  private discoverPods: DiscoverPod[] = []
+
+  private recordValue(values: Record<string, string> | undefined, key: string): string | undefined {
+    if (!values) return undefined
+    return values[key]
+  }
+
+  private toDiscoverGroup(
+    pod: ManagedPod,
+    owner: OwnerReference,
+    replicas: ManagedPod[],
+    expanded: boolean,
+  ): DiscoverGroup {
+    const discoverReplicas = [pod, ...replicas].map(replica => this.createDiscoverPod(replica))
+    return {
+      type: DiscoverType.Group,
+      name: owner.name,
+      uid: owner.uid,
+      namespace: pod.getMetadata()?.namespace || '<unknown>',
+      replicas: discoverReplicas || [],
+      expanded: expanded,
+      config: this.recordValue(pod.getMetadata()?.annotations, 'openshift.io/deployment-config.name'),
+      version: this.recordValue(pod.getMetadata()?.annotations, 'openshift.io/deployment-config.latest-version'),
+      statefulset: this.recordValue(pod.getMetadata()?.labels, 'statefulset.kubernetes.io/pod-name'),
+    }
+  }
+
+  private createDiscoverPod(pod: ManagedPod): DiscoverPod {
+    return {
+      type: DiscoverType.Pod,
+      name: pod.getMetadata()?.name || '<unknown>',
+      uid: pod.getMetadata()?.uid || '<unknown>',
+      namespace: pod.getMetadata()?.namespace || '<unknown>',
+      labels: pod.getMetadata()?.labels || {},
+      annotations: pod.getMetadata()?.annotations || {},
+      mPod: pod,
+    }
+  }
+
+  private podOwner(pod: ManagedPod): OwnerReference | null {
+    const metadata = pod.getMetadata()
+    if (!metadata || !metadata.ownerReferences) return null
+
+    if (metadata.ownerReferences.length === 0) return null
+
+    return metadata.ownerReferences[0]
+  }
+
+  private podsWithOwner(remainingPods: ManagedPod[], ownerRef: OwnerReference): ManagedPod[] {
+    if (!remainingPods) return []
+
+    return remainingPods.filter(pod => {
+      const oRef = this.podOwner(pod)
+      return oRef?.uid === ownerRef.uid
+    })
+  }
+
+  private groupPodsByDeployment(pods: ManagedPod[]) {
+    const discoverPods: DiscoverPod[] = []
+    const discoverGroups: DiscoverGroup[] = []
+
+    for (let i = 0; i < pods.length; ++i) {
+      const pod = pods[i]
+      const ownerRef = this.podOwner(pod)
+
+      if (!ownerRef || !ownerRef?.uid) {
+        discoverPods.push(this.createDiscoverPod(pod))
+        continue
+      }
+
+      const groups = discoverGroups.filter(group => group.uid === ownerRef.uid)
+      if (groups.length > 0) continue // pod already processed into a display group
+
+      /*
+       * Pod has an owner uid but not yet processed
+       */
+
+      // find pods with same owner uid as this one
+      const remainingPods = i < pods.length - 1 ? pods.slice(i + 1) : []
+      const replicas = this.podsWithOwner(remainingPods, ownerRef)
+
+      const oldDiscoverGroups = this.discoverGroups.filter(group => {
+        return (
+          group.uid === pod.getMetadata()?.uid &&
+          group.namespace === pod.getMetadata()?.namespace &&
+          group.name === ownerRef?.name
+        )
+      })
+
+      // Determine if group previously expanded
+      const expanded = oldDiscoverGroups.length > 0 ? oldDiscoverGroups[0].expanded : true
+
+      discoverGroups.push(this.toDiscoverGroup(pod, ownerRef, replicas, expanded))
+    }
+
+    this.discoverGroups = discoverGroups
+    this.discoverPods = discoverPods
+  }
+
+  private applyFilter(filter: TypeFilter, pod: ManagedPod): boolean {
+    if (!pod.getMetadata()) return false
+
+    const metadata = pod.getMetadata()
+    if (!metadata) return false
+
+    type KubeObjKey = keyof typeof metadata
+
+    const podProp = metadata[filter.type.toLowerCase() as KubeObjKey] as string
+
+    // Want to filter on this property but value
+    // is null so filter fails
+    if (!podProp) return false
+
+    return podProp.toLowerCase().includes(filter.value.toLowerCase())
+  }
+
+  filterAndGroupPods(theFilters: TypeFilter[]): [discoverGroups: DiscoverGroup[], discoverPods: DiscoverPod[]] {
+    const pods: ManagedPod[] = mgmtService.pods || []
+
+    let filtered = pods
+    if (theFilters && theFilters.length > 0) {
+      filtered = pods.filter(pod => {
+        let status = true
+        for (const filter of theFilters) {
+          if (!this.applyFilter(filter, pod)) {
+            // service fails filter so return
+            status = false
+            break
+          }
+
+          // service passes this filter so continue
+        }
+        return status
+      })
+    }
+
+    this.groupPodsByDeployment(filtered)
+
+    /**
+     * Notify event service of any errors in the groups and pods
+     */
+    this.discoverGroups.flatMap(discoverGroup =>
+      discoverGroup.replicas.map(discoverPod => discoverPod.mPod.errorNotify()),
+    )
+
+    this.discoverPods.map(discoverPod => discoverPod.mPod.errorNotify())
+
+    return [this.discoverGroups, this.discoverPods]
+  }
+
+  getStatus(pod: DiscoverPod): string {
+    return mgmtService.podStatus(pod.mPod)
+  }
+
+  unwrap(error: Error): string {
+    if (!error) return 'unknown error'
+    if (error.cause instanceof Error) return this.unwrap(error.cause)
+    return error.message
+  }
+}
+
+export const discoverService = new DiscoverService()


### PR DESCRIPTION
* managed-pod.ts
  * Adds the fingerprint functions from management-service so that the fingerprint can be cached on the pod.
  * Important!! fingerprints the management properties and the original kube pod so that changes to the actual pod can be picked up

* management-service.ts
  * Adds the fireUpdate property to the updateQueue so that the queue knows to fire an update if ANY of the pods need to fire an update.
  * Therefore if the QUEUE not just the last pod needs to fire an update then it should be fired.

* context.ts
  * Merges the 2 useEffects into 1 that both organises pods immediately & upon a management update

* Use Cases:
  - Discover is correctly populated on startup
  - Discover is correctly populated when re-clicked on
  - Discover is correctly updated if a change on a pod occurs in cluster
  - Filter toolbar is retained even if a filter is added that filters out all pods
  - Filter can be removed and all pods correctly updated
  - Filters can be cleared and all pods correctly updated
  - Error properly displayed