### PR TITLE
HAWNG-2228: Corrects the real_ip_from settings in the nginx config

### DIFF
--- a/deploy/patches/override-nginx-config/hawtio-nginx-override-configmap.yml
+++ b/deploy/patches/override-nginx-config/hawtio-nginx-override-configmap.yml
@@ -1,0 +1,269 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: hawtio-nginx-template-override
+data:
+  nginx-gateway.conf.template: |
+    # vim: set filetype=nginx:
+
+    error_log /dev/stderr ${NGINX_LOG_LEVEL};
+
+    # IP Resolution
+    real_ip_header X-Forwarded-For;
+
+    #
+    # Overridden hardcoded variable
+    # Set to the class of the IP address of the
+    # hawtio-online pod / nginx server, eg.
+    # if ip is identified as 10.217.0.137
+    # then set to 10.0.0.0/8
+    #
+    set_real_ip_from 10.0.0.0/8;
+
+    # Define Zones
+
+    # Zone A: Sensitive APIs (Login, Management)
+    # Strict: 10 reqs/sec. Good for brute-force protection.
+    limit_req_zone $binary_remote_addr zone=api_limit:10m rate=10r/s;
+
+    # Zone B: Static Assets (Files)
+    # Fast: 50 reqs/sec.
+    limit_req_zone $binary_remote_addr zone=static_limit:10m rate=50r/s;
+
+    # Zone C: Kubernetes Proxy (High Traffic) - NEW
+    # We allow a high rate (30r/s) because the dashboard is chatty.
+    limit_req_zone $binary_remote_addr zone=proxy_limit:10m rate=30r/s;
+
+    # Zone D: Connections
+    limit_conn_zone $binary_remote_addr zone=addr_conn:10m;
+
+    proxy_cache_path /var/cache/nginx/pods levels=1:2 keys_zone=pods:2m max_size=4m inactive=60m use_temp_path=off;
+    proxy_cache_path /var/cache/nginx/rbac levels=1:2 keys_zone=rbac:256k max_size=3m inactive=60m use_temp_path=off;
+    proxy_cache_path /var/cache/nginx/rbac2 levels=1:2 keys_zone=rbac2:256k max_size=3m inactive=60m use_temp_path=off;
+
+    map $uri $new {
+        / /online/;
+        /online /online/;
+    }
+
+    map $http_upgrade $connection_upgrade {
+        default upgrade;
+        ''      close;
+    }
+
+    server {
+        listen              ${LISTEN_SERVER_PORT};
+        server_name         localhost;
+        ${SERVING_SSL_CERTIFICATE}
+        ${SERVING_SSL_KEY}
+        absolute_redirect   off;
+        gzip                on;
+        gzip_types text/plain application/javascript text/javascript;
+        root                /usr/share/nginx/html/;
+
+        # Keep the tunnel open for 1 hour even if silent
+        proxy_read_timeout 3600s;
+        proxy_send_timeout 3600s;
+        # Limit the keepalive of connections (60s default)
+        keepalive_timeout 60s;
+
+        # Do not show server version
+        server_tokens off;
+
+        # Performance tuning
+        subrequest_output_buffer_size ${NGINX_SUBREQUEST_OUTPUT_BUFFER_SIZE};
+        client_body_buffer_size       ${NGINX_CLIENT_BODY_BUFFER_SIZE};
+        proxy_buffers                 ${NGINX_PROXY_BUFFERS};
+
+        # For debugging location rewrite
+        #rewrite_log on;
+
+        if ($request_method !~ ^(GET|HEAD|POST)$ ) {
+          return 444;
+        }
+
+        include /etc/nginx/includes/security-headers-common.conf;
+
+        # Only accept newer ssl protocols (if applicable)
+        ${SERVING_SSL_PROTOCOLS}
+
+        if ($new) {
+            rewrite ^ $new redirect;
+        }
+
+        error_page 403 /hawtio-403.html;
+        location = /hawtio-403.html {
+            internal;
+        }
+
+        error_page 404 /hawtio-404.html;
+        location = /hawtio-404.html {
+            internal;
+        }
+
+        error_page 500 502 503 504 /hawtio-50x.html;
+        location = /hawtio-50x.html {
+            internal;
+        }
+
+        location /auth/logout {
+            limit_req zone=api_limit burst=20 nodelay;
+
+            if ( $arg_redirect_uri = '') {
+              return 200 "Acknowledge logout but nothing further to do";
+            }
+
+            include /etc/nginx/includes/clear-storage-headers.conf;
+            include /etc/nginx/includes/security-headers-common.conf;
+
+            proxy_pass                    ${HAWTIO_ONLINE_GATEWAY_APP_PROTOCOL}://localhost:${HAWTIO_ONLINE_GATEWAY_APP_PORT}/logout;
+            proxy_pass_request_headers    on;
+            proxy_pass_request_body       on;
+            proxy_redirect                off;
+            proxy_ssl_verify              off;
+            proxy_ssl_trusted_certificate /var/run/secrets/kubernetes.io/serviceaccount/ca.crt;
+            proxy_ssl_session_reuse       on;
+            proxy_http_version            1.1;
+            proxy_set_header Upgrade      $http_upgrade;
+            proxy_set_header Connection   $connection_upgrade;
+        }
+
+        # Static content serving
+        location /online {
+            # Allow a big burst (100) and high rate (50r/s) for requests.
+            # This stops a dedicated DoS scripts not a browser.
+            limit_req zone=static_limit burst=100 nodelay;
+
+            add_header location-rule ONLINE always;
+            include /etc/nginx/includes/security-headers-online.conf;
+
+            alias     /usr/share/nginx/html/online;
+            try_files $uri$args $uri /online/index.html;
+            gzip_static on;
+        }
+
+        #
+        # External location that passes control to the gateway
+        # server which checks the URI is approved then proxies
+        # to the kubernetes api server
+        #
+        location ~ ^/master/(.*) {
+            # burst uses the injected value to allow the dashboard
+            # to fire an initial number of requests (default: 5000)
+            # instantly without error.
+            limit_req zone=proxy_limit burst=${NGINX_MASTER_BURST} nodelay;
+
+            add_header                    location-rule MASTER always;
+            include /etc/nginx/includes/security-headers-common.conf;
+
+            proxy_pass                    ${HAWTIO_ONLINE_GATEWAY_APP_PROTOCOL}://localhost:${HAWTIO_ONLINE_GATEWAY_APP_PORT}/master/$1$is_args$args;
+            proxy_pass_request_headers    on;
+            proxy_pass_request_body       on;
+            proxy_redirect                off;
+            proxy_ssl_verify              off;
+            proxy_ssl_trusted_certificate /var/run/secrets/kubernetes.io/serviceaccount/ca.crt;
+            proxy_ssl_session_reuse       on;
+            proxy_http_version            1.1;
+            proxy_set_header Upgrade      $http_upgrade;
+            proxy_set_header Connection   $connection_upgrade;
+        }
+
+        location /management {
+            limit_req zone=api_limit burst=50 nodelay;
+
+            add_header                    location-rule MANAGEMENT always;
+
+            include /etc/nginx/includes/security-headers-common.conf;
+
+            proxy_pass                    ${HAWTIO_ONLINE_GATEWAY_APP_PROTOCOL}://localhost:${HAWTIO_ONLINE_GATEWAY_APP_PORT}/management;
+            proxy_pass_request_headers    on;
+            proxy_pass_request_body       on;
+            proxy_redirect                off;
+            proxy_ssl_verify              off;
+            proxy_ssl_trusted_certificate /var/run/secrets/kubernetes.io/serviceaccount/ca.crt;
+            proxy_ssl_session_reuse       on;
+            proxy_http_version            1.1;
+            proxy_set_header Upgrade      $http_upgrade;
+            proxy_set_header Connection   $connection_upgrade;
+        }
+
+        # Self-LocalSubjectAccessReview requests cache
+        location /authorization {
+            allow 127.0.0.1;
+            allow ::1;
+            deny all;
+
+            proxy_pass                    https://kubernetes.default/;
+            rewrite                       /authorization/([^/]+)/(.*) /apis/$1/v1/$2 break;
+            proxy_set_header              Content-Type application/json;
+            proxy_pass_request_headers    on;
+            proxy_pass_request_body       on;
+            proxy_redirect                off;
+            proxy_ssl_verify              on;
+            proxy_ssl_trusted_certificate /var/run/secrets/kubernetes.io/serviceaccount/ca.crt;
+            proxy_ssl_session_reuse       on;
+            proxy_cache                   rbac;
+            proxy_cache_methods           POST;
+            proxy_cache_key               $uri$is_args$args|$http_authorization;
+            proxy_cache_valid             201 10s;
+            proxy_ignore_headers          Cache-Control;
+        }
+
+        # Duplicated location, as it seems caching does not handle multiple sub-requests calling the same location
+        # leading to different hash keys :(
+        location /authorization2 {
+            allow 127.0.0.1;
+            allow ::1;
+            deny all;
+
+            proxy_pass                    https://kubernetes.default/;
+            rewrite                       /authorization2/([^/]+)/(.*) /apis/$1/v1/$2 break;
+            proxy_set_header              Content-Type application/json;
+            proxy_pass_request_headers    on;
+            proxy_pass_request_body       on;
+            proxy_redirect                off;
+            proxy_ssl_verify              on;
+            proxy_ssl_trusted_certificate /var/run/secrets/kubernetes.io/serviceaccount/ca.crt;
+            proxy_ssl_session_reuse       on;
+            proxy_cache                   rbac2;
+            proxy_cache_methods           POST;
+            proxy_cache_key               $uri$is_args$args|$http_authorization;
+            proxy_cache_valid             201 10s;
+            proxy_ignore_headers          Cache-Control;
+        }
+
+        # Pod details requests cache
+        location /podIP {
+            allow 127.0.0.1;
+            allow ::1;
+            deny all;
+
+            add_header location-rule POD_IP always;
+
+            proxy_pass                    https://kubernetes.default/;
+            rewrite                       /podIP/(.+)/(.+) /api/v1/namespaces/$1/pods/$2 break;
+            proxy_pass_request_headers    on;
+            proxy_redirect                off;
+            proxy_ssl_verify              on;
+            proxy_ssl_trusted_certificate /var/run/secrets/kubernetes.io/serviceaccount/ca.crt;
+            proxy_ssl_session_reuse       on;
+            proxy_cache                   pods;
+            proxy_cache_valid             200 1m;
+            proxy_ignore_headers          Cache-Control;
+        }
+
+        # Proxy pod addressed by podIP
+        location ~ ^/proxy/(http|https):(.+):(\d+)/(.*)$ {
+            allow 127.0.0.1;
+            allow ::1;
+            deny all;
+
+            proxy_pass                $1://$2:$3/$4$is_args$args;
+            proxy_ssl_verify          off;
+            proxy_ssl_session_reuse   on;
+            ${PROXY_SSL_CERTIFICATE}
+            ${PROXY_SSL_KEY}
+            # Do not foward authorization header
+            proxy_set_header          Authorization "";
+        }
+    }

--- a/deploy/patches/override-nginx-config/patch-deployment-nginx-config.yml
+++ b/deploy/patches/override-nginx-config/patch-deployment-nginx-config.yml
@@ -1,0 +1,22 @@
+#
+# Patch to update the deployment
+# to add a custom nginx config from
+# a configmap
+#
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hawtio-online
+spec:
+  template:
+    spec:
+      containers:
+        - name: hawtio-online
+          volumeMounts:
+            - name: nginx-template-override
+              mountPath: /nginx-gateway.conf.template
+              subPath: nginx-gateway.conf.template
+      volumes:
+        - name: nginx-template-override
+          configMap:
+            name: hawtio-nginx-template-override

--- a/docker/nginx-gateway.conf.template
+++ b/docker/nginx-gateway.conf.template
@@ -2,9 +2,14 @@
 
 error_log /dev/stderr ${NGINX_LOG_LEVEL};
 
+# Traverse proxy chains safely
+real_ip_recursive on;
+
 # IP Resolution
 real_ip_header X-Forwarded-For;
-set_real_ip_from ${REAL_IP_FROM};
+
+# Trust ONLY the upstream Ingress Controller / Router subnet
+set_real_ip_from ${CUSTOM_POD_NETWORK};
 
 # Define Zones
 

--- a/docker/nginx.sh
+++ b/docker/nginx.sh
@@ -47,25 +47,32 @@ generate_nginx_gateway_conf() {
   # Get the local IP (handle cases where hostname -i returns multiple IPs)
   LOCAL_IP=$(awk 'END{print $1}' /etc/hosts)
 
-  # Extract the first octet (e.g., 10, 172, 192)
-  FIRST_OCTET=$(echo "${LOCAL_IP}" | cut -d'.' -f1)
-  if [ "${FIRST_OCTET}" = "10" ]; then
-     # Class A Private Network
-     export REAL_IP_FROM="10.0.0.0/8"
-  elif [ "${FIRST_OCTET}" = "172" ]; then
-     # Class B Private Network
-     export REAL_IP_FROM="172.16.0.0/12"
-  elif [ "${FIRST_OCTET}" = "192" ]; then
-     # Class C Private Network
-     export REAL_IP_FROM="192.168.0.0/16"
+  # Secure Default: If HAWTIO_TRUSTED_NETWORK_SUBNET is not explicitly
+  # provided by the operator, limit trust strictly to the pod's /16
+  # network segment (or host IP).
+  if [ -n "${HAWTIO_TRUSTED_NETWORK_SUBNET:-}" ]; then
+    CUSTOM_POD_NETWORK="${HAWTIO_TRUSTED_NETWORK_SUBNET}"
+  elif echo "${LOCAL_IP}" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$'; then
+    # IPv4: Calculate the /16 subnet for this specific pod
+    # node/pod SDN subnets almost always allocate pod ranges
+    # within a /14 or /16 chunk per node or per cluster segment.
+    # Masking to /16 ensures that the Router pod/node IP and the
+    # hawtio-online pod IP share the trusted rule, even if not on
+    # the exact same .x third octet.
+    CUSTOM_POD_NETWORK=$(echo "${LOCAL_IP}" | awk -F. '{print $1"."$2".0.0/16"}')
+  elif echo "${LOCAL_IP}" | grep -q ':'; then
+    # IPv6: Trust only the local /64 subnet
+    CUSTOM_POD_NETWORK=$(echo "${LOCAL_IP}" | awk -F: '{print $1":"$2":"$3"::/64"}')
   else
-     # Fallback: If we can't determine the private net, we must default to 0.0.0.0/0
-     # to ensure the app works, though it reduces the precision of the rate limiting.
-     echo "WARNING: Could not determine private subnet from IP ${LOCAL_IP}. Defaulting 'set_real_ip_from' to 0.0.0.0/0"
-     export REAL_IP_FROM="0.0.0.0/0"
+    # Failsafe: Trust only the specific host IP (/32)
+    CUSTOM_POD_NETWORK="${LOCAL_IP}/32"
   fi
 
-  echo "Detected Local IP: ${LOCAL_IP}. Trusting subnet for Real IP: ${REAL_IP_FROM}"
+  # Export for use in nginx template
+  export CUSTOM_POD_NETWORK="${CUSTOM_POD_NETWORK}"
+
+  echo "Detected Local IP: ${LOCAL_IP}"
+  echo "Trusting pod subnet: ${CUSTOM_POD_NETWORK}"
 
   if [ -n "${HAWTIO_ONLINE_SSL_CERTIFICATE}" ]; then
     echo "Configurating nginx SSL protocol"
@@ -109,7 +116,7 @@ generate_nginx_gateway_conf() {
     $HAWTIO_ONLINE_GATEWAY_APP_PROTOCOL
     $HAWTIO_ONLINE_GATEWAY_APP_PORT
     $NGINX_LOG_LEVEL
-    $REAL_IP_FROM
+    $CUSTOM_POD_NETWORK
     ' < ${TEMPLATE} > /etc/nginx/conf.d/nginx.conf
 }
 


### PR DESCRIPTION

* nginx.sh
  * Instead of assuming a standard ip address class and defaulting to an all-address default, simply pass the 24 subnet mask of the actual IP address through to the nginx comfig file.

* nginx-gateway.conf.template
  * Set multiple real_ip_from properties for the standard ip address classes and the custom subnet injected from the runtime script
  * This allows for the ip address subnet to be trusted and so where applicable (rate limiting) use the client ip address rather than the server address.
  * Avoiding the 0.0.0.0/0 subnet is the crucial aspect as any endpoints that expect to use 127.0.0.1 (localhost) will be respected rather than substituting in the client ip address.

* patches ...
  * Provides a patch for providing a custom nginx configuration if required by users

See [HAWNG-2228](https://redhat.atlassian.net/browse/HAWNG-2228) for more information.
