### PR TITLE
fix: fix connect plugin overriding pods with same name

### DIFF
--- a/packages/management-api/src/management-service.ts
+++ b/packages/management-api/src/management-service.ts
@@ -290,7 +290,7 @@ export class ManagementService extends EventEmitter {
   }
 
   private connectionKeyName(pod: ManagedPod, container: Container) {
-    return `${pod.getMetadata()?.name}-${container.name}`
+    return `${pod.getMetadata()?.namespace}-${pod.getMetadata()?.name}-${container.name}`
   }
 
   refreshConnections(pod: ManagedPod): string[] {

--- a/packages/online-shell/src/discover/DiscoverGroupList.tsx
+++ b/packages/online-shell/src/discover/DiscoverGroupList.tsx
@@ -24,8 +24,9 @@ export const DiscoverGroupList: React.FunctionComponent = () => {
   return (
     <Accordion asDefinitionList>
       {discoverGroups.map(group => {
+        const key = `${group.name}-${group.namespace}`
         return (
-          <AccordionItem key={'item-' + group.name}>
+          <AccordionItem key={'item-' + key}>
             <AccordionToggle
               onClick={() => {
                 onToggle(group)
@@ -35,7 +36,7 @@ export const DiscoverGroupList: React.FunctionComponent = () => {
             >
               <DiscoverGroupLabel group={group} />
             </AccordionToggle>
-            <AccordionContent id={'item-' + group.name + 'expand'} isHidden={!group.expanded}>
+            <AccordionContent id={'item-' + key + 'expand'} isHidden={!group.expanded}>
               <List isBordered={true} iconSize='large'>
                 {group.replicas.map(replica => (
                   <DiscoverPodItem key={replica.uid} pod={replica} />


### PR DESCRIPTION
The pod were overrriden if they were the same name, now namespaces are added as well so the conflicts shouldn't happen anymore.

Closes #510 