### PR TITLE
HAWNG-1485: Sets the default of masking ip addresses to reveal

### DIFF
--- a/charts/hawtio-online/values.yaml
+++ b/charts/hawtio-online/values.yaml
@@ -10,7 +10,7 @@ hawtconfig: true
 #  - Only required if clusterType is k8s
 internalSSL: true
 # Mask IP addresses in application responses [ true | false ]
-maskIPAddresses: true
+maskIPAddresses: false
 
 # The url of the OpenShift Console
 # (only applicable to clusterType: openshift)

--- a/deploy/Makefile
+++ b/deploy/Makefile
@@ -56,7 +56,7 @@ OS_CONSOLE_URL ?=
 # The name of the service-account user
 HAWTIO_USER ?= hawtio-user
 # Whether to mask ip addresses in network responses
-MASK_IP_ADDRESSES ?= true
+MASK_IP_ADDRESSES ?= false
 # The Log Level of the hawtio-online server
 ONLINE_LOG_LEVEL ?= info
 # The Log Level of the hawtio gateway server
@@ -186,7 +186,7 @@ endif
 endif
 
 .mask-ip-addresses:
-ifeq ($(MASK_IP_ADDRESSES), false)
+ifeq ($(MASK_IP_ADDRESSES), true)
 	@$(call add-remove-kind-patch,$(BASE),add,../$(MASK_IP_ADDRESSES_PATCH),Deployment)
 else
 	@$(call add-remove-kind-patch,$(BASE),remove,../$(MASK_IP_ADDRESSES_PATCH),Deployment)

--- a/deploy/patches/patch-mask-ip-addresses.yml
+++ b/deploy/patches/patch-mask-ip-addresses.yml
@@ -1,7 +1,7 @@
 #
-# Patch to update the deployment to reveal ip addresses
+# Patch to update the deployment to mask ip addresses
 # only if the user specifically requires.
-# The default is always to mask them.
+# The default is not to mask them.
 #
 apiVersion: apps/v1
 kind: Deployment
@@ -15,4 +15,4 @@ spec:
           image: quay.io/hawtio/online-gateway
           env:
             - name: HAWTIO_ONLINE_MASK_IP_ADDRESSES
-              value: "false"
+              value: "true"

--- a/docker/gateway/env.development.defaults
+++ b/docker/gateway/env.development.defaults
@@ -64,6 +64,6 @@ TEST_JOLOKIA_PATH=actuator/jolokia/?ignoreErrors=true&canonicalNaming=false
 # HAWTIO_ONLINE_GATEWAY_SSL_CERTIFICATE_CA=<path to a valid ssl certificate authority file>
 
 #
-# Reveal IP addresses if network traffic
+# Reveal IP addresses in network traffic
 #
-HAWTIO_ONLINE_MASK_IP_ADDRESSES=true
+HAWTIO_ONLINE_MASK_IP_ADDRESSES=false

--- a/docker/gateway/src/gateway-api.ts
+++ b/docker/gateway/src/gateway-api.ts
@@ -54,8 +54,8 @@ logger.info(`* App Port:          ${port}`)
 logger.info(`* Web Server:        ${gatewayOptions.websvr}`)
 logger.info(`* Log Level:         ${logger.level}`)
 logger.info(`* SSL Enabled:       ${sslCertificate !== ''}`)
-logger.info(`* RBAC:              ${process.env['HAWTIO_ONLINE_RBAC_ACL'] || 'default'}`)
-logger.info(`* Mask IP Addresses: ${process.env['HAWTIO_ONLINE_MASK_IP_ADDRESSES'] || 'true'}`)
+logger.info(`* RBAC:              ${process.env['HAWTIO_ONLINE_RBAC_ACL'] ?? 'default'}`)
+logger.info(`* Mask IP Addresses: ${process.env['HAWTIO_ONLINE_MASK_IP_ADDRESSES'] ?? 'false'}`)
 logger.info('**************************************')
 
 // Log middleware requests

--- a/docker/gateway/src/utils.ts
+++ b/docker/gateway/src/utils.ts
@@ -45,7 +45,8 @@ export function maskIPAddresses(obj: string | object): string {
   if (isObject(obj)) jsonStr = JSON.stringify(obj)
   else jsonStr = obj
 
-  const shouldMaskIPAddresses = process.env.HAWTIO_ONLINE_MASK_IP_ADDRESSES ?? 'true'
+  // Enable masking only if env var has been specified
+  const shouldMaskIPAddresses = process.env.HAWTIO_ONLINE_MASK_IP_ADDRESSES ?? 'false'
   // Return jsonStr if masking has been disabled
   if (shouldMaskIPAddresses.toLowerCase() !== 'true') return jsonStr
 


### PR DESCRIPTION
* Helm
  * Changes the default value of the maskIPAddresses flag to false

* Makefile
  * Changes the default value of MASK_IP_ADDRESSESS to false
  * Inflects logic by only adding a mask ip patch if the value of the flag is true
  * Inflects intent of patch by making the latter set the env var to true which will only get applied if the user wants to mask ip addresses

* utils.ts
  * Inflects the logic that if the env var is not specified then the value of the flag is false and no masking is performed

* jolokia-agent.test.ts
  * Unit tests to confirm default behaviour