### PR TITLE
fix: HAWNG-519 Add the Strict-Transport-Security header to all locations

### DIFF
--- a/docker/nginx-gateway.conf.template
+++ b/docker/nginx-gateway.conf.template
@@ -47,6 +47,9 @@ server {
     # Prevent click jacking attacks
     add_header X-Frame-Options "SAMEORIGIN";
 
+    # Ensure only https is used for this server
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+
     # Only accept newer ssl protocols
     ssl_protocols TLSv1.2 TLSv1.3;
 
@@ -73,12 +76,22 @@ server {
         # preferences and connections but without credentials.
         add_header Clear-Site-Data "\"cache\", \"cookies\"";
         add_header Cache-Control "no-store";
+
+        # Ensure only https is used for this server
+        # Note: must be re-declared since other headers have been added
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+
         return 307 $decodeRedirectUri;
     }
 
     # Static content serving
     location /online {
         add_header location-rule ONLINE always;
+
+        # Ensure only https is used for this server
+        # Note: must be re-declared since other headers have been added
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+
         alias     /usr/share/nginx/html/online;
         try_files $uri$args $uri /online/index.html;
         gzip_static on;
@@ -87,6 +100,11 @@ server {
     # Kubernetes master API reverse proxying
     location /master {
         add_header                    location-rule MASTER always;
+
+        # Ensure only https is used for this server
+        # Note: must be re-declared since other headers have been added
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+
         proxy_pass                    https://kubernetes.default/;
         rewrite                       /master/(.*) /$1 break;
         proxy_pass_request_headers    on;
@@ -102,6 +120,11 @@ server {
 
     location /management {
         add_header                    location-rule MANAGEMENT always;
+
+        # Ensure only https is used for this server
+        # Note: must be re-declared since other headers have been added
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+
         js_content                    gateway.proxyJolokiaAgent;
     }
 
@@ -146,6 +169,7 @@ server {
     # Pod details requests cache
     location /podIP {
         add_header location-rule POD_IP always;
+
         internal;
         proxy_pass                    https://kubernetes.default/;
         rewrite                       /podIP/(.+)/(.+) /api/v1/namespaces/$1/pods/$2 break;
@@ -180,6 +204,11 @@ server {
 
     location @console_redirect {
         add_header Location $upstream_http_location always;
+
+        # Ensure only https is used for this server
+        # Note: must be re-declared since other headers have been added
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+
         return 200;
     }
 }


### PR DESCRIPTION
* The header mandates an HTTPS connection with no initial plain HTTP request/response so ensuring the whole connection is secure.

* While it is inherited but sub-locations, where other add_header properties are defined, it must be re-defined