### PR TITLE
fix: HAWNG-475 - Limits access to the cluster API using a whitelist

### DIFF
--- a/docker/nginx-gateway.conf.template
+++ b/docker/nginx-gateway.conf.template
@@ -105,9 +105,26 @@ server {
         gzip_static on;
     }
 
-    # Kubernetes master API reverse proxying
+    #
+    # External location which checks whether the
+    # requested uri is accessible before redirecting
+    # to the internal /masterinternal
+    #
     location /master {
         add_header                    location-rule MASTER always;
+        js_content                    gateway.proxyMasterGuard;
+    }
+
+    #
+    # Kubernetes master API reverse proxying
+    #
+    # Configured as internal so that all requests should be submitted
+    # through the /master location and checked with the proxyMasterGuard
+    #
+    location /masterinternal {
+        internal;
+
+        add_header                    location-rule MASTER-INTERNAL always;
 
         # Prevent click jacking attacks
         # Note: must be re-declared since other headers have been added
@@ -118,7 +135,7 @@ server {
         add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
 
         proxy_pass                    https://kubernetes.default/;
-        rewrite                       /master/(.*) /$1 break;
+        rewrite                       /masterinternal/(.*) /$1 break;
         proxy_pass_request_headers    on;
         proxy_pass_request_body       on;
         proxy_redirect                off;

--- a/docker/test.js
+++ b/docker/test.js
@@ -11,13 +11,17 @@ var listMBeans = fs.readFileSync('test.listMBeans.json');
 
 function report(code, expectedCode, message) {
   console.log('code:', code);
+  console.log('expected-code:', expectedCode);
   console.log('message:', message, "\n");
 
-  if (code !== expectedCode)
+  if (code !== expectedCode) {
     throw new Error(`Failure: Return status code ${code} does not match expected ${expectedCode}`);
+  }
 }
 
-function callGateway(input) {
+/* === Jolokia Gateway === */
+
+function callJolokiaGateway(input) {
   var options = {
     return: (code, message) => {
       report(code, input.expectedCode, message);
@@ -33,7 +37,7 @@ function callGateway(input) {
 
 function requestWithViewerRoleTest() {
   console.log('=== requestWithViewerRoleTest');
-  return callGateway({
+  return callJolokiaGateway({
     method: 'POST',
     uri: '/management/namespaces/test/pods/https:pod:443/remaining',
     requestBody: JSON.stringify({
@@ -49,7 +53,7 @@ function requestWithViewerRoleTest() {
 
 function bulkRequestWithViewerRoleTest() {
   console.log('=== bulkRequestWithViewerRoleTest');
-  return callGateway({
+  return callJolokiaGateway({
     method: 'POST',
     uri: '/management/namespaces/test/pods/https:pod:443/remaining',
     requestBody: JSON.stringify([
@@ -72,7 +76,7 @@ function bulkRequestWithViewerRoleTest() {
 
 function requestOperationWithArgumentsAndNoRoleTest() {
   console.log('=== requestOperationWithArgumentsAndNoRoleTest');
-  return callGateway({
+  return callJolokiaGateway({
     method: 'POST',
     uri: '/management/namespaces/test/pods/https:pod:443/remaining',
     requestBody: JSON.stringify({
@@ -91,7 +95,7 @@ function requestOperationWithArgumentsAndNoRoleTest() {
 
 function requestOperationWithArgumentsAndViewerRoleTest() {
   console.log('=== requestOperationWithArgumentsAndViewerRoleTest');
-  return callGateway({
+  return callJolokiaGateway({
     method: 'POST',
     uri: '/management/namespaces/test/pods/https:pod:443/remaining',
     requestBody: JSON.stringify({
@@ -111,7 +115,7 @@ function requestOperationWithArgumentsAndViewerRoleTest() {
 
 function searchCamelRoutesTest() {
   console.log('=== searchCamelRoutesTest');
-  return callGateway({
+  return callJolokiaGateway({
     method: 'POST',
     uri: '/management/namespaces/test/pods/https:pod:443/remaining',
     requestBody: JSON.stringify({
@@ -126,7 +130,7 @@ function searchCamelRoutesTest() {
 
 function searchRbacMBeanTest() {
   console.log('=== searchRbacMBeanTest');
-  return callGateway({
+  return callJolokiaGateway({
     method: 'POST',
     uri: '/management/namespaces/test/pods/https:pod:443/remaining',
     requestBody: JSON.stringify({
@@ -141,7 +145,7 @@ function searchRbacMBeanTest() {
 
 function bulkRequestWithInterceptionTest() {
   console.log('=== bulkRequestWithInterceptionTest');
-  return callGateway({
+  return callJolokiaGateway({
     method: 'POST',
     uri: '/management/namespaces/test/pods/https:pod:443/remaining',
     requestBody: JSON.stringify([
@@ -167,7 +171,7 @@ function bulkRequestWithInterceptionTest() {
 
 function canInvokeSingleOperationTest() {
   console.log('=== canInvokeSingleOperationTest');
-  return callGateway({
+  return callJolokiaGateway({
     method: 'POST',
     uri: '/management/namespaces/test/pods/https:pod:443/remaining',
     requestBody: JSON.stringify({
@@ -187,7 +191,7 @@ function canInvokeSingleOperationTest() {
 
 function canInvokeSingleAttributeTest() {
   console.log('=== canInvokeSingleAttributeTest');
-  return callGateway({
+  return callJolokiaGateway({
     method: 'POST',
     uri: '/management/namespaces/test/pods/https:pod:443/remaining',
     requestBody: JSON.stringify({
@@ -207,7 +211,7 @@ function canInvokeSingleAttributeTest() {
 
 function canInvokeMapTest() {
   console.log('=== canInvokeMapTest');
-  return callGateway({
+  return callJolokiaGateway({
     method: 'POST',
     uri: '/management/namespaces/test/pods/https:pod:443/remaining',
     requestBody: JSON.stringify({
@@ -290,6 +294,78 @@ function doWithViewerRole(uri, options) {
   return Promise.resolve(res);
 }
 
+/* === Master Gateway === */
+
+function callMasterGateway(input) {
+  /*
+   * Separate out the args from the uri as per real Request specification
+   */
+  var is_args = input.uri.includes('?');
+  var args = is_args ? input.uri.substring(input.uri.indexOf('?') + 1, input.uri.length) : '';
+  input.uri = is_args ? input.uri.substring(0, input.uri.indexOf('?')) : input.uri;
+
+  var options = {
+    return: (code, message) => {
+      report(code, input.expectedCode, message);
+    },
+    log: (message) => {
+      console.log(message);
+    },
+    headersOut: {},
+    variables: {
+      is_args: is_args,
+      args: args
+    },
+    internalRedirect: (uri) => {
+      console.log(`redirected-uri: ${uri}`, "\n");
+
+      if (input.expectedURI !== uri)
+        throw new Error(`Failure: Redirect uri ${uri} does not match expected uri ${input.expectedURI}`);
+    }
+  }
+
+  var payload = Object.assign(input, options);
+  gateway.proxyMasterGuard(payload);
+}
+
+function canMasterAuthServerMetadataTest() {
+  console.log('=== canMasterAuthServerMetadataTest');
+
+  return callMasterGateway({
+    method: 'GET',
+    uri: '/master/.well-known/oauth-authorization-server',
+    expectedURI: '/masterinternal/.well-known/oauth-authorization-server',
+    expectedCode: 200
+  });
+}
+
+function canMasterApiPodsTest() {
+  console.log('=== canMasterApiPodsTest');
+
+  callMasterGateway({
+    method: 'GET',
+    uri: '/master/api/v1/namespaces/hawtio/pods?watch=true',
+    expectedURI: '/masterinternal/api/v1/namespaces/hawtio/pods?watch=true',
+    expectedCode: 200
+  });
+}
+
+/* Should be illegal - guard should stop it and return a 502 */
+function canMasterApiSecretsTest() {
+  console.log('=== canMasterApiSecretsTest');
+
+  return callMasterGateway({
+    method: 'GET',
+    uri: '/master/api/v1/namespaces/hawtio/secrets',
+    expectedCode: 502
+  });
+}
+
+/* Execute non-promise tests first */
+canMasterAuthServerMetadataTest()
+canMasterApiPodsTest()
+canMasterApiSecretsTest()
+
 Promise.resolve()
   .then(requestWithViewerRoleTest)
   .then(bulkRequestWithViewerRoleTest)
@@ -301,4 +377,3 @@ Promise.resolve()
   .then(canInvokeSingleOperationTest)
   .then(canInvokeSingleAttributeTest)
   .then(canInvokeMapTest)
-  ;


### PR DESCRIPTION
* nginx-gateway.conf.template
  * Changes the master location to first send it through a javascript guard function that determines if the URI is acceptable. Thereby disallowing requests such as secrets and configmaps.

* nginx.js
  * proxyMasterGuard function that checks the given uri against a set of accepted patterns.
    * If pattern not found then return a 502 and error message.
    * If found then internally redirect to the masterinternal location

* test.js
  * Adds tests to check syntax and exercise proxyMasterGuard