### PR TITLE
Fix generate certificate docs link

### DIFF
--- a/docs/install/manual.md
+++ b/docs/install/manual.md
@@ -64,7 +64,7 @@ You can optionally pass `SECRET_NAME` and `CN` to customise the secret name and 
 
 Instead of running the scripts you can choose to perform everything manually.
 
-For manual steps, see [Generating Certificates Manually](docs/generate-certificates.md).
+For manual steps, see [Generating Certificates Manually](../generate-certificates.md).
 
 ## Deployment
 


### PR DESCRIPTION
Fix broken relative link in `docs/install/manual.md`.

Previous link resolved to `docs/install/docs/generate-certificates.md`.
This updates it to point to `docs/generate-certificates.md`.