### PR TITLE
fix: logging-in should not navigate to auth/logout (#407)

### DIFF
--- a/packages/oauth/src/openshift/osoauth-service.ts
+++ b/packages/oauth/src/openshift/osoauth-service.ts
@@ -4,7 +4,7 @@ import $ from 'jquery'
 import { OAuthProtoService } from '../api'
 import { UserProfile, log } from '../globals'
 import { CLUSTER_CONSOLE_KEY } from '../metadata'
-import { fetchPath, getCookie, isBlank, redirect } from '../utils'
+import { fetchPath, getCookie, isBlank, logoutUri, redirect } from '../utils'
 import {
   CLUSTER_VERSION_KEY,
   DEFAULT_CLUSTER_VERSION,
@@ -237,6 +237,11 @@ export class OSOAuthService implements OAuthProtoService {
     }
 
     const currentURI = new URL(window.location.href)
+    if (currentURI.pathname === logoutUri().pathname) {
+      //Reset the logout path to the base path
+      currentURI.pathname = currentURI.pathname.replace(logoutUri().pathname, '/')
+    }
+
     try {
       this.clearKeepAlive()
 

--- a/packages/oauth/src/utils/urls.ts
+++ b/packages/oauth/src/utils/urls.ts
@@ -38,13 +38,17 @@ async function logoutRedirectAvailable(): Promise<boolean> {
   return true
 }
 
+export function logoutUri(): URL {
+  return new URL(relToAbsUrl(LOGOUT_ENDPOINT))
+}
+
 export function logoutRedirect(redirectUri: URL): void {
   // Have a logout page so append redirect uri to its url
-  const logoutUri = new URL(relToAbsUrl(LOGOUT_ENDPOINT))
-  logoutUri.searchParams.append('redirect_uri', redirectUri.toString())
+  const targetUri = logoutUri()
+  targetUri.searchParams.append('redirect_uri', redirectUri.toString())
 
   logoutRedirectAvailable().then(exists => {
-    if (exists) redirect(logoutUri)
+    if (exists) redirect(targetUri)
     else redirect(redirectUri)
   })
 }


### PR DESCRIPTION
* When the logout button is clicked in development mode, the app navigates to /auth/logout, which in turn sets up a redirect_uri to the root uri. However, redirecting preserves the logout uri as the final target uri and ends up displaying a blank page.

* If the current uri is /auth/logout when creating a login then reset it back to / ensuring that the blank page is never displayed and the app correctly logs in.