### PR TITLE
Fix: Downgrade @types/react to 18.2.64 (#425)

### DIFF
--- a/packages/kubernetes-api-app/package.json
+++ b/packages/kubernetes-api-app/package.json
@@ -17,7 +17,7 @@
     "@patternfly/react-table": "^4.113.7",
     "@patternfly/react-tokens": "^4.94.6",
     "@types/node": "^18.19.28",
-    "@types/react": "^18.2.73",
+    "@types/react": "18.2.64",
     "@types/react-dom": "^18.2.23",
     "mini-css-extract-plugin": "2.8.1",
     "react": "^18.2.0",

--- a/packages/management-api-app/package.json
+++ b/packages/management-api-app/package.json
@@ -17,7 +17,7 @@
     "@patternfly/react-table": "^4.113.7",
     "@patternfly/react-tokens": "^4.94.6",
     "@types/node": "^18.19.28",
-    "@types/react": "^18.2.73",
+    "@types/react": "18.2.64",
     "@types/react-dom": "^18.2.23",
     "mini-css-extract-plugin": "2.8.1",
     "react": "^18.2.0",

--- a/packages/oauth-app/package.json
+++ b/packages/oauth-app/package.json
@@ -17,7 +17,7 @@
     "@patternfly/react-table": "^4.113.7",
     "@patternfly/react-tokens": "^4.94.6",
     "@types/node": "^18.19.28",
-    "@types/react": "^18.2.73",
+    "@types/react": "18.2.64",
     "@types/react-dom": "^18.2.23",
     "mini-css-extract-plugin": "2.8.1",
     "react": "^18.2.0",

--- a/packages/online-shell/package.json
+++ b/packages/online-shell/package.json
@@ -42,7 +42,7 @@
     "@patternfly/react-table": "^4.113.7",
     "@patternfly/react-tokens": "^4.94.6",
     "@types/node": "^18.19.28",
-    "@types/react": "^18.2.73",
+    "@types/react": "18.2.64",
     "@types/react-dom": "^18.2.23",
     "jquery-match-height": "^0.7.2",
     "jsonpath": "^1.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1960,7 +1960,7 @@ __metadata:
     "@patternfly/react-table": "npm:^4.113.7"
     "@patternfly/react-tokens": "npm:^4.94.6"
     "@types/node": "npm:^18.19.28"
-    "@types/react": "npm:^18.2.73"
+    "@types/react": "npm:18.2.64"
     "@types/react-dom": "npm:^18.2.23"
     connect-history-api-fallback: "npm:^2.0.0"
     css-loader: "npm:^6.10.0"
@@ -2031,7 +2031,7 @@ __metadata:
     "@patternfly/react-table": "npm:^4.113.7"
     "@patternfly/react-tokens": "npm:^4.94.6"
     "@types/node": "npm:^18.19.28"
-    "@types/react": "npm:^18.2.73"
+    "@types/react": "npm:18.2.64"
     "@types/react-dom": "npm:^18.2.23"
     connect-history-api-fallback: "npm:^2.0.0"
     css-loader: "npm:^6.10.0"
@@ -2101,7 +2101,7 @@ __metadata:
     "@patternfly/react-table": "npm:^4.113.7"
     "@patternfly/react-tokens": "npm:^4.94.6"
     "@types/node": "npm:^18.19.28"
-    "@types/react": "npm:^18.2.73"
+    "@types/react": "npm:18.2.64"
     "@types/react-dom": "npm:^18.2.23"
     connect-history-api-fallback: "npm:^2.0.0"
     css-loader: "npm:^6.10.0"
@@ -2192,7 +2192,7 @@ __metadata:
     "@patternfly/react-table": "npm:^4.113.7"
     "@patternfly/react-tokens": "npm:^4.94.6"
     "@types/node": "npm:^18.19.28"
-    "@types/react": "npm:^18.2.73"
+    "@types/react": "npm:18.2.64"
     "@types/react-dom": "npm:^18.2.23"
     babel-loader: "npm:^9.1.3"
     connect-history-api-fallback: "npm:^2.0.0"
@@ -3919,13 +3919,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react@npm:^18.2.73":
-  version: 18.2.73
-  resolution: "@types/react@npm:18.2.73"
+"@types/react@npm:18.2.64":
+  version: 18.2.64
+  resolution: "@types/react@npm:18.2.64"
   dependencies:
     "@types/prop-types": "npm:*"
+    "@types/scheduler": "npm:*"
     csstype: "npm:^3.0.2"
-  checksum: 10/799e30e73464dff40e04f4eb7499ebc31f99b1711a69263b9af340af738e35c9cdf53084e3dacc3b21c031aaa0cba1b51f4ba60490204b7abb75f115b841583f
+  checksum: 10/e82bd16660030c9aabdb5027bb9bf69570a90813e4a894c17bfb288978c2b80251def5754e455d72aa3485d99136e1b11b694f78c586e5918e10b3bb09b91b3c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
* Any further increment of @types/react causes compile errors from the Patternfly TableComposable Function Component