### PR TITLE
Work to make Discovery page more similar to OCP design (#531)

### DIFF
--- a/packages/online-shell/src/discover/Discover.css
+++ b/packages/online-shell/src/discover/Discover.css
@@ -51,6 +51,11 @@
   color: rgb(117, 117, 117);
 }
 
+.pod-item-list-item {
+  display: flex;
+  align-items: center;
+}
+
 .pod-item-name-with-labels {
   flex-grow: 3;
   display: flex;
@@ -90,6 +95,13 @@
   padding-top: 0.1em;
 }
 
+.state-icon-wrapper {
+  display: flex;
+  align-items: center; /* Vertically centers the icon and text */
+  gap: 0.5em;
+  font-size: 0.8rem;
+}
+
 .state-icon {
   border-radius: 50%;
   height: 1.5em;
@@ -98,8 +110,7 @@
 }
 
 .running-state {
-  color: green;
-  background-color: lightcyan;
+  color: black;
 }
 
 .text-danger {

--- a/packages/online-shell/src/discover/DiscoverGroupLabel.tsx
+++ b/packages/online-shell/src/discover/DiscoverGroupLabel.tsx
@@ -81,9 +81,8 @@ export const DiscoverGroupLabel: React.FunctionComponent<DiscoverGroupLabelProps
   return (
     <React.Fragment>
       <Title className='discover-group-label' headingLevel='h3'>
-        {title}
+        {title} {content}
       </Title>
-      {content}
     </React.Fragment>
   )
 }

--- a/packages/online-shell/src/discover/StatusIcon.tsx
+++ b/packages/online-shell/src/discover/StatusIcon.tsx
@@ -19,6 +19,7 @@ interface StatusProps {
 }
 
 interface StatusIconDefinition {
+  text: string
   iconDef: IconDefinition
   spin?: boolean
   beat?: boolean
@@ -28,43 +29,49 @@ interface StatusIconDefinition {
 
 export const StatusIcon: React.FunctionComponent<StatusProps> = (props: StatusProps) => {
   const statusIconDef = (): StatusIconDefinition => {
-    switch (discoverService.getStatus(props.pod)) {
+    const status = discoverService.getStatus(props.pod)
+    const statusDef: StatusIconDefinition = {
+      text: status,
+      iconDef: faQuestion,
+    }
+
+    switch (status) {
       case 'Cancelled':
-        return { iconDef: faBan, className: 'text-muted' }
+        return { ...statusDef, iconDef: faBan, className: 'text-muted' }
       case 'Complete':
-        return { iconDef: faCheck, className: 'text-success' }
+        return { ...statusDef, iconDef: faCheck, className: 'text-success' }
       case 'Completed':
-        return { iconDef: faCheck, className: 'text-success' }
+        return { ...statusDef, iconDef: faCheck, className: 'text-success' }
       case 'Active':
-        return { iconDef: faRefresh }
+        return { ...statusDef, iconDef: faRefresh }
       case 'Error':
-        return { iconDef: faTimes, beat: true, className: 'text-danger' }
+        return { ...statusDef, iconDef: faTimes, beat: true, className: 'text-danger' }
       case 'Failed':
-        return { iconDef: faTimes, beat: true, className: 'text-danger' }
+        return { ...statusDef, iconDef: faTimes, beat: true, className: 'text-danger' }
       case 'New':
-        return { iconDef: faHourglass }
+        return { ...statusDef, iconDef: faHourglass }
       case 'Pending':
-        return { iconDef: faHourglassHalf, beatFade: true }
+        return { ...statusDef, iconDef: faHourglassHalf, beatFade: true }
       case 'Ready':
-        return { iconDef: faCheck, className: 'text-success' }
+        return { ...statusDef, iconDef: faCheck, className: 'text-success' }
       case 'Running':
-        return { iconDef: faRefresh, spin: true, className: 'running-state' }
+        return { ...statusDef, iconDef: faRefresh, spin: true, className: 'running-state' }
       case 'Succeeded':
-        return { iconDef: faCheck, className: 'text-success' }
+        return { ...statusDef, iconDef: faCheck, className: 'text-success' }
       case 'Bound':
-        return { iconDef: faCheck, className: 'text-success' }
+        return { ...statusDef, iconDef: faCheck, className: 'text-success' }
       case 'Terminating':
-        return { iconDef: faTimes, beatFade: true, className: 'text-danger' }
+        return { ...statusDef, iconDef: faTimes, beatFade: true, className: 'text-danger' }
       case 'Terminated':
-        return { iconDef: faTimes, beat: true, className: 'text-danger' }
+        return { ...statusDef, iconDef: faTimes, beat: true, className: 'text-danger' }
       case 'Unknown':
-        return { iconDef: faQuestion, beatFade: true, className: 'text-danger' }
+        return { ...statusDef, iconDef: faQuestion, beatFade: true, className: 'text-danger' }
 
       // Container Runtime States
       case 'Init Error':
-        return { iconDef: faTimes, className: 'text-danger' }
+        return { ...statusDef, iconDef: faTimes, className: 'text-danger' }
       case 'ContainerCreating':
-        return { iconDef: faHourglassHalf, beatFade: true }
+        return { ...statusDef, iconDef: faHourglassHalf, beatFade: true }
       case 'CrashLoopBackOff':
       case 'ImagePullBackOff':
       case 'ImageInspectError':
@@ -78,23 +85,26 @@ export const StatusIcon: React.FunctionComponent<StatusProps> = (props: StatusPr
       case 'SetupNetworkError':
       case 'TeardownNetworkError':
       case 'DeadlineExceeded':
-        return { iconDef: faTimes, beat: true, className: 'text-danger' }
+        return { ...statusDef, iconDef: faTimes, beat: true, className: 'text-danger' }
       case 'PodInitializing':
-        return { iconDef: faHourglassHalf, beatFade: true }
+        return { ...statusDef, iconDef: faHourglassHalf, beatFade: true }
       default:
-        return { iconDef: faQuestion }
+        return { ...statusDef, iconDef: faQuestion }
     }
   }
 
   const defn = statusIconDef()
 
   return (
-    <FontAwesomeIcon
-      className={'state-icon ' + defn.className}
-      icon={defn.iconDef}
-      beat={defn.beat ? defn.beat : false}
-      spin={defn.spin ? defn.spin : false}
-      title={discoverService.getStatus(props.pod)}
-    />
+    <span className='state-icon-wrapper'>
+      <FontAwesomeIcon
+        className={'state-icon ' + defn.className}
+        icon={defn.iconDef}
+        beat={defn.beat ? defn.beat : false}
+        spin={defn.spin ? defn.spin : false}
+        title={defn.text}
+      />
+      <span className='state-text'>{defn.text}</span>
+    </span>
   )
 }


### PR DESCRIPTION
This doesn't try and clone the Pod page of OCP exactly but adds some characteristics that are similar but also useful to the Discover component. 

* Make status icons smaller and add the status text adjacent to them

* Modifies pod container label to show how many containers in the pod are ready in the form ${ready}/${total}

* Moves the group name up to the same level as the group type so the item as a whole takes up less vertical space