### PR TITLE
HAWNG-1248: Fixes invalid XML characters in ip mask

### DIFF
--- a/docker/gateway/src/utils.test.ts
+++ b/docker/gateway/src/utils.test.ts
@@ -1,4 +1,4 @@
-import { maskIPAddresses } from './utils'
+import { IP_ADDRESS_MASK, maskIPAddresses } from './utils'
 
 describe('utils', () => {
   const OLD_ENV = process.env
@@ -33,7 +33,7 @@ describe('utils', () => {
     const response = maskIPAddresses(input)
     expect(response).not.toContain(ip1)
     expect(response).not.toContain(ip2)
-    expect(response).toContain('<masked>')
+    expect(response).toContain(IP_ADDRESS_MASK)
   })
 
   it('maskIPAddresses-false', () => {

--- a/docker/gateway/src/utils.ts
+++ b/docker/gateway/src/utils.ts
@@ -1,3 +1,5 @@
+export const IP_ADDRESS_MASK = '***.***.***.***'
+
 export function isObject(value: unknown): value is object {
   if (!value) return false
 
@@ -47,5 +49,5 @@ export function maskIPAddresses(obj: string | object): string {
   // Return jsonStr if masking has been disabled
   if (shouldMaskIPAddresses.toLowerCase() !== 'true') return jsonStr
 
-  return jsonStr.replaceAll(ipPattern, '<masked>')
+  return jsonStr.replaceAll(ipPattern, IP_ADDRESS_MASK)
 }


### PR DESCRIPTION
* '<' and '>' are invalid in xml strings since used for tags so replace the masking syntax with something much safer and less likely to fail parsing.