### PR TITLE
fix: Switches JsonPathCodegen to JsonPathEval (#832)

### DIFF
--- a/packages/kubernetes-api/src/client/namespace-client.ts
+++ b/packages/kubernetes-api/src/client/namespace-client.ts
@@ -1,4 +1,4 @@
-import { JsonPathCodegen } from '@jsonjoy.com/json-path'
+import { JsonPathEval } from '@jsonjoy.com/json-path'
 import { JOLOKIA_PORT_QUERY, KubeObject, KubePod, Paging, log } from '../globals'
 import { TypeFilter } from '../filter'
 import { WatchTypes } from '../model'
@@ -24,8 +24,6 @@ export interface PodWatchers {
 }
 
 export class NamespaceClient implements Paging {
-  private static jsonQueryFn = JsonPathCodegen.compile(JOLOKIA_PORT_QUERY)
-
   private _current = 0
 
   private _podList: Set<string> = new Set<string>()
@@ -228,7 +226,7 @@ export class NamespaceClient implements Paging {
       const podNames: string[] = []
       pods
         .filter(pod => {
-          const matches = NamespaceClient.jsonQueryFn(pod)
+          const matches = JsonPathEval.run(JOLOKIA_PORT_QUERY, pod)
           return matches && matches.length > 0
         })
         .forEach(pod => {

--- a/packages/management-api/src/managed-pod.ts
+++ b/packages/management-api/src/managed-pod.ts
@@ -5,7 +5,7 @@ import {
 } from 'jolokia.js'
 import Jolokia from '@jolokia.js/simple'
 import { eventService } from '@hawtio/react'
-import { JsonPathCodegen } from '@jsonjoy.com/json-path'
+import { JsonPathEval } from '@jsonjoy.com/json-path'
 import {
   k8Api,
   KubePod,
@@ -78,8 +78,6 @@ export class ManagedPod {
     return defaultValue
   }
 
-  static jsonQueryFn = JsonPathCodegen.compile(JOLOKIA_PORT_QUERY)
-
   static getJolokiaPath(pod: KubePod, port: number): string | null {
     if (!k8Api.masterUri()) {
       return null
@@ -103,7 +101,7 @@ export class ManagedPod {
   }
 
   private extractPort(pod: KubePod): number {
-    const portsValue = ManagedPod.jsonQueryFn(pod)
+    const portsValue = JsonPathEval.run(JOLOKIA_PORT_QUERY, pod)
     if (!portsValue || portsValue.length === 0) return ManagedPod.DEFAULT_JOLOKIA_PORT
 
     const node = portsValue[0] as unknown as { data?: { containerPort?: number } }


### PR DESCRIPTION
* To address the errors generated, stopping Hawtio loading, switch from JIT code generation to AST path evaluation, which is not so efficient but acceptable to CSP security paramaters.