### PR TITLE
Masks IP Addresses in json responses (HAWNG-824)

### DIFF
--- a/docker/gateway/src/jolokia-agent/jolokia-agent.ts
+++ b/docker/gateway/src/jolokia-agent/jolokia-agent.ts
@@ -5,7 +5,7 @@ import * as fs from 'fs'
 import { JolokiaRequest as MBeanRequest } from 'jolokia.js'
 import { logger } from '../logger'
 import { GatewayOptions } from '../globals'
-import { isObject, isError } from '../utils'
+import { isObject, isError, maskIPAddresses } from '../utils'
 import {
   AgentInfo,
   InterceptedResponse,
@@ -62,7 +62,9 @@ function response(agentInfo: AgentInfo, res: SimpleResponse) {
    */
   agentInfo.response.setHeader('content-type', 'application/json')
 
-  agentInfo.response.status(res.status).send(res.body)
+  const maskedResponse = maskIPAddresses(res.body)
+
+  agentInfo.response.status(res.status).send(maskedResponse)
 }
 
 function reject(status: number, body: Record<string, string>): Promise<SimpleResponse> {

--- a/docker/gateway/src/utils.ts
+++ b/docker/gateway/src/utils.ts
@@ -31,3 +31,15 @@ export function toStringArray(value: unknown): string[] {
 export function isError(obj: unknown): obj is Error {
   return obj instanceof Error
 }
+
+// IP Address Regex Matcher
+const ipPattern =
+  /\b(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\b/gm
+
+export function maskIPAddresses(obj: string | object): string {
+  let jsonStr
+  if (isObject(obj)) jsonStr = JSON.stringify(obj)
+  else jsonStr = obj
+
+  return jsonStr.replaceAll(ipPattern, '<masked>')
+}


### PR DESCRIPTION
* gateway-api.ts
  * Adds response interceptor to proxy to capture the body and mask any ip addresses in the body string

* jolokia-agent.ts
  * Before sending back the response, ip addresses are masked in the body

* utils.ts
  * Regex matched and replacement function

* Only response that cannot be masked is the responses from the websockets as these are never intercepted by the express server.