### PR TITLE
HAWNG-1155: Fixes jolokia agent issue where gateway has no rbac confi…

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -5,3 +5,5 @@ dist
 
 # any directories specifically labelled ignore
 **/ignore/**
+
+**/test.invalid.ACL.yaml

--- a/Dockerfile-gateway
+++ b/Dockerfile-gateway
@@ -1,4 +1,4 @@
-FROM node:22-alpine as builder
+FROM docker.io/node:22-alpine as builder
 
 WORKDIR /hawtio-online-gateway
 

--- a/docker/gateway/src/jolokia-agent/index.ts
+++ b/docker/gateway/src/jolokia-agent/index.ts
@@ -1,2 +1,2 @@
-export { enableRbac, proxyJolokiaAgent } from './jolokia-agent'
+export { processRBACEnvVar, proxyJolokiaAgent } from './jolokia-agent'
 export * from './globals'

--- a/docker/gateway/src/jolokia-agent/rbac.ts
+++ b/docker/gateway/src/jolokia-agent/rbac.ts
@@ -563,7 +563,7 @@ function checkACLs(role: string, jolokia: JmxUnionRequest) {
 function checkACL(role: string, jolokia: JmxUnionRequest, name: string) {
   logger.trace(`Checking ACL for role ${role} on request ${jolokia.type} named ${name}`)
 
-  const acl = ACL[name]
+  const acl = ACL ? ACL[name] : null
   if (!acl) {
     return null
   }

--- a/docker/gateway/src/jolokia-agent/test.ACL.yaml
+++ b/docker/gateway/src/jolokia-agent/test.ACL.yaml
@@ -1,0 +1,13 @@
+#
+# Default, generic rules, declared as an ordered map, so that the most specific keys
+# are tested first.
+default:
+  - version: admin, viewer
+  - list: admin, viewer
+  - read: admin, viewer
+  - search: admin, viewer
+  - /list.*/: admin, viewer
+  - /get.*/: admin, viewer
+  - /is.*/: admin, viewer
+  - /set.*/: admin
+  - /.*/: admin

--- a/docker/gateway/src/jolokia-agent/test.invalid.ACL.yaml
+++ b/docker/gateway/src/jolokia-agent/test.invalid.ACL.yaml
@@ -1,0 +1,1 @@
+%%%% This is an invalid yaml file %%%


### PR DESCRIPTION
…gmap

* If an rbac configmap is not defined then the operator does not define the HAWTIO_ONLINE_RBAC_ACL env var. However, this wrongly assumes that the gateway should function with rbac disabled rather that with the default rbac file.

* jolokia-agent.ts
  * Refactor the logic to allow for the following use-cases:
    * RBAC disabled
    * RBAC enabled and use the default RBAC file
    * RBAC enabled and use the custom RBAC file defined by the env var
 * Locates the logic into a pair of functions so the unit tests can be implemented that test the different use-cases

* jolokia-agent.test.ts
  * Adds tests to exercise the different use-cases of processRBACEnvVar