### PR TITLE
fix: Use webpack DefinePlugin to inject the package version

### DIFF
--- a/packages/online-shell/package.json
+++ b/packages/online-shell/package.json
@@ -19,10 +19,9 @@
     "react"
   ],
   "scripts": {
-    "start": "webpack serve --hot --mode development --progress --config webpack.config.dev.js",
-    "build": "yarn build:webpack && yarn replace-version",
-    "build:webpack": "webpack --mode production --progress --config webpack.config.prod.js --output-public-path='/online/'",
-    "replace-version": "replace __HAWTIO_ONLINE_PACKAGE_VERSION_PLACEHOLDER__ $npm_package_version ./build -r",
+    "start": "webpack serve --hot --mode development --progress --config webpack.config.dev.js --env PACKAGE_VERSION=$npm_package_version",
+    "build": "yarn build:webpack",
+    "build:webpack": "webpack --mode production --progress --config webpack.config.prod.js --output-public-path='/online/' --env PACKAGE_VERSION=$npm_package_version",
     "test": "jest --watchAll=false --passWithNoTests",
     "test:coverage": "yarn test --coverage",
     "analyze:webpack:dev": "webpack --mode development --analyze --progress --config webpack.config.dev.js --output-public-path='/online/'",
@@ -68,7 +67,6 @@
     "os-browserify": "^0.3.0",
     "path-browserify": "^1.0.1",
     "process": "^0.11.10",
-    "replace": "^1.2.2",
     "source-map-loader": "^5.0.0",
     "style-loader": "^4.0.0",
     "ts-loader": "^9.5.1",

--- a/packages/online-shell/src/bootstrap.tsx
+++ b/packages/online-shell/src/bootstrap.tsx
@@ -17,8 +17,9 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import { discover } from './discover'
 import { reportWebVitals } from './reportWebVitals'
+import { HAWTIO_ONLINE_VERSION } from './constants'
 
-configManager.addProductInfo('Hawtio Online', '__HAWTIO_ONLINE_PACKAGE_VERSION_PLACEHOLDER__')
+configManager.addProductInfo('Hawtio Online', HAWTIO_ONLINE_VERSION)
 
 const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement)
 root.render(<HawtioLoadingPage />)

--- a/packages/online-shell/src/constants.ts
+++ b/packages/online-shell/src/constants.ts
@@ -1,0 +1,9 @@
+/**
+ * Hawtio-Online version number
+ * Injected by build system
+ */
+declare const HAWTIO_ONLINE_PACKAGE_VERSION: string
+
+const HAWTIO_ONLINE_VERSION = HAWTIO_ONLINE_PACKAGE_VERSION
+
+export { HAWTIO_ONLINE_VERSION }

--- a/packages/online-shell/webpack.config.common.js
+++ b/packages/online-shell/webpack.config.common.js
@@ -6,9 +6,10 @@ const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin')
 const path = require('path')
 const { dependencies } = require('./package.json')
 
-const common = (mode, publicPath) => {
+const common = (mode, publicPath, packageVersion) => {
   console.log(`Compilation Mode: ${mode}`)
   console.log(`Public Path: ${publicPath}`)
+  console.log(`Package Version: ${packageVersion}`)
 
   return {
     mode: mode,
@@ -98,6 +99,7 @@ const common = (mode, publicPath) => {
       }),
       new webpack.DefinePlugin({
         'process.env': JSON.stringify(process.env),
+        HAWTIO_ONLINE_PACKAGE_VERSION: JSON.stringify(packageVersion),
       }),
     ],
     output: {

--- a/packages/online-shell/webpack.config.dev.js
+++ b/packages/online-shell/webpack.config.dev.js
@@ -11,7 +11,7 @@ const { common } = require('./webpack.config.common.js')
 // this will update the process.env with environment variables in .env file
 dotenv.config({ path: path.join(__dirname, '.env') })
 
-module.exports = () => {
+module.exports = (env, argv) => {
   const masterKind = process.env.MASTER_KIND || 'kubernetes'
   const clusterAuthType = process.env.CLUSTER_AUTH_TYPE || 'oauth'
 
@@ -52,7 +52,7 @@ module.exports = () => {
   const devPort = process.env.PORT || 2772
   const proxiedMaster = `http://localhost:${devPort}/master`
 
-  return merge(common('development', publicPath), {
+  return merge(common('development', publicPath, env.PACKAGE_VERSION), {
     devtool: 'eval-source-map',
     stats: 'errors-warnings',
 

--- a/packages/online-shell/webpack.config.prod.js
+++ b/packages/online-shell/webpack.config.prod.js
@@ -6,13 +6,13 @@ const { common } = require('./webpack.config.common.js')
 
 const CompressionPlugin = require('compression-webpack-plugin')
 
-module.exports = () => {
+module.exports = (env, argv) => {
   //
   // Prefix path will be determined by the installed web server platform
   //
   const publicPath = '/online'
 
-  return merge(common('production', publicPath), {
+  return merge(common('production', publicPath, env.PACKAGE_VERSION), {
     devtool: 'source-map',
 
     plugins: [

--- a/yarn.lock
+++ b/yarn.lock
@@ -2214,7 +2214,6 @@ __metadata:
     react: "npm:^18.2.0"
     react-dom: "npm:^18.3.1"
     react-markdown: "npm:^8.0.7"
-    replace: "npm:^1.2.2"
     source-map-loader: "npm:^5.0.0"
     style-loader: "npm:^4.0.0"
     ts-loader: "npm:^9.5.1"


### PR DESCRIPTION
* The replace-version of the compiled build directory is not correctly replacing the version placeholder due to it already been compressed in the bundle chunks

* Uses webpack DefinePlugin to inject the version DURING the compile stage of the javascript

* package.json
  * Add env parameter to the start and build executions that provides the npm package version

* webpack.config.[...].js
  * Carry the PACKAGE_VERSION constant through to the DefinePlugin and set the HAWTIO_ONLINE_PACKAGE_VERSION constant to its value

* constants.ts
  * Declare the HAWTIO_ONLINE_PACKAGE_VERSION constant that will be assigned by webpack, assign it to an internal var and export it for use

* bootstrap.tsx
  * Import the version constant and assign it to the product info