### PR TITLE
fix: Improves the error handling and tracing in the gateway

### DIFF
--- a/docker/gateway/src/jolokia-agent/globals.ts
+++ b/docker/gateway/src/jolokia-agent/globals.ts
@@ -91,6 +91,8 @@ export interface SimpleResponse {
 }
 
 export function isSimpleResponse(obj: unknown): obj is SimpleResponse {
+  if (!obj) return false
+
   return (
     (obj as SimpleResponse).status !== undefined &&
     (obj as SimpleResponse).body !== undefined &&
@@ -99,6 +101,8 @@ export function isSimpleResponse(obj: unknown): obj is SimpleResponse {
 }
 
 export function isResponse(obj: unknown): obj is Response {
+  if (!obj) return false
+
   return (
     (obj as Response).status !== undefined &&
     (obj as Response).statusText !== undefined &&

--- a/docker/gateway/src/utils.ts
+++ b/docker/gateway/src/utils.ts
@@ -37,6 +37,8 @@ const ipPattern =
   /\b(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\b/gm
 
 export function maskIPAddresses(obj: string | object): string {
+  if (!obj) return ''
+
   let jsonStr
   if (isObject(obj)) jsonStr = JSON.stringify(obj)
   else jsonStr = obj


### PR DESCRIPTION
* globals.ts
 * Handle possibility of the object being tested by guard functions being null or undefined

* jolokia-agent.ts
 * Rejecting a promise with an object is considered an anti-pattern. Far better to reject with an error. Even better in async functions to throw rather than reject.
 * Consistently converts all rejections into SimpleResponseErrors which when caught ensure that the response status, statusText and body properties are captured in both the logs and the json returned by the response.