### PR TITLE
feat(security): If user requires, allow ip addresses to be unmasked #661

### DIFF
--- a/charts/hawtio-online/Chart.yaml
+++ b/charts/hawtio-online/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: hawtio-online
 description: A Helm chart for installing HawtIO
 type: application
-version: 1.0.1
-appVersion: 2.3.0
+version: 1.0.2
+appVersion: 2.4.0
 keywords:
   - hawtio
   - camel

--- a/charts/hawtio-online/templates/base/deployment.yml
+++ b/charts/hawtio-online/templates/base/deployment.yml
@@ -97,6 +97,8 @@ spec:
             value: /etc/hawtio/rbac/ACL.yaml
           - name: HAWTIO_ONLINE_GATEWAY_WEB_SERVER
             value: {{ (include "hawtio-online.deployment.scheme" .Values) | lower }}://localhost:{{ include "hawtio-online.deployment.port" .Values }}
+          - name: HAWTIO_ONLINE_MASK_IP_ADDRESSES
+            value: "{{ .Values.maskIPAddresses }}"
 {{- if include "hawtio-online.use.ssl" .Values }}
           - name: HAWTIO_ONLINE_GATEWAY_SSL_KEY
             value: /etc/tls/private/serving/tls.key

--- a/charts/hawtio-online/values.yaml
+++ b/charts/hawtio-online/values.yaml
@@ -9,6 +9,8 @@ hawtconfig: true
 # Use internal SSL [ true | false ]
 #  - Only required if clusterType is k8s
 internalSSL: true
+# Mask IP addresses in application responses [ true | false ]
+maskIPAddresses: true
 
 # The url of the OpenShift Console
 # (only applicable to clusterType: openshift)

--- a/deploy/Makefile
+++ b/deploy/Makefile
@@ -55,6 +55,8 @@ HAWTCONFIG ?= true
 OS_CONSOLE_URL ?=
 # The name of the service-account user
 HAWTIO_USER ?= hawtio-user
+# Whether to mask ip addresses in network responses
+MASK_IP_ADDRESSES ?= true
 
 # Uninstall all hawtio-onlineresources: [true|false]
 UNINSTALL_ALL ?=false
@@ -69,6 +71,7 @@ SSL_DEPLOYMENT_SECRET_PATCH := $(PATCHES)/patch-deployment-ssl-serving-secret.ym
 SSL_DEPLOYMENT_PORTS_PATCH := $(PATCHES)/patch-deployment-ssl-ports.yml
 SSL_SERVICE_PATCH := $(PATCHES)/patch-service-ssl-ports.yml
 SSL_INGRESS_PATCH := patch-ingress-ssl-ports.yml
+MASK_IP_ADDRESSES_PATCH := $(PATCHES)/patch-mask-ip-addresses.yml
 
 #
 # Macro for editing kustomization to define
@@ -175,6 +178,13 @@ else
 endif
 endif
 
+.mask-ip-addresses:
+ifeq ($(MASK_IP_ADDRESSES), false)
+	@$(call add-remove-kind-patch,$(BASE),add,../$(MASK_IP_ADDRESSES_PATCH),Deployment)
+else
+	@$(call add-remove-kind-patch,$(BASE),remove,../$(MASK_IP_ADDRESSES_PATCH),Deployment)
+endif
+
 #---
 #
 #@ install
@@ -197,6 +207,9 @@ endif
 #**                            (only used in 'openshift' cluster type)
 #** INTERNAL_SERVER_SSL:     Set whether SSL should be used for internal server communication
 #**                            (only configurable in 'k8s' -- assumed in 'openshift')
+#** MASK_IP_ADDRESSES:       Set whether to mask IP Addresses in response data
+#**                            [ true | false ]
+#**                            (true by default)
 #** CUSTOM_IMAGE:            Set a custom image to install from
 #** CUSTOM_GATEWAY_IMAGE:    Set a custom gateway image to install from
 #** CUSTOM_VERSION:          Set a custom version to install from
@@ -214,6 +227,8 @@ install: kustomize kubectl
 	@$(call set-kustomize-gateway-image,$(CLUSTER_TYPE)/$(MODE))
 # Configure use of hawtconfig configmap
 	@$(MAKE) -s .hawtconfig
+# Do not mask IP addresses if required
+	@$(MAKE) -s .mask-ip-addresses
 # Set the console url on openshift, if specified
 ifeq ($(CLUSTER_TYPE), openshift)
 	@$(MAKE) -s .openshift-console-url

--- a/deploy/base/deployment.yml
+++ b/deploy/base/deployment.yml
@@ -59,6 +59,8 @@ spec:
               value: /etc/hawtio/rbac/ACL.yaml
             - name: HAWTIO_ONLINE_GATEWAY_WEB_SERVER
               value: http://localhost:8080
+            - name: HAWTIO_ONLINE_MASK_IP_ADDRESSES
+              value: "true"
           ports:
             - name: express
               containerPort: 3000

--- a/deploy/patches/patch-mask-ip-addresses.yml
+++ b/deploy/patches/patch-mask-ip-addresses.yml
@@ -1,0 +1,18 @@
+#
+# Patch to update the deployment to reveal ip addresses
+# only if the user specifically requires.
+# The default is always to mask them.
+#
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hawtio-online
+spec:
+  template:
+    spec:
+      containers:
+        - name: hawtio-online-gateway
+          image: quay.io/hawtio/online-gateway
+          env:
+            - name: HAWTIO_ONLINE_MASK_IP_ADDRESSES
+              value: "false"

--- a/docker/gateway/env.development.defaults
+++ b/docker/gateway/env.development.defaults
@@ -59,3 +59,8 @@ TEST_JOLOKIA_PATH=actuator/jolokia/?ignoreErrors=true&canonicalNaming=false
 # HAWTIO_ONLINE_GATEWAY_SSL_KEY=<path to a valid ssl key file>
 # HAWTIO_ONLINE_GATEWAY_SSL_CERTIFICATE=<path to a valid ssl certificate file>
 # HAWTIO_ONLINE_GATEWAY_SSL_CERTIFICATE_CA=<path to a valid ssl certificate authority file>
+
+#
+# Reveal IP addresses if network traffic
+#
+HAWTIO_ONLINE_MASK_IP_ADDRESSES=true

--- a/docker/gateway/src/gateway-api.ts
+++ b/docker/gateway/src/gateway-api.ts
@@ -49,12 +49,13 @@ const gatewayOptions: GatewayOptions = {
 export const gatewayServer = express()
 
 logger.info('**************************************')
-logger.info(`* Environment:      ${environment}`)
-logger.info(`* App Port:         ${port}`)
-logger.info(`* Web Server:       ${gatewayOptions.websvr}`)
-logger.info(`* Log Level:        ${logger.level}`)
-logger.info(`* SSL Enabled:      ${sslCertificate !== ''}`)
-logger.info(`* RBAC:             ${process.env['HAWTIO_ONLINE_RBAC_ACL'] || 'default'}`)
+logger.info(`* Environment:       ${environment}`)
+logger.info(`* App Port:          ${port}`)
+logger.info(`* Web Server:        ${gatewayOptions.websvr}`)
+logger.info(`* Log Level:         ${logger.level}`)
+logger.info(`* SSL Enabled:       ${sslCertificate !== ''}`)
+logger.info(`* RBAC:              ${process.env['HAWTIO_ONLINE_RBAC_ACL'] || 'default'}`)
+logger.info(`* Mask IP Addresses: ${process.env['HAWTIO_ONLINE_MASK_IP_ADDRESSES'] || 'true'}`)
 logger.info('**************************************')
 
 // Log middleware requests

--- a/docker/gateway/src/utils.test.ts
+++ b/docker/gateway/src/utils.test.ts
@@ -1,0 +1,45 @@
+import { maskIPAddresses } from './utils'
+
+describe('utils', () => {
+  const OLD_ENV = process.env
+  const ip1 = '192.168.126.11'
+  const ip2 = '10.217.0.126'
+  const input = {
+    status: {
+      containerStatuses: {
+        image: 'image-registry.openshift-image-registry.svc:5000/hawtio-dev/camel-sb-4@sha256:19049',
+      },
+      name: 'spring-boot',
+      ready: true,
+      hostIP: ip1,
+      hostIPs: [{ ip: ip1 }],
+      phase: 'Running',
+      podIP: ip2,
+      podIPs: [{ ip: ip2 }],
+    },
+  }
+
+  beforeEach(() => {
+    jest.resetModules() // Most important - it clears the cache
+    process.env = { ...OLD_ENV } // Make a copy
+  })
+
+  afterAll(() => {
+    process.env = OLD_ENV // Restore old environment
+  })
+
+  it('maskIPAddresses-true', () => {
+    process.env.HAWTIO_ONLINE_MASK_IP_ADDRESSES = 'true'
+    const response = maskIPAddresses(input)
+    expect(response).not.toContain(ip1)
+    expect(response).not.toContain(ip2)
+    expect(response).toContain('<masked>')
+  })
+
+  it('maskIPAddresses-false', () => {
+    process.env.HAWTIO_ONLINE_MASK_IP_ADDRESSES = 'false'
+    const response = maskIPAddresses(input)
+    expect(response).toContain(ip1)
+    expect(response).toContain(ip2)
+  })
+})

--- a/docker/gateway/src/utils.ts
+++ b/docker/gateway/src/utils.ts
@@ -41,5 +41,9 @@ export function maskIPAddresses(obj: string | object): string {
   if (isObject(obj)) jsonStr = JSON.stringify(obj)
   else jsonStr = obj
 
+  const shouldMaskIPAddresses = process.env.HAWTIO_ONLINE_MASK_IP_ADDRESSES ?? 'true'
+  // Return jsonStr if masking has been disabled
+  if (shouldMaskIPAddresses.toLowerCase() !== 'true') return jsonStr
+
   return jsonStr.replaceAll(ipPattern, '<masked>')
 }

--- a/docs/install/helm-charts.md
+++ b/docs/install/helm-charts.md
@@ -89,6 +89,8 @@ hawtconfig: true
 # Use internal SSL [ true | false ]
 #  - Only required if clusterType is k8s
 internalSSL: true
+# Mask IP addresses in application responses [ true | false ]
+maskIPAddresses: true
 
 # The url of the OpenShift Console
 # (only applicable to clusterType: openshift)
@@ -166,3 +168,14 @@ $ helm install \
   hawtio-online hawtio/hawtio-online
 ```
 This has the effect of stripping out the _hawtio-serving_ certificate being applied to the internal deployment servers, updates the http protocol to plain rather from SSL and changes the ports to expected plain values.
+
+###### Masking IP Addresses in connection responses
+As a security measure, any IP address patterns contained in json response data are, by default,  masked with the placeholder `<masked>`. Should users wish to disable this masking then the following override the `maskIPAddresses` property:
+```
+$ helm install \
+  --set clusterType=k8s \
+  --set mode=cluster \
+  --set maskIPAddresses=false \
+  hawtio-online hawtio/hawtio-online
+```
+This will set the deployment resource environment variable HAWTIO_ONLINE_MASK_IP_ADDRESSES to false which will disable the ip address masking.

--- a/docs/install/kustomize.md
+++ b/docs/install/kustomize.md
@@ -21,6 +21,9 @@ HAWTCONFIG:              Set whether to use configmap as hawtconfig.json
                            [ true | false ] (true by default)
 INTERNAL_SERVER_SSL:     Set whether SSL should be used for internal server communication
                            (only configurable in 'k8s' -- assumed in 'openshift')
+MASK_IP_ADDRESSES:       Set whether to mask IP Addresses in response data
+                           [ true | false ]
+                           (true by default)
 OS_CONSOLE_URL:          Set the location URL of the openshift console
                            (only used in 'openshift' mode)
 DRY_RUN:                 Print the resources to be applied instead of applying them
@@ -70,5 +73,3 @@ $ CLUSTER_TYPE=k8s make install
 Given the variation of kubernetes implementations, secure communication and access to target applications can also vary. Therefore, at this time only the connection between the client and the Hawtio-Online connection has been secured with SSL encryption. So during the installation, a self-signed certificate is generated and stored in the _hawtio-online-tls-serving_ secret. This is then applied to Hawtio-Online's ingress resource as well as the internal communication between the service and server processes.
 
 In some implementations, it may be preferred to terminate the SSL encryption at the ingress and have unsecured communication internal to the cluster. In that case, set the INTERNAL_SERVER_SSL environment variable to _false_.
-
-


### PR DESCRIPTION
* Request by user to not make ip addresses in network traffic responses

* By default, ip address data is replaced with <masked> before being transmitted from the gateway to the client.

* Includes a variableto control this functionality:
 * MASK_IP_ADDRESSES
