### PR TITLE
Fix console links and remove inconsistent link styling

### DIFF
--- a/packages/online-shell/src/console/ConsoleLink.tsx
+++ b/packages/online-shell/src/console/ConsoleLink.tsx
@@ -21,7 +21,7 @@ export const ConsoleLink: React.FunctionComponent<PropsWithChildren<ConsoleLinkP
   return (
     <React.Fragment>
       {url && (
-        <Button href={url.toString()} target='_blank' variant='link' isInline className='console-link'>
+        <Button component='a' href={url.toString()} target='_blank' variant='link' isInline className='console-link'>
           {props.children}
         </Button>
       )}

--- a/packages/online-shell/src/discover/Discover.css
+++ b/packages/online-shell/src/discover/Discover.css
@@ -6,6 +6,11 @@
   justify-content: end;
 }
 
+.pf-v5-c-menu__item a {
+  text-decoration: none;
+  color: unset;
+}
+
 .online-header-toolbar-dropdown {
   border: none;
 }


### PR DESCRIPTION
Patternfly requires for Buttons to have the `component='a'` attribute to respect the `href` attribute https://www.patternfly.org/components/button#links-as-buttons
Removes the underscore from the preferences dropdown of the first link
Closes #503 